### PR TITLE
Custom tilegrid for vectortiles

### DIFF
--- a/src/layer/vectortile.js
+++ b/src/layer/vectortile.js
@@ -4,6 +4,7 @@ var ol = require('openlayers');
 var $ = require('jquery');
 var viewer = require('../viewer');
 var vector = require('./vector');
+var maputils = require('../maputils');
 
 var vectortile = function vectortile(layerOptions) {
   var vectortileDefault = {
@@ -16,7 +17,12 @@ var vectortile = function vectortile(layerOptions) {
   var sourceOptions = $.extend(sourceDefault, viewer.getMapSource()[layerOptions.source]);
   sourceOptions.attributions = vectortileOptions.attribution;
   sourceOptions.projection = viewer.getProjectionCode() || 'EPSG:3857';
-  sourceOptions.tileGrid = viewer.getTileGrid();
+  if(sourceOptions.tileGrid){
+    sourceOptions.tileGrid = maputils.tileGrid(sourceOptions.tileGrid);
+  } else {
+    sourceOptions.tileGrid = viewer.getTileGrid();
+  }
+  
   var vectortileSource = createSource(sourceOptions, vectortileOptions);
   return vector(vectortileOptions, vectortileSource);
 }

--- a/src/maputils.js
+++ b/src/maputils.js
@@ -12,13 +12,16 @@ module.exports = {
       });
   },
   tileGrid: function(settings) {
-      var origin = settings.alignTopLeft === false ? ol.extent.getBottomLeft(settings.extent) : ol.extent.getTopLeft(settings.extent);
-      return new ol.tilegrid.TileGrid({
-          extent: settings.extent,
-          origin: settings.origin,
-          resolutions: settings.resolutions,
-          tileSize: settings.tileSize || [256,256]
-      });
+    var extent = settings.extent || viewer.getExtent();
+    var origin = settings.alignBottomLeft === false ? ol.extent.getTopLeft(extent) : ol.extent.getBottomLeft(extent);
+    var resolutions = settings.resolutions || viewer.getResolutions();
+    var tileSize = settings.tileSize || viewer.getTileSize();
+    return new ol.tilegrid.TileGrid({
+        extent: extent,
+        origin: origin,
+        resolutions: resolutions,
+        tileSize: tileSize
+    });
   },
   checkZoomChange: function checkZoomChange(resolution, currentResolution) {
       if(resolution !== currentResolution) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -58,7 +58,7 @@ function init(el, mapOptions) {
   settings.zoom = urlParams.zoom || mapOptions.zoom;
   mapOptions.tileGrid = mapOptions.tileGrid || {};
   settings.tileSize = mapOptions.tileGrid.tileSize ? [mapOptions.tileGrid.tileSize,mapOptions.tileGrid.tileSize] : [256,256];
-  settings.alignTopLeft = mapOptions.tileGrid.alignTopLeft;
+  settings.alignBottomLeft = mapOptions.tileGrid.alignBottomLeft;
 
   if (mapOptions.hasOwnProperty('proj4Defs') || mapOptions.projectionCode=="EPSG:3857" || mapOptions.projectionCode=="EPSG:4326") {
     // Projection to be used in map

--- a/tasks/build-ol-standard.json
+++ b/tasks/build-ol-standard.json
@@ -35,6 +35,7 @@
     "ol.View#setZoom",
     "ol.View#fit",
     "ol.View#un",
+    "ol.extent.getBottomLeft",
     "ol.extent.getTopLeft",
     "ol.tilegrid.TileGrid",
     "ol.tilegrid.WMTS",


### PR DESCRIPTION
Fixes #334 
Makes it possible to have a different tileGrid for vector tiles sources which is often necessary when combining with wms. Also changes the
alignTopLeft option to alignBottomLeft to match the default Openlayers behaviour.