### PR TITLE
Added option to add selection style

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -36,7 +36,7 @@ function init(opt_options) {
   pinStyle = style.createStyleRule(pinStyleOptions)[0];
   savedPin = options.savedPin ? maputils.createPointFeature(opt_options.savedPin, pinStyle) : undefined;
 
-  selectionStyles = style.createEditStyle();
+  selectionStyles = 'selectionStyles' in options ? style.createGeometryStyle(options.selectionStyles) : style.createEditStyle();
 
   var savedSelection = options.savedSelection || undefined;
   var savedFeature = savedPin || savedSelection || undefined;
@@ -160,7 +160,7 @@ function clear() {
   selectionLayer.clear();
   sidebar.setVisibility(false);
   if (overlay) {
-    Viewer.removeOverlays(overlay);      
+    Viewer.removeOverlays(overlay);
   }
   console.log("Clearing selection");
 }

--- a/src/style.js
+++ b/src/style.js
@@ -65,8 +65,9 @@ module.exports = function() {
     createStyleRule: createStyleRule,
     createStyle: createStyle,
     styleFunction: styleFunction,
-    createEditStyle: createEditStyle
-  }
+    createEditStyle: createEditStyle,
+    createGeometryStyle: createGeometryStyle
+  };
 };
 
 function Init() {
@@ -211,13 +212,17 @@ function styleFunction(styleSettings, styleList, clusterStyleSettings, clusterSt
 }
 
 function createEditStyle() {
+  return createGeometryStyle(editStyleOptions);
+}
+
+function createGeometryStyle(geometryStyleOptions) {
   return {
-    'Point': createStyleRule(editStyleOptions['Point']),
-    'MultiPoint': createStyleRule(editStyleOptions['Point']),
-    'LineString': createStyleRule(editStyleOptions['LineString']),
-    'MultiLineString': createStyleRule(editStyleOptions['LineString']),
-    'Polygon': createStyleRule(editStyleOptions['Polygon']),
-    'MultiPolygon': createStyleRule(editStyleOptions['Polygon'])
+    'Point': createStyleRule(geometryStyleOptions.Point),
+    'MultiPoint': createStyleRule(geometryStyleOptions.Point),
+    'LineString': createStyleRule(geometryStyleOptions.LineString),
+    'MultiLineString': createStyleRule(geometryStyleOptions.LineString),
+    'Polygon': createStyleRule(geometryStyleOptions.Polygon),
+    'MultiPolygon': createStyleRule(geometryStyleOptions.Polygon)
   };
 }
 


### PR DESCRIPTION
Fixes 417. A selection style can for example be added like this:
```JSON
  "featureinfoOptions": {
    "overlay": true,
    "hitTolerance": 5,
    "selectionStyles": {
      "Point": [{
        "circle": {
          "radius": 5,
          "stroke": {
            "color": [0, 153, 255, 1],
            "width": 0
          },
          "fill": {
            "color": [0, 153, 255, 1]
          }
        }
      }],
      "LineString": [{
          "stroke": {
            "color": [255, 255, 255, 1],
            "width": 5
          }
        },
        {
          "stroke": {
            "color": [0, 153, 255, 1],
            "width": 3
          }
        }
      ],
      "Polygon": [{
          "stroke": {
            "color": [255, 255, 255, 1],
            "width": 5
          }
        },
        {
          "stroke": {
            "color": [0, 153, 255, 1],
            "width": 3
          }
        }
      ]
    }
  }
```