### PR TITLE
Upgraded to OL 3.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "browserify": "^11.0.1",
     "jquery": "^1.11.3",
-    "openlayers": "^3.13.1",
+    "openlayers": "^3.16.0",
     "proj4": "^2.3.10",
     "svg4everybody": "^2.0.3",
     "typeahead.js-browserify": "^1.0.7"


### PR DESCRIPTION
This PR updates package.json to OL 31.16.0. Only problem I have found are need for polyfills for animation och layerspy if using IE 9. At this point Origo doesn't depend on those functions.