### PR TITLE
Ignore build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build-dev
 dist
 css/style.css
 node_modules

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "watch-sass": "node-sass -w --include-path scss scss/origo.scss css/style.css",
     "prebuild-sass": "node-sass --include-path scss scss/origo.scss css/style.css",
     "build": "npm run build-js && npm run build-sass | npm run copy",
+    "build-dev": "npm run build-js && npm run build-sass | npm run copy-dev",
     "build-sass": "node-sass --include-path scss scss/origo.scss dist/style.css",
     "build-js": "webpack --config ./tasks/webpack.prod.js",
     "build-js-analyze": "webpack --config ./tasks/webpack.analyze.js",
-    "copy": "webpack --config ./tasks/webpack.copy.js"
+    "copy": "webpack --config ./tasks/webpack.copy.js",
+    "copy-dev": "webpack --config ./tasks/webpack.copy-dev.js"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/tasks/webpack.copy-dev.js
+++ b/tasks/webpack.copy-dev.js
@@ -1,0 +1,26 @@
+const merge = require('webpack-merge');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  context: `${__dirname}/../`,
+  output: {
+    path: `${__dirname}/../build-dev`,
+    filename: 'js/origo.js',
+    libraryTarget: 'var',
+    libraryExport: 'default',
+    library: 'Origo'
+  },
+  mode: 'development',
+  plugins: [
+    new CopyWebpackPlugin([
+      { from: 'dist/origo.min.js', to: 'js/origo.min.js' },
+      'css/**',
+      'examples/**',
+      'data/*',
+      'index.html',
+      'index.json',
+      'img/**'
+    ])
+  ]
+});


### PR DESCRIPTION
Fixes #596 

Added new build script, adding build-dev folder.

Notes:

- Use build-dev script for development (or production) builds that should be ignored by git.
- Use original build script for release builds