### PR TITLE
Added option to set mapmenu to open on load

### DIFF
--- a/index.json
+++ b/index.json
@@ -4,7 +4,10 @@
       "name": "home"
     },
     {
-      "name": "mapmenu"
+      "name": "mapmenu",
+      "options": {
+        "isActive": false
+      }
     },
     {
       "name": "sharemap"

--- a/src/mapmenu.js
+++ b/src/mapmenu.js
@@ -12,9 +12,15 @@ var options;
 var isActive;
 
 function init(opt_options) {
+    var breakPointSize;
+    var breakPoint;
+
     options = opt_options || {};
     isActive = options.isActive || false;
+    breakPointSize = options.breakPointSize || 'l';
+    breakPoint  = viewer.getBreakPoints(breakPointSize);
     styleSettings = viewer.getStyleSettings();
+
     var el = utils.createButton({
         text: 'Meny',
         id: 'o-mapmenu-button',
@@ -50,7 +56,7 @@ function init(opt_options) {
 
     bindUIActions();
 
-    if(isActive && window.innerWidth >= 768) {
+    if(isActive && $('#o-map').width() >= breakPoint[0]) {
       toggleMenu();
     }
 }

--- a/src/mapmenu.js
+++ b/src/mapmenu.js
@@ -8,8 +8,12 @@ var $menuButton, $closeButton, $mapMenu;
 
 var symbolSize = 20;
 var styleSettings;
+var options;
+var isActive;
 
-function init() {
+function init(opt_options) {
+    options = opt_options || {};
+    isActive = options.isActive || false;
     styleSettings = viewer.getStyleSettings();
     var el = utils.createButton({
         text: 'Meny',
@@ -45,6 +49,10 @@ function init() {
     $closeButton = $('#o-mapmenu-button-close');
 
     bindUIActions();
+
+    if(isActive && window.innerWidth >= 768) {
+      toggleMenu();
+    }
 }
 function bindUIActions() {
     $menuButton.on('click', function(e) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -53,6 +53,7 @@ function init(el, mapOptions) {
   settings.url = mapOptions.url;
   settings.target = mapOptions.target;
   settings.baseUrl = mapOptions.baseUrl;
+  settings.breakPoints = mapOptions.breakPoints;
   settings.extent = mapOptions.extent || undefined;
   settings.center = urlParams.center || mapOptions.center;
   settings.zoom = urlParams.zoom || mapOptions.zoom;
@@ -203,6 +204,10 @@ function getExtent() {
 
 function getBaseUrl() {
   return settings.baseUrl;
+}
+
+function getBreakPoints(size) {
+  return size && settings.breakPoints.hasOwnProperty(size) ? settings.breakPoints[size] : settings.breakPoints;
 }
 
 function getMapName() {
@@ -496,6 +501,7 @@ function render(el, mapOptions) {
 module.exports.init = init;
 module.exports.createLayers = createLayers;
 module.exports.getBaseUrl = getBaseUrl;
+module.exports.getBreakPoints = getBreakPoints;
 module.exports.getExtent = getExtent;
 module.exports.getSettings = getSettings;
 module.exports.getStyleSettings = getStyleSettings;


### PR DESCRIPTION
Fixes #346.

Option added to mapmenu control:
```
{
  "name": "mapmenu",
  "options": {
    "isActive": false
  }
}
```
Setting the ```isActive``` option to false is redundant and only for show - the variable is set to false by default.