### PR TITLE
Added condition to suggestion filter

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -139,7 +139,9 @@ function initAutocomplete() {
     maxItems: limit,
     item: renderList,
     filter: function(suggestion, input) {
-      return suggestion.value;
+      if (suggestion.value.toLowerCase().includes(input.toLowerCase())) {
+        return suggestion.value;
+      }
     }
   });
 


### PR DESCRIPTION
Possible solution for #425 . It works by simply not showing any suggestions if the input does not match any part of the suggestions.