### PR TITLE
Removed width in scalepicker

### DIFF
--- a/scss/_scalepicker.scss
+++ b/scss/_scalepicker.scss
@@ -1,4 +1,5 @@
 .o-scalepicker {
+  min-width: 110px;
   margin-right: 5px;
   height: 1.25rem;
 }

--- a/scss/_scalepicker.scss
+++ b/scss/_scalepicker.scss
@@ -1,5 +1,4 @@
 .o-scalepicker {
-  width: 110px;
   margin-right: 5px;
   height: 1.25rem;
 }


### PR DESCRIPTION
Fixes #780 
Partly fixes the issue by removing the width for scalepicker. However, fitting scalepicker and position in the left side of the footer can be an issue when working on a smaller browser window/screen. The footer may need an overhaul.