### PR TITLE
Extended TMS support

### DIFF
--- a/src/layer/xyz.js
+++ b/src/layer/xyz.js
@@ -22,16 +22,22 @@ var xyz = function xyz(layerOptions) {
   sourceOptions.projection = viewer.getProjectionCode() || 'EPSG:3857';
   sourceOptions.tileGrid = viewer.getTileGrid();
 
-  var xyzSource = createSource(sourceOptions);
+  var xyzSource = createSource(sourceOptions, xyzOptions);
   return tile(xyzOptions, xyzSource);
+}
 
-  function createSource(options) {
+function createSource(options, xyzOptions) {
+  if(xyzOptions.layerURL){
+    options.url += xyzOptions.layerURL;
+  }
+  else {
     var format = options.sourceName.split('.')[1],
       url = options.sourceName.split('.')[0] + '/{z}/{x}/{y}.';
     url += format;
-    options.url = format;
-    return new ol.source.XYZ(options);
+    options.url = url;
   }
+  options.crossOrigin = 'anonymous';
+  return new ol.source.XYZ(options);
 }
 
 module.exports = xyz;

--- a/src/layer/xyz.js
+++ b/src/layer/xyz.js
@@ -21,21 +21,20 @@ var xyz = function xyz(layerOptions) {
   sourceOptions.attributions = xyzOptions.attribution;
   sourceOptions.projection = viewer.getProjectionCode() || 'EPSG:3857';
   sourceOptions.tileGrid = viewer.getTileGrid();
-
-  var xyzSource = createSource(sourceOptions, xyzOptions);
+  if(xyzOptions.layerURL){
+    sourceOptions.url += xyzOptions.layerURL;
+  }
+  else {
+    var format = sourceOptions.sourceName.split('.')[1],
+      url = sourceOptions.sourceName.split('.')[0] + '/{z}/{x}/{y}.';
+    url += format;
+    sourceOptions.url = url;
+  }
+  var xyzSource = createSource(sourceOptions);
   return tile(xyzOptions, xyzSource);
 }
 
-function createSource(options, xyzOptions) {
-  if(xyzOptions.layerURL){
-    options.url += xyzOptions.layerURL;
-  }
-  else {
-    var format = options.sourceName.split('.')[1],
-      url = options.sourceName.split('.')[0] + '/{z}/{x}/{y}.';
-    url += format;
-    options.url = url;
-  }
+function createSource(options) {
   options.crossOrigin = 'anonymous';
   return new ol.source.XYZ(options);
 }


### PR DESCRIPTION
Edited the XYZ-source to support servers with different syntaxes for
TMS-services. Now you can specify the layer-part of the TMS request in
the config with the layerURL-parameter. 
Solves #251 