### PR TITLE
Added geometryType check and alert

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -292,7 +292,9 @@ function onDeleteSelected() {
 }
 
 function startDraw() {
-  if (hasDraw !== true && isActive()) {
+  if (!editLayers[currentLayer].get('geometryType')) {
+    alert(`"geometryType" saknas för ${editLayers[currentLayer].get('name')}`);
+  } else if (hasDraw !== true && isActive()) {
     setActive('draw');
     hasDraw = true;
     dispatcher.emitChangeEdit('draw', true);

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -293,7 +293,7 @@ function onDeleteSelected() {
 
 function startDraw() {
   if (!editLayers[currentLayer].get('geometryType')) {
-    alert(`"geometryType" saknas för ${editLayers[currentLayer].get('name')}`);
+    alert(`"geometryType" har inte angivits för ${editLayers[currentLayer].get('name')}`);
   } else if (hasDraw !== true && isActive()) {
     setActive('draw');
     hasDraw = true;


### PR DESCRIPTION
Fixes #546.

Adds a simple check if `geometryType` is set when the draw tool is activated. If not set, an alert message will tell the user that `geometryType` is missing.

Can be tested on empty, editable layers. Please note that if any features are present in the layer, `geometryType` will be set automatically, based on those feature types, and no message will be prompted.

The documentation will be updated with information regarding this.