### PR TITLE
Show attribute as title

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -9,6 +9,7 @@ import featurelayer from './featurelayer';
 import Style from './style';
 import StyleTypes from './style/styletypes';
 import getFeatureInfo from './getfeatureinfo';
+import replacer from '../src/utils/replacer';
 
 const style = Style();
 const styleTypes = StyleTypes();
@@ -45,17 +46,16 @@ function callback(evt) {
       selectionStyles[items[currentItem].feature.getGeometry().getType()]
     );
     const layer = viewer.getLayersByProperty('name', items[currentItem].name)[0];
-    const titleAttribute = layer.getProperties().titleAttribute;
+    const featureinfoTitle = layer.getProperties().featureinfoTitle;
     let title;
-    if (titleAttribute) {
+    if (featureinfoTitle) {
       const featureProps = items[currentItem].feature.getProperties();
-      if (titleAttribute in featureProps) {
-        title = featureProps[titleAttribute];
-      } else {
-        title = items[currentItem].title;
+      title = replacer.replace(featureinfoTitle, featureProps);
+      if (!title) {
+        title = items[currentItem].title ? items[currentItem].title : items[currentItem].name;
       }
     } else {
-      title = items[currentItem].title;
+      title = items[currentItem].title ? items[currentItem].title : items[currentItem].name;
     }
     if (identifyTarget === 'overlay') {
       popup.setTitle(title);

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -44,10 +44,23 @@ function callback(evt) {
       items[currentItem].feature.clone(),
       selectionStyles[items[currentItem].feature.getGeometry().getType()]
     );
-    if (identifyTarget === 'overlay') {
-      popup.setTitle(items[currentItem].title);
+    const layer = viewer.getLayersByProperty('name', items[currentItem].name)[0];
+    const titleAttribute = layer.getProperties().titleAttribute;
+    let title;
+    if (titleAttribute) {
+      const featureProps = items[currentItem].feature.getProperties();
+      if (titleAttribute in featureProps) {
+        title = featureProps[titleAttribute];
+      } else {
+        title = items[currentItem].title;
+      }
     } else {
-      sidebar.setTitle(items[currentItem].title);
+      title = items[currentItem].title;
+    }
+    if (identifyTarget === 'overlay') {
+      popup.setTitle(title);
+    } else {
+      sidebar.setTitle(title);
     }
   }
 }

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -172,7 +172,8 @@ function getFeaturesFromRemote(evt) {
       requestResult.push({
         title: layer.get('title'),
         feature,
-        content: getAttributes(feature, layer)
+        content: getAttributes(feature, layer),
+        layer: layer.get('name')
       });
       return requestResult;
     }
@@ -209,6 +210,7 @@ function getFeaturesAtPixel(evt, clusterFeatureinfoLevel) {
           item.title = l.get('title');
           item.feature = f;
           item.content = getAttributes(f, l);
+          item.name = l.get('name');
           result.push(item);
         });
       } else if (collection.length === 1 && queryable) {
@@ -216,6 +218,7 @@ function getFeaturesAtPixel(evt, clusterFeatureinfoLevel) {
         item.title = l.get('title');
         item.feature = collection[0];
         item.content = getAttributes(collection[0], l);
+        item.name = l.get('name');
         result.push(item);
       }
     } else if (queryable) {
@@ -223,6 +226,7 @@ function getFeaturesAtPixel(evt, clusterFeatureinfoLevel) {
       item.title = l.get('title');
       item.feature = feature;
       item.content = getAttributes(feature, l);
+      item.name = l.get('name');
       result.push(item);
     }
 


### PR DESCRIPTION
Fixes #449
Adds a titleAttribute option for layers to show a attribute value instead of the layer name as the title in the popup/sidebar.