### PR TITLE
Require list items contents to add them to the feature info popup DOM

### DIFF
--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -143,7 +143,7 @@ function getAttributes(feature, layer, map) {
           } else {
             val = customAttribute(feature, attribute, attributes, map);
           }
-          if (val instanceof HTMLLIElement) {
+          if (val instanceof HTMLLIElement && val.innerHTML.length > 0) {
             ulList.appendChild(val);
           }
         }


### PR DESCRIPTION
Fixes #864.

Another condition was added for featureinfo popup list elements to be added to the DOM, requiring that the list item has contents (`.innerHTML.length > 0`).