### PR TITLE
Fixed searchHandler bug

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -230,7 +230,8 @@ function selectHandler(evt, data) {
         showFeatureInfo([feature], data[titleAttribute], content);
     } else if (geometryAttribute && title) {
         var feature = wktToFeature(data[geometryAttribute], projectionCode);
-        showFeatureInfo([feature], title, data);
+        var content = utils.createElement('div', data[name]);
+        showFeatureInfo([feature], title, content);
     } else if (easting && northing && title) {
         var coord = [data[easting], data[northing]];
         showOverlay(data, coord);


### PR DESCRIPTION
This PR fixes a bug in the search control when using geometryAttribute and title as options. The content was not showing in Popup.