### PR TITLE
Adds projection option for wfs and geojson

### DIFF
--- a/src/layer/geojson.js
+++ b/src/layer/geojson.js
@@ -7,20 +7,21 @@ function createSource(options) {
   const vectorSource = new VectorSource({
     attributions: options.attribution,
     loader() {
-      fetch(options.url).then(response => response.json()).then(
-        (data) => {
-          vectorSource.addFeatures(vectorSource.getFormat().readFeatures(data));
-          const numFeatures = vectorSource.getFeatures().length;
-          for (let i = 0; i < numFeatures; i += 1) {
-            vectorSource.forEachFeature((feature) => {
-              feature.setId(i);
-              i += 1;
-            });
-          }
+      fetch(options.url).then(response => response.json()).then((data) => {
+        vectorSource.addFeatures(vectorSource.getFormat().readFeatures(data));
+        const numFeatures = vectorSource.getFeatures().length;
+        for (let i = 0; i < numFeatures; i += 1) {
+          vectorSource.forEachFeature((feature) => {
+            feature.setId(i);
+            i += 1;
+          });
         }
-      ).catch(error => console.warn(error));
+      }).catch(error => console.warn(error));
     },
-    format: new GeoJSON()
+    format: new GeoJSON({
+      dataProjection: options.dataProjection,
+      featureProjection: options.projectionCode
+    })
   });
   return vectorSource;
 }
@@ -34,6 +35,13 @@ const geojson = function geojson(layerOptions, viewer) {
   const sourceOptions = {};
   sourceOptions.attribution = geojsonOptions.attribution;
   sourceOptions.projectionCode = viewer.getProjectionCode();
+  if (geojsonOptions.projection) {
+    sourceOptions.dataProjection = geojsonOptions.projection;
+  } else if (sourceOptions.projection) {
+    sourceOptions.dataProjection = sourceOptions.projection;
+  } else {
+    sourceOptions.dataProjection = viewer.getProjectionCode();
+  }
   sourceOptions.sourceName = layerOptions.source;
   if (isurl(geojsonOptions.source)) {
     sourceOptions.url = geojsonOptions.source;

--- a/src/layer/wfs.js
+++ b/src/layer/wfs.js
@@ -16,7 +16,6 @@ function createSource(options) {
     queryFilter = options.filter ? `&CQL_FILTER=${options.filter} AND BBOX(${options.geometryName},` : '&BBOX=';
   }
   const bboxProjectionCode = options.filter ? `'${options.dataProjection}')` : options.dataProjection;
-  console.log(options.dataProjection);
   const vectorSource = new VectorSource({
     attributions: options.attribution,
     format: new GeoJSONFormat({

--- a/src/layer/wfs.js
+++ b/src/layer/wfs.js
@@ -2,6 +2,7 @@ import * as LoadingStrategy from 'ol/loadingstrategy';
 import { createXYZ } from 'ol/tilegrid';
 import VectorSource from 'ol/source/Vector';
 import GeoJSONFormat from 'ol/format/GeoJSON';
+import { transformExtent } from 'ol/proj';
 import vector from './vector';
 
 function createSource(options) {
@@ -14,17 +15,26 @@ function createSource(options) {
   } else {
     queryFilter = options.filter ? `&CQL_FILTER=${options.filter} AND BBOX(${options.geometryName},` : '&BBOX=';
   }
-  const bboxProjectionCode = options.filter ? `'${options.projectionCode}')` : options.projectionCode;
+  const bboxProjectionCode = options.filter ? `'${options.dataProjection}')` : options.dataProjection;
+  console.log(options.dataProjection);
   const vectorSource = new VectorSource({
     attributions: options.attribution,
     format: new GeoJSONFormat({
-      geometryName: options.geometryName
+      geometryName: options.geometryName,
+      dataProjection: options.dataProjection,
+      featureProjection: options.projectionCode
     }),
     loader(extent) {
+      let requestExtent;
+      if (options.dataProjection !== options.projectionCode) {
+        requestExtent = transformExtent(extent, options.projectionCode, options.dataProjection);
+      } else {
+        requestExtent = extent;
+      }
       let url = [`${serverUrl}?service=WFS`,
         `&version=1.1.0&request=GetFeature&typeName=${options.featureType}&outputFormat=application/json`,
-        `&srsname=${options.projectionCode}`].join('');
-      url += options.strategy === 'all' ? queryFilter : `${queryFilter + extent.join(',')},${bboxProjectionCode}`;
+        `&srsname=${options.dataProjection}`].join('');
+      url += options.strategy === 'all' ? queryFilter : `${queryFilter + requestExtent.join(',')},${bboxProjectionCode}`;
       url = encodeURI(url);
 
       fetch(url).then(response => response.json({
@@ -52,6 +62,13 @@ export default function wfs(layerOptions, viewer) {
   sourceOptions.attribution = wfsOptions.attribution;
   sourceOptions.resolutions = viewer.getResolutions();
   sourceOptions.projectionCode = viewer.getProjectionCode();
+  if (wfsOptions.projection) {
+    sourceOptions.dataProjection = wfsOptions.projection;
+  } else if (sourceOptions.projection) {
+    sourceOptions.dataProjection = sourceOptions.projection;
+  } else {
+    sourceOptions.dataProjection = viewer.getProjectionCode();
+  }
 
   sourceOptions.strategy = layerOptions.strategy ? layerOptions.strategy : sourceOptions.strategy;
   switch (sourceOptions.strategy) {


### PR DESCRIPTION
Fixes # 734
Adds projection option for wfs and geojson.
Simply set "projection":"EPSG:4326" to request features in another reference system and Origo will handle the transformation. The proj4Defs has to be configured in index.json unless it's EPSG:4326 or 3857. 