### PR TITLE
Added rotation by attribute for icons

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -146,6 +146,11 @@ function checkOptions(feature, scale, styleSettings, styleList, size) {
         } else if (Object.prototype.hasOwnProperty.call(element, 'text')) {
           styleList[j][index].getText().setText(replacer.replace(element.text.text, feature.getProperties()));
         }
+        if (element.icon && Object.prototype.hasOwnProperty.call(element.icon, 'rotation')) {
+          const degrees = replacer.replace(element.icon.rotation, feature.getProperties());
+          const radians = degrees * (Math.PI / 180);
+          styleList[j][index].getImage().setRotation(radians);
+        }
         return null;
       });
       if (Object.prototype.hasOwnProperty.call(s[j][0], 'filter')) {


### PR DESCRIPTION
Fixes #457.

Allows icon rotation to be set based on an attribute by enclosing the attribute name in double curly braces, eg. `"rotation": "{{rotationAttributeName}}"`. The rotation value should be expressed in degrees. 

Config for testing can be found [here](https://gis.hudiksvall.se/examples/rotation.json).
