### PR TITLE
New `groupSuggestions` option, and group titles same as in feature info popups

### DIFF
--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -235,13 +235,18 @@ const Search = function Search(options = {}) {
     const ids = Object.keys(data);
     ids.forEach((id) => {
       const item = data[id];      
-      const typeTitle =
-        (layerNameAttribute && idAttribute) ? viewer.getLayer(item[layerNameAttribute]).get('title') :
-        (geometryAttribute && layerName) ? viewer.getLayer(item[layerName]).get('title') :
-        (titleAttribute && contentAttribute && geometryAttribute) ? item[titleAttribute] :
-        (geometryAttribute && title) ? title :
-        (easting && northing && title) ? title :
-        undefined;
+      const typeTitle = undefined;
+      if (layerNameAttribute && idAttribute) {
+        typeTitle = viewer.getLayer(item[layerNameAttribute]).get('title');
+      } else if (geometryAttribute && layerName) {
+        typeTitle = viewer.getLayer(item[layerName]).get('title');
+      } else if (titleAttribute && contentAttribute && geometryAttribute) {
+        typeTitle = item[titleAttribute];
+      } else if (geometryAttribute && title) {
+        typeTitle = title;
+      } else if (easting && northing && title) {
+        typeTitle = title;
+      }
       if (typeTitle && typeTitle in group === false) {
         group[typeTitle] = [];
         item.header = typeTitle;

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -235,7 +235,7 @@ const Search = function Search(options = {}) {
     const ids = Object.keys(data);
     ids.forEach((id) => {
       const item = data[id];      
-      const typeTitle = undefined;
+      let typeTitle = undefined;
       if (layerNameAttribute && idAttribute) {
         typeTitle = viewer.getLayer(item[layerNameAttribute]).get('title');
       } else if (geometryAttribute && layerName) {


### PR DESCRIPTION
Fixes #868.

A `groupSuggestions` option is added for the Search control which replaces `layerNameAttribute` in controlling whether or not to group suggestions.

The titles for suggestion groups are now fetched the same way as the titles for feature info popups, providing more consistency and flexibility, such as the possibility to add suggestion group titles for single layer searches or searches without defined map layers.