### PR TITLE
Autotoggle subgroups

### DIFF
--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -16,7 +16,8 @@ const Group = function Group(options = {}, viewer) {
     name,
     parent,
     position = 'top',
-    type = 'group'
+    type = 'group',
+    autoExpand = true
   } = options;
 
   const stateCls = {
@@ -200,6 +201,9 @@ const Group = function Group(options = {}, viewer) {
             this.dispatch('change:visible', { state: 'none' });
             visibleState = 'none';
           }
+          if (autoExpand) {
+            collapse.collapse();
+          }
         });
         this.on('tick:all', () => {
           const overlays = groupList.getOverlays();
@@ -214,6 +218,9 @@ const Group = function Group(options = {}, viewer) {
           if (visibleState !== 'all') {
             this.dispatch('change:visible', { state: 'all' });
             visibleState = 'all';
+          }
+          if (autoExpand) {
+            collapse.expand();
           }
         });
       }

--- a/src/ui/collapse.js
+++ b/src/ui/collapse.js
@@ -37,34 +37,38 @@ export default function Collapse(options = {}) {
   };
 
   const expand = function expand() {
+    if (!expanded) {
+      collapseEl.classList.add('expanded');
+      const newHeight = contentEl.offsetHeight;
+      const newWidth = contentEl.scrollWidth;
+      if (collapseY) containerEl.style.height = `${newHeight}px`;
+      if (collapseX) containerEl.style.width = `${newWidth}px`;
+      containerEl.addEventListener('transitionend', onTransitionEnd);
+    }
     expanded = true;
-    collapseEl.classList.add('expanded');
-    const newHeight = contentEl.offsetHeight;
-    const newWidth = contentEl.scrollWidth;
-    if (collapseY) containerEl.style.height = `${newHeight}px`;
-    if (collapseX) containerEl.style.width = `${newWidth}px`;
-    containerEl.addEventListener('transitionend', onTransitionEnd);
   };
 
   const collapse = function collapse() {
-    expanded = false;
-    const collapseSize = 0;
-    collapseEl.classList.remove('expanded');
-    const currentHeight = contentEl.offsetHeight;
-    const currentWidth = contentEl.scrollWidth;
-    const elementTransition = containerEl.style.transition;
-    containerEl.style.transition = '';
-
-    requestAnimationFrame(() => {
-      if (collapseY) containerEl.style.height = `${currentHeight}px`;
-      if (collapseX) containerEl.style.width = `${currentWidth}px`;
-      containerEl.style.transition = elementTransition;
+    if (expanded) {
+      const collapseSize = 0;
+      collapseEl.classList.remove('expanded');
+      const currentHeight = contentEl.offsetHeight;
+      const currentWidth = contentEl.scrollWidth;
+      const elementTransition = containerEl.style.transition;
+      containerEl.style.transition = '';
 
       requestAnimationFrame(() => {
-        if (collapseY) containerEl.style.height = `${collapseSize}px`;
-        if (collapseX) containerEl.style.width = `${collapseSize}px`;
+        if (collapseY) containerEl.style.height = `${currentHeight}px`;
+        if (collapseX) containerEl.style.width = `${currentWidth}px`;
+        containerEl.style.transition = elementTransition;
+
+        requestAnimationFrame(() => {
+          if (collapseY) containerEl.style.height = `${collapseSize}px`;
+          if (collapseX) containerEl.style.width = `${collapseSize}px`;
+        });
       });
-    });
+    }
+    expanded = false;
   };
 
   const toggle = function toggle(evt) {


### PR DESCRIPTION
@mulfvik
Fixes #245, rewrote #503
By default you expand/collapse subgroups when ticking the subgroups checkbox. However you can override this by setting `"autoExpand": false` for a certain group.