### PR TITLE
Option to automatically show attribute form

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -16,6 +16,7 @@ module.exports = function() {
 function Init(opt_options) {
   var options = opt_options || {};
   options.autoSave = options.hasOwnProperty('autoSave') ? options.autoSave : true;
+  options.autoForm = options.hasOwnProperty('autoForm') ? options.autoForm : false;
   options.currentLayer = options.defaultLayer || options.editableLayers[0];
   editorToolbar.init(options);
   render();

--- a/src/editor/edithandler.js
+++ b/src/editor/edithandler.js
@@ -16,6 +16,7 @@ var shapes = require('./shapes');
 
 var editLayers = {};
 var autoSave = undefined;
+var autoForm = undefined;
 var editSource = undefined;
 var geometryType = undefined;
 var geometryName = undefined;
@@ -51,6 +52,7 @@ module.exports = function(options) {
   });
 
   autoSave = options.autoSave;
+  autoForm = options.autoForm;
   $(document).on('toggleEdit', onToggleEdit);
   $(document).on('changeEdit', onChangeEdit);
   $(document).on('editorShapes', onChangeShape);
@@ -189,6 +191,9 @@ function onDrawEnd(evt) {
     action: 'insert'
   });
   dispatcher.emitChangeEdit('draw', false);
+  if (autoForm) {
+    editAttributes(feature);
+  }
 }
 
 function cancelDraw() {
@@ -429,11 +434,17 @@ function setActive(editType) {
   }
 }
 
-function editAttributes() {
+function editAttributes(feature) {
   var attributeObjects;
+  var features;
 
-  //Get attributes from selected feature and fill DOM elements with the values
-  var features = select.getFeatures();
+  //Get attributes from the created, or the selected, feature and fill DOM elements with the values
+  if (feature) {
+    features = new ol.Collection();
+    features.push(feature);
+  } else {
+    features = select.getFeatures();
+  }
   if (features.getLength() === 1) {
     dispatcher.emitChangeEdit('attribute', true);
     var feature = features.item(0);
@@ -540,7 +551,7 @@ function getFeaturesByIds(type, layer, ids) {
         feature.unset('bbox');
         features.push(feature);
         /*** *** ***/
-        
+
         //features.push(source.getFeatureById(id));
       }
     });


### PR DESCRIPTION
A suggested fix for https://github.com/origo-map/origo/issues/6. With this change the user will be able to set an autoForm configuration for the editor control. With autoForm set to true (defaults to false), the attribute form will show up automatically after the feature has been drawn. 

Configuration example:

```json
    {
      "name": "editor",
      "options": {
        "editableLayers": ["test_byggnadsytor", "test_punkt"],
        "isActive": true,
        "autoSave": false,        
        "autoForm": true
      }
    }
```