### PR TITLE
Add button to hide splash

### DIFF
--- a/src/controls/splash.js
+++ b/src/controls/splash.js
@@ -1,33 +1,97 @@
-import { Component, Modal } from '../ui';
+import { Component, Button, Modal } from '../ui';
 
 const Splash = function Splash(options = {}) {
   const defaultTitle = 'Om kartan';
   const defaultContent = '';
   const cls = 'o-splash';
   let viewer;
+  let hideButton;
+  let modal;
+  let component;
 
   let {
     title,
     content,
-    target
+    target,
+    hideButtonVisible,
+    hideText,
+    confirmText
   } = options;
 
   const {
     url
   } = options;
 
+  const addButton = function addButton() {
+    const hideButtonHtml = hideButton.render();
+    content += hideButtonHtml;
+    return content;
+  };
+
+  const clearLocalStorage = function clearLocalStorage() {
+    localStorage.removeItem('splashVisibility');
+    localStorage.removeItem('splashContent');
+  };
+
+  const setLocalStorage = function setLocalStorage() {
+    const newContent = localStorage.getItem('splashContent') !== content;
+    if (localStorage.getItem('splashVisibility') !== 'false' || newContent) {
+      localStorage.setItem('splashContent', content);
+      if (newContent) {
+        localStorage.setItem('splashVisibility', 'true');
+      }
+    }
+  };
+
   const createModal = function createModal(modalContent) {
-    return Modal({
-      title,
-      content: modalContent,
-      cls,
-      target
-    });
+    content = modalContent;
+
+    if (hideButton) {
+      setLocalStorage();
+      component.addComponent(hideButton);
+      content = addButton();
+    } else {
+      clearLocalStorage();
+    }
+
+    if (localStorage.getItem('splashVisibility') !== 'false') {
+      modal = Modal({
+        title,
+        content,
+        cls,
+        target
+      });
+      component.dispatch('render');
+    }
   };
 
   return Component({
     name: 'splash',
+    onInit() {
+      if (!title) title = defaultTitle;
+      if (!content) content = defaultContent;
+      if (options.hideButton) {
+        hideButtonVisible = Object.prototype.hasOwnProperty.call(options.hideButton, 'visible') ? options.hideButton.visible : false;
+        hideText = Object.prototype.hasOwnProperty.call(options.hideButton, 'hideText') ? options.hideButton.hideText : 'Visa inte igen';
+        confirmText = Object.prototype.hasOwnProperty.call(options.hideButton, 'confirmText') ? options.hideButton.confirmText : 'Är du säker på att du inte vill se informationen igen?';
+      }
+      if (hideButtonVisible) {
+        hideButton = Button({
+          cls: 'rounded margin-top-small padding-y grey-lightest',
+          style: 'display: block;',
+          text: hideText,
+          click() {
+            const proceed = window.confirm(confirmText);
+            if (proceed) {
+              modal.closeModal();
+              localStorage.setItem('splashVisibility', false);
+            }
+          }
+        });
+      }
+    },
     onAdd(evt) {
+      component = this;
       viewer = evt.target;
       target = viewer.getId();
       if (!title) title = defaultTitle;
@@ -37,10 +101,16 @@ const Splash = function Splash(options = {}) {
         const fullUrl = viewer.getBaseUrl() + url;
         const req = new Request(`${fullUrl}`);
         fetch(req).then(response => response.text().then((text) => {
-          this.addComponent(createModal(text));
+          createModal(text);
+          if (modal) {
+            this.addComponent(modal);
+          }
         }));
       } else {
-        this.addComponent(createModal(content));
+        createModal(content);
+        if (modal) {
+          this.addComponent(modal);
+        }
       }
     }
   });


### PR DESCRIPTION
This fixes #591. It is configured like so:

```json
{
  "name": "splash",
  "options": {
    "url": "test.html",
    "hideButton": {
      "visible": true,
      "hideText": "Visa inte fler gånger",
      "confirmText": "Vill du verkligen inte se den här informationen igen?"
    }
  }
}
```

The only thing needed is the "visible" option, the text configurations are optional.