### PR TITLE
Fix for background maps and measure icons

### DIFF
--- a/scss/_measure.scss
+++ b/scss/_measure.scss
@@ -25,3 +25,6 @@
 .o-measure-button-true .o-icon-minicons-line-vector {
   fill: $o-btn-active-color;
 }
+.o-measure-length .icon svg, .o-measure-area .icon svg {
+  overflow: visible;
+}

--- a/scss/ui/_button.scss
+++ b/scss/ui/_button.scss
@@ -102,6 +102,7 @@ button {
     border-radius: $button-round;
     [class*='icon'] > *,
     [class^='icon'] > * {
+      border-radius: $button-round;
       overflow: hidden;
     }         
   }


### PR DESCRIPTION
Fixes #738 
Makes an exception for the measure icons (they are to big to fit inside the round icons) and reverts the ui button.css to previous state.