### PR TITLE
Fixed broken function call in AGS_MAP

### DIFF
--- a/src/layer/agsmap.js
+++ b/src/layer/agsmap.js
@@ -14,11 +14,11 @@ const agsMap = function agsMap(layerOptions, viewer) {
   };
   const sourceDefault = {
     crossOrigin: 'anonymous',
-    projection: viewer.getProjection,
+    projection: viewer.getProjection(),
     ratio: 1
   };
-  const layerSettings = Object.assign({}, layerDefault, layerOptions);
-  const sourceSettings = Object.assign({}, sourceDefault, viewer.getSource(layerOptions.source));
+  const layerSettings = { ...layerDefault, ...layerOptions };
+  const sourceSettings = { ...sourceDefault, ...viewer.getSource(layerOptions.source) };
   sourceSettings.params = layerSettings.params || {};
   sourceSettings.params.layers = `show:${layerSettings.id}`;
 


### PR DESCRIPTION
Fixes #872.

Can be tested with the release test config found [here](https://www.malardalskartan.se/origo/v2.0.1/test.json). Just change the layer "isbanor" to this:

```
{
      "name": "isbanor",
      "id": "0",
      "source": "ags_tile_vasteras",
      "style": "isbanor",
      "title": "AGS map service",
      "group": "layers",
      "type": "AGS_MAP",
      "renderMode": "image",
      "visible": false,
      "queryable": true,
      "attributes": [{
        "name": "PLATS"
      }, {
        "html": "<a href='http://www.vasteras.se/uppleva-och-gora/idrott-och-friluftsliv/skridskoakning.html' target='_blank'>Läs mer &raquo;</a>"
      }]
    }
```