### PR TITLE
Hide mapmenu on mapclick

### DIFF
--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -6,6 +6,7 @@ const Legend = function Legend(options = {}) {
   const {
     cls: clsSettings = '',
     style: styleSettings = {},
+    autoHide = 'never',
     expanded = true,
     contentCls,
     contentStyle,
@@ -127,6 +128,17 @@ const Legend = function Legend(options = {}) {
     isExpanded = !isExpanded;
   };
 
+  const onMapClick = function onMapClick() {
+    if (autoHide === 'always' && isExpanded) {
+      toggleVisibility();
+    } else if (autoHide === 'mobile' && isExpanded) {
+      const size = viewer.getSize();
+      if (size === 'm' || size === 's' || size === 'xs') {
+        toggleVisibility();
+      }
+    }
+  };
+
   return Component({
     name,
     onInit() {
@@ -146,6 +158,7 @@ const Legend = function Legend(options = {}) {
 
       this.render();
       this.dispatch('render');
+      viewer.getMap().on('click', onMapClick);
     },
     onRender() {
       mainContainerEl = document.getElementById(mainContainerCmp.getId());

--- a/src/controls/mapmenu.js
+++ b/src/controls/mapmenu.js
@@ -1,6 +1,9 @@
-import { Component, Button, Element as El, dom } from '../ui';
+import {
+  Component, Button, Element as El, dom
+} from '../ui';
 
 const Mapmenu = function Mapmenu({
+  autoHide = 'never',
   closeIcon = '#ic_close_24px',
   menuIcon = '#ic_menu_24px'
 } = {}) {
@@ -24,6 +27,17 @@ const Mapmenu = function Mapmenu({
   const close = function close() {
     if (isExpanded) {
       toggle();
+    }
+  };
+
+  const onMapClick = function onMapClick() {
+    if (autoHide === 'always') {
+      close();
+    } else if (autoHide === 'mobile') {
+      const size = viewer.getSize();
+      if (size === 'm' || size === 's' || size === 'xs') {
+        close();
+      }
     }
   };
 
@@ -72,6 +86,7 @@ const Mapmenu = function Mapmenu({
       this.on('render', this.onRender);
       this.addComponents([mapMenu, menuButton]);
       this.render();
+      viewer.getMap().on('click', onMapClick);
     },
     onInit() {
       const menuButtonCls = isExpanded ? ' faded' : '';


### PR DESCRIPTION
Fixes #179.

Adds the option `"autoHide"` to the mapmenu control. It has three different settings: `"always"`. `"mobile"` and `"never"` (default).

`"always"` always closes the mapmenu when clicking the map.
`"mobile"` hides the mapmenu when clicking the map if the map size is `m`, `s` or `xs` (see breakpoints in origo.js)
`"never"` never closes the mapmenu when clicking the map.

This function could easily be added to the legend as well.