### PR TITLE
Option to open modal in full screen as iframe (ES6)

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -9,7 +9,7 @@
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: 105;
+  z-index: 1015;
 }
 .o-modal {
   background-color: white;
@@ -29,7 +29,29 @@
   -moz-transform-style: preserve-3d;
   transform-style: preserve-3d;
   width: 300px;
-  z-index: 110;
+  z-index: 1020;
+}
+.o-modal-full {
+  background-color: white;
+  border-radius: 6px;
+  bottom: auto;
+  -webkit-box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
+  box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
+  font-family: Arial,sans-serif;
+  left: 49%;
+  -ms-transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  position: absolute;
+  right: auto;
+  top: 49%;
+  -webkit-transform-style: preserve-3d;
+  -moz-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  z-index: 1020;
+  height: 98%;
+  width: 98%;
+  margin:1%;
 }
 .o-no-csstransforms .o-modal {
   margin-left: -150px;
@@ -50,6 +72,11 @@
   padding: 10px 15px;
 	overflow-y: auto;
 }
+.o-modal-content-full {
+  height: calc(100vh - 65px);
+  width:100%;
+  border:0;
+}
 .o-modal-content .o-share-link {
   padding: 10px 5px;
 }
@@ -69,10 +96,17 @@
   margin-left: -15px;
   margin-right: -15px;
 }
-
 &[class*=#{$media-l}] {
 .o-modal {
   max-width: 300px;
   width: 90%;
 }
+}
+.o-external-link-button {
+  height: 2.429em;
+  float: right;
+  width: 2.429em;
+}
+.o-external-link-button:hover {
+  cursor: pointer;
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -93,7 +93,7 @@
 }
 
 .o-modal-content-iframe {
-  height: calc(100vh - 65px);
+  height: calc(100vh - 68px);
   width: 100%;
   border: 0;
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -2,6 +2,7 @@
   font-size: 1em;
   line-height: 1.42857143;
 }
+
 .o-modal-screen {
   background-color: rgba(0,0,0,0.5);
   height: 100%;
@@ -11,10 +12,11 @@
   width: 100%;
   z-index: 1015;
 }
+
 .o-modal {
   background-color: white;
   border-radius: 6px;
-	bottom: auto;
+  bottom: auto;
   -webkit-box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
   box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
   font-family: Arial,sans-serif;
@@ -23,40 +25,45 @@
   -webkit-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   position: absolute;
-	right: auto;
-	top: 50%;
-	-webkit-transform-style: preserve-3d;
+  right: auto;
+  top: 50%;
+  -webkit-transform-style: preserve-3d;
   -moz-transform-style: preserve-3d;
   transform-style: preserve-3d;
   width: 300px;
   z-index: 1020;
 }
+
 .o-modal-full {
   background-color: white;
-  border-radius: 6px;
-  bottom: auto;
-  -webkit-box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
-  box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
   font-family: Arial,sans-serif;
-  left: 49%;
-  -ms-transform: translate(-50%, -50%);
-  -webkit-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
-  position: absolute;
-  right: auto;
+  position: fixed;
   top: 49%;
-  -webkit-transform-style: preserve-3d;
-  -moz-transform-style: preserve-3d;
-  transform-style: preserve-3d;
-  z-index: 1020;
+  right: auto;
+  bottom: auto;
+  left: 49%;
   height: 98%;
   width: 98%;
-  margin:1%;
+  margin: 1%;
+  z-index: 1020;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
+  -webkit-box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
+  transform: translate(-50%, -50%);
+  transform-style: preserve-3d;
+  -ms-transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -webkit-transform-style: preserve-3d;
+  -moz-transform-style: preserve-3d;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
+
 .o-no-csstransforms .o-modal {
   margin-left: -150px;
   margin-top: -50px;
 }
+
 .o-modal-title {
   background-color: #F7F7F7;
   border-bottom: 1px solid #EBEBEB;
@@ -64,30 +71,46 @@
   font-size: 1em;
   font-weight: bold;
   padding: 10px;
+  word-wrap: break-word;
 }
+
 .o-modal-content {
   font-size: 0.9em;
   line-height: 1.1em;
-	max-height: calc(100vh - 100px);
+  max-height: calc(100vh - 100px);
   padding: 10px 15px;
-	overflow-y: auto;
+  overflow-y: auto;
 }
+
 .o-modal-content-full {
-  height: calc(100vh - 65px);
-  width:100%;
-  border:0;
+  position: relative;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
+
+.o-modal-content-iframe {
+  height: calc(100vh - 65px);
+  width: 100%;
+  border: 0;
+}
+
 .o-modal-content .o-share-link {
   padding: 10px 5px;
 }
-.o-modal input[type=button],
-.o-modal select,
-.o-modal textarea,
+
 .o-modal img,
+.o-modal input[type=button],
 .o-modal input[type=file],
-.o-modal input[type=text] {
+.o-modal input[type=text],
+.o-modal select,
+.o-modal textarea {
   width: 100%;
 }
+
 .o-modal li {
   font-family: Arial,sans-serif;
   font-size: 14px;
@@ -96,17 +119,20 @@
   margin-left: -15px;
   margin-right: -15px;
 }
+
 &[class*=#{$media-l}] {
-.o-modal {
-  max-width: 300px;
-  width: 90%;
+  .o-modal {
+    max-width: 300px;
+    width: 90%;
+  }
 }
-}
+
 .o-external-link-button {
   height: 2.429em;
   float: right;
   width: 2.429em;
 }
+
 .o-external-link-button:hover {
   cursor: pointer;
 }

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -9,6 +9,7 @@ import featurelayer from './featurelayer';
 import Style from './style';
 import StyleTypes from './style/styletypes';
 import getFeatureInfo from './getfeatureinfo';
+import Modal from './modal';
 
 const style = Style();
 const styleTypes = StyleTypes();
@@ -86,6 +87,19 @@ function getHitTolerance() {
   return hitTolerance;
 }
 
+function bindUIActions() {
+  $('.o-modal-link-iframe').on('click', function create(e) {
+    Modal.createModal('#o-map', {
+      title: $(this).text(),
+      content: $(this).attr('href'),
+      target: 'iframe'
+    });
+
+    Modal.showModal();
+    e.preventDefault();
+  });
+}
+
 function identify(identifyItems, target, coordinate) {
   items = identifyItems;
   clear();
@@ -100,6 +114,7 @@ function identify(identifyItems, target, coordinate) {
         title: items[0].title
       });
       popup.setVisibility(true);
+      bindUIActions();
       initCarousel('#o-identify-carousel');
       const popupHeight = $('.o-popup').outerHeight() + 20;
       $('#o-popup').height(popupHeight);

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -17,6 +17,7 @@ export default function (feature, layer) {
   let li = '';
   let title;
   let val;
+  let aCls;
   // If layer is configured with attributes
   if (layer.get('attributes')) {
     // If attributes is string then use template named with the string
@@ -28,6 +29,7 @@ export default function (feature, layer) {
         attribute = layer.get('attributes')[i];
         title = '';
         val = '';
+        aCls = attribute.target === 'iframe' ? 'o-modal-link-iframe' : '';
         if (attribute.name) {
           if (feature.get(attribute.name)) {
             val = feature.get(attribute.name);
@@ -37,7 +39,7 @@ export default function (feature, layer) {
             if (attribute.url) {
               if (feature.get(attribute.url)) {
                 const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), feature.getProperties()));
-                val = `<a href="${url}" target="_blank">
+                val = `<a href="${url}" target="_blank" class="${aCls}">
                   ${feature.get(attribute.name)}
                   </a>`;
               }
@@ -47,7 +49,7 @@ export default function (feature, layer) {
           if (feature.get(attribute.url)) {
             const text = attribute.html || attribute.url;
             const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), attributes));
-            val = `<a href="${url}" target="_blank">
+            val = `<a href="${url}" target="_blank" class="${aCls}">
               ${text}
               </a>`;
           }

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -171,6 +171,7 @@ function getFeaturesFromRemote(evt) {
     if (feature) {
       requestResult.push({
         title: layer.get('title'),
+        name: layer.get('name'),
         feature,
         content: getAttributes(feature, layer)
       });
@@ -207,6 +208,7 @@ function getFeaturesAtPixel(evt, clusterFeatureinfoLevel) {
         collection.forEach((f) => {
           const item = {};
           item.title = l.get('title');
+          item.name = l.get('name');
           item.feature = f;
           item.content = getAttributes(f, l);
           result.push(item);
@@ -214,6 +216,7 @@ function getFeaturesAtPixel(evt, clusterFeatureinfoLevel) {
       } else if (collection.length === 1 && queryable) {
         const item = {};
         item.title = l.get('title');
+        item.name = l.get('name');
         item.feature = collection[0];
         item.content = getAttributes(collection[0], l);
         result.push(item);
@@ -221,6 +224,7 @@ function getFeaturesAtPixel(evt, clusterFeatureinfoLevel) {
     } else if (queryable) {
       const item = {};
       item.title = l.get('title');
+      item.name = l.get('name');
       item.feature = feature;
       item.content = getAttributes(feature, l);
       result.push(item);

--- a/src/modal.js
+++ b/src/modal.js
@@ -23,7 +23,7 @@ const modal = function modal() {
     }
     modalEl += `<div class="o-modal-title">${title}</div>`;
     if (target === 'iframe') {
-      modalEl += `<iframe src="${content}" class="o-modal-content-full"></iframe>`;
+      modalEl += `<div class="o-modal-content-full"><iframe src="${content}" class="o-modal-content-iframe"></iframe></div>`;
     } else {
       modalEl += `<div class="o-modal-content">${content}</div>`;
     }

--- a/src/modal.js
+++ b/src/modal.js
@@ -4,19 +4,30 @@ const modal = function modal() {
   let isStatic;
   let $target;
   let modalEl;
+  let extLink;
 
   function closeModal() {
     $('#o-modal').remove();
   }
 
-  function render(title, content, cls) {
+  function render(title, content, cls, target) {
     modalEl = `<div id="o-modal" class="${cls}">
-                <div class="o-modal-screen"></div>
-                <div class="o-modal">
-                  <div class="o-close-button"><svg class="o-icon-fa-times"><use xlink:href="#fa-times"></use></svg></div>
-                  <div class="o-modal-title">${title}</div>
-                  <div class="o-modal-content">${content}</div>
-                </div>
+                <div class="o-modal-screen"></div>`;
+    if (target === 'iframe') {
+      modalEl += `<div class="o-modal-full"><div class="o-close-button"><svg class="o-icon-fa-times"><use xlink:href="#fa-times"></use></svg></div>
+      <div class="o-external-link-button"><svg class="o-icon-fa-times"><use xlink:href="#fa-external-link"></use></svg></div>`;
+      extLink = content;
+    } else {
+      modalEl += `<div class="o-modal">
+                    <div class="o-close-button"><svg class="o-icon-fa-times"><use xlink:href="#fa-times"></use></svg></div>`;
+    }
+    modalEl += `<div class="o-modal-title">${title}</div>`;
+    if (target === 'iframe') {
+      modalEl += `<iframe src="${content}" class="o-modal-content-full"></iframe>`;
+    } else {
+      modalEl += `<div class="o-modal-content">${content}</div>`;
+    }
+    modalEl += `</div>
               </div>`;
   }
 
@@ -30,19 +41,25 @@ const modal = function modal() {
         closeModal();
       });
     }
+    if (extLink) {
+      $('.o-external-link-button').click(() => {
+        window.open(extLink, '_blank');
+      });
+    }
   }
 
   function createModal(modalTarget, options) {
     const title = options.title || '';
     const content = options.content || '';
     const cls = options.cls || '';
+    const target = options.target || '';
     if (Object.prototype.hasOwnProperty.call(options, 'static')) {
       isStatic = options.static;
     } else {
       isStatic = false;
     }
 
-    render(title, content, cls);
+    render(title, content, cls, target);
     $target = $(modalTarget);
   }
 


### PR DESCRIPTION
Fixes #381
With this PR it is possible to config an url to be opened inside a modal window instead of a new window. Adding "target" = "iframe" will add a class to the url which will open the link as an iframe inside modal window.
Rewrote earlier PR according to es6