### PR TITLE
Extended legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-import": "^2.10.0",
     "exports-loader": "^0.7.0",
     "imports-loader": "^0.8.0",
-    "node-sass": "4.7.2",
+    "node-sass": "^4.11.0",
     "npm-run-all": "^3.1.2",
     "run-sequence": "^2.1.0",
     "uglify-js": "3.4.9",

--- a/src/utils/legendmaker.js
+++ b/src/utils/legendmaker.js
@@ -121,7 +121,6 @@ export const renderLegendItem = function renderLegendItem(svgIcon, label = '') {
 };
 
 export const renderExtendedLegendItem = function renderExtendedLegendItem(extendedLegendItem) {
-  const style = `style="width: ${size}px; height: ${size}px;"`;
   return `<li class="flex row align-center padding-y-smallest">
             <img src=${extendedLegendItem.icon.src} />
           </li>`;

--- a/src/utils/legendmaker.js
+++ b/src/utils/legendmaker.js
@@ -44,10 +44,10 @@ export const findStyleType = function findStyleType(styles) {
   return null;
 };
 
-// This returns the last styleRule flagged as header. In other words, if there are 3 styleRules 
+// If there is only one styleRule that will be used as header icon, but not if that is extendedLegend. In latter case null is returned  meaning that list_icon will be set as header icon.
+// If there are more than one styleRule the last styleRule flagged as header will be returned. In other words, if there are for example 3 styleRules 
 // an all of them have header=true, then the last one will be returned and set on the icon legend.
-// If there is only one styleRule that will be used as header icon.
-// If there are more than on styleRule but none of them has header flag, then null is returned meaning that list_icon will set as header icon
+// If there are more than one styleRule but none of them has header flag, then null is returned meaning that list_icon will be set as header icon.
 export const findHeaderStyle = function findHeaderStyle(styleRules) {
   if (styleRules.length === 1) {
     const icons = styleRules[0].filter(sr => sr.icon);


### PR DESCRIPTION
if there is an icon in the style config of a layer that is flagged as extendedLegend like:
```
{
  "icon": {
    "src": "url request to GetLegendGraphic or any other statis asset"
   },
  "extendedLegend": true
}
```
then it will be embedded in the legend instead of the usual legend.

Related issue: #394 