### PR TITLE
Fix to make proj4Defs not mandatory

### DIFF
--- a/index.json
+++ b/index.json
@@ -32,6 +32,9 @@
     },
     {
       "name": "measure"
+    },
+    {
+      "name": "scaleLine"
     }
   ],
   "projectionCode": "EPSG:3857",
@@ -40,13 +43,6 @@
     -20048966.10,
     20026376.39,
     20048966.10
-  ],
-  "proj4Defs": [
-      {
-        "code": "EPSG:3857",
-        "alias": "urn:ogc:def:crs:EPSG::3857",
-        "projection": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"
-      }
   ],
   "extent": [
     -20026376.39,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -62,7 +62,7 @@ function init(el, mapOptions) {
     settings.projection = new ol.proj.Projection({
       code: settings.projectionCode,
       extent: settings.projectionExtent,
-	  units: proj4.defs(settings.projectionCode).units || undefined
+      units: proj4.defs(settings.projectionCode).units || undefined
     });
     settings.resolutions = mapOptions.resolutions || undefined;
     settings.tileGrid = maputils.tileGrid(settings.projectionExtent, settings.resolutions);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -55,13 +55,14 @@ function init(el, mapOptions) {
   settings.map = mapOptions.map;
   settings.url = mapOptions.url;
   settings.baseUrl = mapOptions.baseUrl;
-  if (mapOptions.hasOwnProperty('proj4Defs')) {
+  if (mapOptions.hasOwnProperty('proj4Defs') || mapOptions.projectionCode=="EPSG:3857" || mapOptions.projectionCode=="EPSG:4326") {
     // Projection to be used in map
     settings.projectionCode = mapOptions.projectionCode || undefined;
     settings.projectionExtent = mapOptions.projectionExtent;
     settings.projection = new ol.proj.Projection({
       code: settings.projectionCode,
-      extent: settings.projectionExtent
+      extent: settings.projectionExtent,
+	  units: proj4.defs(settings.projectionCode).units || undefined
     });
     settings.resolutions = mapOptions.resolutions || undefined;
     settings.tileGrid = maputils.tileGrid(settings.projectionExtent, settings.resolutions);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -62,7 +62,7 @@ function init(el, mapOptions) {
     settings.projection = new ol.proj.Projection({
       code: settings.projectionCode,
       extent: settings.projectionExtent,
-      units: proj4.defs(settings.projectionCode).units || undefined
+      units: getUnits(settings.projectionCode)
     });
     settings.resolutions = mapOptions.resolutions || undefined;
     settings.tileGrid = maputils.tileGrid(settings.projectionExtent, settings.resolutions);
@@ -363,6 +363,21 @@ function getScale(resolution) {
   var scale = resolution * mpu * 39.37 * dpi;
   scale = Math.round(scale);
   return scale;
+}
+
+function getUnits(proj) {
+  var units;
+  switch(proj) {
+    case 'EPSG:3857':
+    units = 'm';
+    break;
+    case 'EPSG:4326':
+    units = 'degrees';
+    break;
+    default:
+	proj4.defs(proj) ? units = proj4.defs(proj).units : units = undefined;
+  }
+  return units;
 }
 
 function autoPan() {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -369,13 +369,13 @@ function getUnits(proj) {
   var units;
   switch(proj) {
     case 'EPSG:3857':
-    units = 'm';
-    break;
+      units = 'm';
+      break;
     case 'EPSG:4326':
-    units = 'degrees';
-    break;
+      units = 'degrees';
+      break;
     default:
-	proj4.defs(proj) ? units = proj4.defs(proj).units : units = undefined;
+      units = proj4.defs(proj) ? proj4.defs(proj).units : undefined;
   }
   return units;
 }


### PR DESCRIPTION
Fix to make proj4Defs not mandatory when using EPSG:3857 or 4326 that's
supported natively in Openlayers.
Solves #196