### PR TITLE
Enables the constrainResolution option for an Origo map

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -11,7 +11,8 @@ const Map = (options = {}) => {
       center: options.center,
       resolutions: options.resolutions || undefined,
       zoom: options.zoom,
-      enableRotation: options.enableRotation
+      enableRotation: options.enableRotation,
+      constrainResolution: options.constrainResolution
     })
   });
   return map;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -31,6 +31,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
     consoleId = 'o-console',
     mapCls = 'o-map',
     controls = [],
+    constrainResolution = false,
     enableRotation = true,
     featureinfoOptions = {},
     groups: groupOptions = [],
@@ -372,6 +373,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
         center,
         resolutions,
         zoom,
+        constrainResolution,
         enableRotation,
         target: this.getId()
       }));


### PR DESCRIPTION
Satisfies #759 

Currently as link in the issue states this property (still) defaults to false in OL6 but the behaviour around scroll wheels on mice appears to differ, as mentioned in the issue. The default property in this PR is false, the important bit to me is that the option joins the mothership.