### PR TITLE
Makes it possible to use static urls as attributes

### DIFF
--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -1,6 +1,6 @@
 import featureinfotemplates from './featureinfotemplates';
-import replacer from '../src/utils/replacer';
-import isUrl from '../src/utils/isurl';
+import replacer from './utils/replacer';
+import isUrl from './utils/isurl';
 import geom from './geom';
 
 function createUrl(prefix, suffix, url) {
@@ -26,7 +26,7 @@ const getContent = {
             url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), feature.getProperties(), null, map));
           } else if (isUrl(attribute.url)) {
             url = attribute.url;
-          } else return;
+          } else return false;
           let aTarget = '_blank';
           let aCls = 'o-identify-link';
           if (attribute.target === 'modal') {
@@ -52,7 +52,7 @@ const getContent = {
       url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), attributes, null, map));
     } else if (isUrl(attribute.url)) {
       url = attribute.url;
-    } else return;
+    } else return false;
     const text = attribute.html || attribute.title || attribute.url;
     let aTarget = '_blank';
     let aCls = 'o-identify-link';

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -1,5 +1,6 @@
 import featureinfotemplates from './featureinfotemplates';
 import replacer from '../src/utils/replacer';
+import isUrl from '../src/utils/isurl';
 import geom from './geom';
 
 function createUrl(prefix, suffix, url) {
@@ -20,19 +21,22 @@ const getContent = {
           title = `<b>${attribute.title}</b>`;
         }
         if (attribute.url) {
+          let url;
           if (feature.get(attribute.url)) {
-            const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), feature.getProperties(), null, map));
-            let aTarget = '_blank';
-            let aCls = 'o-identify-link';
-            if (attribute.target === 'modal') {
-              aTarget = 'modal';
-              aCls = 'o-identify-link-modal';
-            } else if (attribute.target === 'modal-full') {
-              aTarget = 'modal-full';
-              aCls = 'o-identify-link-modal';
-            }
-            val = `<a class="${aCls}" target="${aTarget}" href="${url}">${feature.get(attribute.name)}</a>`;
+            url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), feature.getProperties(), null, map));
+          } else if (isUrl(attribute.url)) {
+            url = attribute.url;
+          } else return;
+          let aTarget = '_blank';
+          let aCls = 'o-identify-link';
+          if (attribute.target === 'modal') {
+            aTarget = 'modal';
+            aCls = 'o-identify-link-modal';
+          } else if (attribute.target === 'modal-full') {
+            aTarget = 'modal-full';
+            aCls = 'o-identify-link-modal';
           }
+          val = `<a class="${aCls}" target="${aTarget}" href="${url}">${feature.get(attribute.name)}</a>`;
         }
       }
     }
@@ -43,20 +47,23 @@ const getContent = {
   },
   url(feature, attribute, attributes, map) {
     let val = '';
+    let url;
     if (feature.get(attribute.url)) {
-      const text = attribute.html || attribute.url;
-      const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), attributes, null, map));
-      let aTarget = '_blank';
-      let aCls = 'o-identify-link';
-      if (attribute.target === 'modal') {
-        aTarget = 'modal';
-        aCls = 'o-identify-link-modal';
-      } else if (attribute.target === 'modal-full') {
-        aTarget = 'modal-full';
-        aCls = 'o-identify-link-modal';
-      }
-      val = `<a class="${aCls}" target="${aTarget}" href="${url}">${text}</a>`;
+      url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.url), attributes, null, map));
+    } else if (isUrl(attribute.url)) {
+      url = attribute.url;
+    } else return;
+    const text = attribute.html || attribute.title || attribute.url;
+    let aTarget = '_blank';
+    let aCls = 'o-identify-link';
+    if (attribute.target === 'modal') {
+      aTarget = 'modal';
+      aCls = 'o-identify-link-modal';
+    } else if (attribute.target === 'modal-full') {
+      aTarget = 'modal-full';
+      aCls = 'o-identify-link-modal';
     }
+    val = `<a class="${aCls}" target="${aTarget}" href="${url}">${text}</a>`;
     const newElement = document.createElement('li');
     newElement.classList.add(attribute.cls);
     newElement.innerHTML = val;


### PR DESCRIPTION
Fixes #660 
If url-value is not an attribute it checks if its a valid url
```
      "attributes": [
          {
            "title": "Some title",
            "url": "//www.static.url/that/is?true=yes",
            "target": "modal"
          }
      ],
```