### PR TITLE
Modal iframe

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -14,7 +14,7 @@
 .o-modal {
   background-color: white;
   border-radius: 6px;
-	bottom: auto;
+  bottom: auto;
   -webkit-box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
   box-shadow: 0 2px 8px 1px rgba(0,0,0,0.45);
   font-family: Arial,sans-serif;
@@ -23,9 +23,9 @@
   -webkit-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   position: absolute;
-	right: auto;
-	top: 50%;
-	-webkit-transform-style: preserve-3d;
+  right: auto;
+  top: 50%;
+  -webkit-transform-style: preserve-3d;
   -moz-transform-style: preserve-3d;
   transform-style: preserve-3d;
   width: 300px;
@@ -46,10 +46,10 @@
 .o-modal-content {
   font-size: 0.9em;
   line-height: 1.1em;
-	max-height: calc(100vh - 60px);
+  max-height: calc(100vh - 60px);
   height: 100%;
   padding: 10px 15px;
-	overflow-y: auto;
+  overflow-y: auto;
 }
 .o-modal-content .o-share-link {
   padding: 10px 5px;

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -47,6 +47,7 @@
   font-size: 0.9em;
   line-height: 1.1em;
 	max-height: calc(100vh - 100px);
+  height: 100%;
   padding: 10px 15px;
 	overflow-y: auto;
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -46,7 +46,7 @@
 .o-modal-content {
   font-size: 0.9em;
   line-height: 1.1em;
-	max-height: calc(100vh - 100px);
+	max-height: calc(100vh - 60px);
   height: 100%;
   padding: 10px 15px;
 	overflow-y: auto;

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -167,7 +167,7 @@ const Featureinfo = function Featureinfo(options = {}) {
         }
       }
       Modal({
-        title: targ.innerText,
+        title: targ.href,
         content: `<iframe src="${targ.href}" class=""style="width:100%;height:99%"></iframe>`,
         target: viewer.getId(),
         style: modalStyle,

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -1,7 +1,7 @@
 import 'owl.carousel';
 import Overlay from 'ol/Overlay';
 import $ from 'jquery';
-import { Component } from './ui';
+import { Component, Modal } from './ui';
 import Popup from './popup';
 import sidebar from './sidebar';
 import maputils from './maputils';
@@ -149,6 +149,32 @@ const Featureinfo = function Featureinfo(options = {}) {
     return getContent;
   };
 
+  const addLinkListener = function addLinkListener(el) {
+    el.addEventListener('click', (e) => {
+      e.preventDefault();
+      const targ = e.target;
+      let modalStyle = '';
+      switch (targ.target) {
+        case 'modal-full':
+        {
+          modalStyle = 'max-width:unset;width:98%;height:98%;';
+          break;
+        }
+        default:
+        {
+          modalStyle = '';
+          break;
+        }
+      }
+      Modal({
+        title: targ.innerText,
+        content: `<iframe src="${targ.href}" class=""style="width:100%;height:99%;"></iframe>`,
+        target: viewer.getId(),
+        style: modalStyle
+      });
+    });
+  };
+
   const render = function render(identifyItems, target, coordinate) {
     const map = viewer.getMap();
     items = identifyItems;
@@ -204,6 +230,11 @@ const Featureinfo = function Featureinfo(options = {}) {
       {
         break;
       }
+    }
+
+    const modalLinks = document.getElementsByClassName('o-identify-link-modal');
+    for (let i = 0; i < modalLinks.length; i += 1) {
+      addLinkListener(modalLinks[i]);
     }
   };
 

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -157,18 +157,18 @@ const Featureinfo = function Featureinfo(options = {}) {
       switch (targ.target) {
         case 'modal-full':
         {
-          modalStyle = 'max-width:unset;width:98%;height:98%;';
+          modalStyle = 'max-width:unset;width:98%;height:98%;resize:both;overflow:auto;display:flex;flex-flow:column;';
           break;
         }
         default:
         {
-          modalStyle = '';
+          modalStyle = 'resize:both;overflow:auto;display:flex;flex-flow:column;';
           break;
         }
       }
       Modal({
         title: targ.innerText,
-        content: `<iframe src="${targ.href}" class=""style="width:100%;height:99%;"></iframe>`,
+        content: `<iframe src="${targ.href}" class=""style="width:100%;height:99%"></iframe>`,
         target: viewer.getId(),
         style: modalStyle,
         newTabUrl: targ.href

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -170,7 +170,8 @@ const Featureinfo = function Featureinfo(options = {}) {
         title: targ.innerText,
         content: `<iframe src="${targ.href}" class=""style="width:100%;height:99%;"></iframe>`,
         target: viewer.getId(),
-        style: modalStyle
+        style: modalStyle,
+        newTabUrl: targ.href
       });
     });
   };

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -22,7 +22,16 @@ const getContent = {
         if (attribute.url) {
           if (feature.get(attribute.url)) {
             const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), feature.getProperties(), null, map));
-            val = `<a href="${url}" target="_blank">${feature.get(attribute.name)}</a>`;
+            let aTarget = '_blank';
+            let aCls = 'o-identify-link';
+            if (attribute.target === 'modal') {
+              aTarget = 'modal';
+              aCls = 'o-identify-link-modal';
+            } else if (attribute.target === 'modal-full') {
+              aTarget = 'modal-full';
+              aCls = 'o-identify-link-modal';
+            }
+            val = `<a class="${aCls}" target="${aTarget}" href="${url}">${feature.get(attribute.name)}</a>`;
           }
         }
       }
@@ -37,7 +46,16 @@ const getContent = {
     if (feature.get(attribute.url)) {
       const text = attribute.html || attribute.url;
       const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), attributes, null, map));
-      val = `<a href="${url}" target="_blank">${text}</a>`;
+      let aTarget = '_blank';
+      let aCls = 'o-identify-link';
+      if (attribute.target === 'modal') {
+        aTarget = 'modal';
+        aCls = 'o-identify-link-modal';
+      } else if (attribute.target === 'modal-full') {
+        aTarget = 'modal-full';
+        aCls = 'o-identify-link-modal';
+      }
+      val = `<a class="${aCls}" target="${aTarget}" href="${url}">${text}</a>`;
     }
     const newElement = document.createElement('li');
     newElement.classList.add(attribute.cls);

--- a/src/ui/modal.js
+++ b/src/ui/modal.js
@@ -12,7 +12,8 @@ export default function Modal(options = {}) {
     isStatic = options.static,
     target,
     closeIcon = '#ic_close_24px',
-    style = ''
+    style = '',
+    newTabUrl = ''
   } = options;
 
   let modal;
@@ -21,6 +22,7 @@ export default function Modal(options = {}) {
   let headerEl;
   let contentEl;
   let closeButton;
+  let newTabButton;
 
   const closeModal = function closeModal() {
     modal.parentNode.removeChild(modal);
@@ -33,11 +35,25 @@ export default function Modal(options = {}) {
         cls: 'o-modal-screen'
       });
 
+      const headerCmps = [];
+
       titleEl = Element({
         cls: 'flex row justify-start margin-top-small margin-left text-weight-bold',
         style: 'width: 100%;',
         innerHTML: `${title}`
       });
+      headerCmps.push(titleEl);
+
+      if (newTabUrl) {
+        newTabButton = Button({
+          cls: 'small round margin-top-small margin-right icon-smaller grey-lightest no-shrink',
+          icon: '#ic_launch_24px',
+          click() {
+            window.open(newTabUrl);
+          }
+        });
+        headerCmps.push(newTabButton);
+      }
 
       closeButton = Button({
         cls: 'small round margin-top-small margin-right icon-smaller grey-lightest no-shrink',
@@ -47,10 +63,11 @@ export default function Modal(options = {}) {
           closeModal();
         }
       });
+      headerCmps.push(closeButton);
 
       headerEl = Element({
         cls: 'flex row justify-end grey-lightest',
-        components: [titleEl, closeButton]
+        components: headerCmps
       });
 
       contentEl = Element({
@@ -61,9 +78,6 @@ export default function Modal(options = {}) {
       this.addComponent(screenEl);
       this.addComponent(headerEl);
       this.addComponent(contentEl);
-
-      headerEl.addComponent(titleEl);
-      headerEl.addComponent(closeButton);
 
       this.on('render', this.onRender);
       document.getElementById(target).appendChild(html(this.render()));


### PR DESCRIPTION
Fixes #381 
Add target: modal or modal-full to open links in modal window instead of a new window. Used along with url. 
Example:

```
{
  "name": "name",
  "url": "url",
  "target": "modal-full"
}
```