### PR TITLE
Fixed @center coordinate transformation bug

### DIFF
--- a/src/geometry/getcenter.js
+++ b/src/geometry/getcenter.js
@@ -7,7 +7,6 @@ export default function getCenter(geometryIn, destination, axisOrientation, map)
     geometry.transform(map.getView().getProjection(), destination);
   }
 
-
   const type = geometry.getType();
   let center;
   switch (type) {

--- a/src/geometry/getcenter.js
+++ b/src/geometry/getcenter.js
@@ -1,5 +1,3 @@
-import viewer from '../viewer';
-
 export default function getCenter(geometryIn, destination, axisOrientation, map) {
   const geometry = geometryIn.clone();
 

--- a/src/utils/replacer.js
+++ b/src/utils/replacer.js
@@ -13,7 +13,7 @@ const replacer = function replacer() {
     return ['', str];
   }
 
-  function searchAndReplace(name, obj) {
+  function searchAndReplace(name, obj, map) {
     const regex = new RegExp(`${start}(.*?)${end}`, 'g');
     const matches = regex.exec(name);
     if (matches) {
@@ -23,11 +23,11 @@ const replacer = function replacer() {
         if (nsIndex) {
           const helperParts = getArgs(matches[1]);
           const helperName = helperParts[1].substring(nsIndex - 1);
-          const args = helperArg.concat(helperParts[0]);
+          const args = helperArg.concat(helperParts[0], map);
           val = Object.prototype.hasOwnProperty.call(helper, helperName) ? helper[helperName].apply(null, args).toString() : '';
         }
       }
-      return searchAndReplace(name.replace(matches[0], val), obj);
+      return searchAndReplace(name.replace(matches[0], val), obj, map);
     }
     return name;
   }
@@ -39,7 +39,7 @@ const replacer = function replacer() {
     helperNS = options.helperNS || '@';
     helperArg = [options.helperArg] || [];
 
-    const result = searchAndReplace(name, obj);
+    const result = searchAndReplace(name, obj, map);
     return result;
   }
 


### PR DESCRIPTION
Fixes #687.

Can be tested using the default config while adding the snippet below as an attribute to the 'origo-cities' layer.

```
{
  "html": "<a href='https://www.google.se/maps/dir//{{@center(EPSG:4326,reverse)}}/@{{@center(EPSG:4326,reverse)}}' target='_blank' style='float: right'>Directions &raquo;</a>"
}
```

This PR is a quick fix to solve the issue mentioned above. But it only works if two arguments are passed to the @&#x200B;center helper function. E.g. 'EPSG:4326' and 'reverse' in the snippet above. If the 'reverse' argument is omitted, an empty argument must be passed to the function, like this (note the trailing comma separator):

```
@center(EPSG:4326,)
```

This is, in part, because of the way the searchAndReplace function is written, including a helper function call with flexible number of arguments. There are a few ways around this, but I found it hard to come up with something pretty that doesn't require rewriting everything related to the searchAndReplace function.

Suggestions are welcome.