### PR TITLE
Made wfs loadingstrategy configurable

### DIFF
--- a/src/layer/wfs.js
+++ b/src/layer/wfs.js
@@ -41,7 +41,7 @@ var wfs = function wfs(layerOptions) {
     var queryFilter;
 
     //If cql filter then bbox must be used in the filter.
-    if(options.strategy == 'all'){
+    if(options.strategy === 'all'){
       queryFilter = options.filter ? '&CQL_FILTER=' + options.filter : '';
     }
     else{
@@ -59,7 +59,7 @@ var wfs = function wfs(layerOptions) {
           'version=1.1.0&request=GetFeature&typeName=' + options.featureType +
           '&outputFormat=application/json' +
           '&srsname=' + options.projectionCode;
-        url += options.strategy == 'all' ? queryFilter : queryFilter + extent.join(',') + ',' + bboxProjectionCode;
+        url += options.strategy === 'all' ? queryFilter : queryFilter + extent.join(',') + ',' + bboxProjectionCode;
         $.ajax({
             url: url,
             cache: false

--- a/src/layer/wfs.js
+++ b/src/layer/wfs.js
@@ -20,13 +20,16 @@ var wfs = function wfs(layerOptions) {
 
   sourceOptions.strategy = layerOptions.strategy ? layerOptions.strategy : sourceOptions.strategy;
   switch (sourceOptions.strategy) {
+    case 'all':
+      sourceOptions.loadingstrategy = ol.loadingstrategy.all;
+    break;
     case 'tile':
-    sourceOptions.strategy = ol.loadingstrategy.tile(ol.tilegrid.createXYZ({
+    sourceOptions.loadingstrategy = ol.loadingstrategy.tile(ol.tilegrid.createXYZ({
         maxZoom: sourceOptions.resolutions.length
       }));
     break;
     default:
-    sourceOptions.strategy = ol.loadingstrategy.bbox;
+    sourceOptions.loadingstrategy = ol.loadingstrategy.bbox;
     break;
   }
   var wfsSource = createSource(sourceOptions);
@@ -35,9 +38,15 @@ var wfs = function wfs(layerOptions) {
   function createSource(options) {
     var vectorSource = null;
     var serverUrl = options.url;
+    var queryFilter;
 
     //If cql filter then bbox must be used in the filter.
-    var queryFilter = options.filter ? '&CQL_FILTER=' + options.filter + ' AND BBOX(' + options.geometryName + ',' : '&BBOX=';
+    if(options.strategy == 'all'){
+      queryFilter = options.filter ? '&CQL_FILTER=' + options.filter : '';
+    }
+    else{
+      queryFilter = options.filter ? '&CQL_FILTER=' + options.filter + ' AND BBOX(' + options.geometryName + ',' : '&BBOX=';
+    }
     var bboxProjectionCode = options.filter ? "'" + options.projectionCode + "')" : options.projectionCode;
     vectorSource = new ol.source.Vector({
       attributions: options.attribution,
@@ -49,8 +58,8 @@ var wfs = function wfs(layerOptions) {
           '?service=WFS&' +
           'version=1.1.0&request=GetFeature&typeName=' + options.featureType +
           '&outputFormat=application/json' +
-          '&srsname=' + options.projectionCode +
-          queryFilter + extent.join(',') + ',' + bboxProjectionCode;
+          '&srsname=' + options.projectionCode;
+        url += options.strategy == 'all' ? queryFilter : queryFilter + extent.join(',') + ',' + bboxProjectionCode;
         $.ajax({
             url: url,
             cache: false
@@ -59,7 +68,7 @@ var wfs = function wfs(layerOptions) {
             vectorSource.addFeatures(vectorSource.getFormat().readFeatures(response));
           });
       },
-      strategy: options.strategy
+      strategy: options.loadingstrategy
     });
     return vectorSource;
   }

--- a/src/layer/wfs.js
+++ b/src/layer/wfs.js
@@ -18,6 +18,17 @@ var wfs = function wfs(layerOptions) {
   sourceOptions.resolutions = viewer.getResolutions();
   sourceOptions.projectionCode = viewer.getProjectionCode();
 
+  sourceOptions.strategy = layerOptions.strategy ? layerOptions.strategy : sourceOptions.strategy;
+  switch (sourceOptions.strategy) {
+    case 'tile':
+    sourceOptions.strategy = ol.loadingstrategy.tile(ol.tilegrid.createXYZ({
+        maxZoom: sourceOptions.resolutions.length
+      }));
+    break;
+    default:
+    sourceOptions.strategy = ol.loadingstrategy.bbox;
+    break;
+  }
   var wfsSource = createSource(sourceOptions);
   return vector(wfsOptions, wfsSource);
 
@@ -48,9 +59,7 @@ var wfs = function wfs(layerOptions) {
             vectorSource.addFeatures(vectorSource.getFormat().readFeatures(response));
           });
       },
-      strategy: ol.loadingstrategy.tile(ol.tilegrid.createXYZ({
-        maxZoom: options.resolutions.length
-      }))
+      strategy: options.strategy
     });
     return vectorSource;
   }


### PR DESCRIPTION
Fixes #173 The loadingstrategy for WFS layers are configurable to load either the whole bbox or tiled. However, I excluded the all-option since it didn't work very well. The strategy can be set either on layer or source.