### PR TITLE
Markus' search suggestions fix

### DIFF
--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -293,8 +293,8 @@ const Search = function Search(options = {}) {
       sort: false,
       maxItems: limit,
       item: renderList,
-      filter(suggestion, input) {
-        if (suggestion.value.toLowerCase().includes(input.toLowerCase())) {
+      filter(suggestion, userInput) {
+        if (suggestion.value.toLowerCase().includes(userInput.toLowerCase())) {
           return suggestion.value;
         }
         return false;

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -297,6 +297,7 @@ const Search = function Search(options = {}) {
         if (suggestion.value.toLowerCase().includes(input.toLowerCase())) {
           return suggestion.value;
         }
+        return false;
       }
     });
 

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -293,8 +293,10 @@ const Search = function Search(options = {}) {
       sort: false,
       maxItems: limit,
       item: renderList,
-      filter(suggestion) {
-        return suggestion.value;
+      filter(suggestion, input) {
+        if (suggestion.value.toLowerCase().includes(input.toLowerCase())) {
+          return suggestion.value;
+        }
       }
     });
 


### PR DESCRIPTION
Proposes to fix #425 , same as old PR #426, as agreed. (ESlint doesn't like a conditional return statement; I can't tell that this causes a functional issue however.) Movies:

![search_pre_Markus](https://user-images.githubusercontent.com/5138906/68865407-122d4e00-06f3-11ea-937c-7ede4fa2d19c.gif)
![search_post_Markus](https://user-images.githubusercontent.com/5138906/68865415-15283e80-06f3-11ea-896e-6908c2431ca4.gif)

Tested with V:ås external map's search back end, clicking hits does not pan and zoom by default neither with the current search nor the slightly altered version proposed here, perhaps a trivial thing, may be that someone else is interested in testing.

Edit. Yeah, two movies of unequal lenghts autoplaying right next to each other is a bit annoying