### PR TITLE
Updated to ol450

### DIFF
--- a/examples/editor.json
+++ b/examples/editor.json
@@ -48,7 +48,7 @@
   ],
   "proj4Defs": [
       {
-          "code": "EPSG:3010",
+          "code": "3010",
           "alias": "urn:ogc:def:crs:EPSG::3010",
           "projection": "+proj=tmerc +lat_0=0 +lon_0=16.5 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify": "11.0.1",
     "jquery": "2.1.4",
     "localforage": "1.5.0",
-    "openlayers": "4.3.4",
+    "openlayers": "4.5.0",
     "proj4": "2.3.10"
   },
   "devDependencies": {


### PR DESCRIPTION
I've tested ol 4.5.0 and I only stumbled on one problem. I got problems with reading ags tile. I hade to change the projection code name to 3010 for proj4defs, instead of EPSG:3010 to make it work. For those using Arc GIS server map services this is an important change.