### PR TITLE
Makes the mapgrid available again

### DIFF
--- a/scss/origo.scss
+++ b/scss/origo.scss
@@ -1,5 +1,5 @@
 @import 'no-map.scss';
-// @import 'background-grid.scss';
+@import 'background-grid.scss';
 @import 'variables';
 @import 'ui/ui';
 .o-map {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -38,7 +38,6 @@ const Viewer = function Viewer(targetOption, options = {}) {
     enableRotation = true,
     featureinfoOptions = {},
     groups: groupOptions = [],
-    mapGrid = true,
     pageSettings = {},
     projectionCode,
     projectionExtent,
@@ -69,7 +68,12 @@ const Viewer = function Viewer(targetOption, options = {}) {
     tileSize: [256, 256]
   };
   const tileGridSettings = Object.assign({}, defaultTileGridOptions, tileGridOptions);
-  const mapGridCls = mapGrid ? 'o-mapgrid' : '';
+  let mapGridCls = '';
+  if (pageSettings.mapGrid) {
+    if (pageSettings.mapGrid.visible) {
+      mapGridCls = 'o-map-grid';
+    }
+  }
   const cls = `${clsOptions} ${mapGridCls} ${mapCls} o-ui`.trim();
   const footerData = pageSettings.footer || {};
   const main = Main();


### PR DESCRIPTION
Fixes #883 

The assignment in viewer.js isn't as pretty anymore but it seems robust and now it cares about the visibility param of mapGrid under pageSettings, refers to the (previously disabled) o-map-grid and usage should rhyme with the documentation (defaults to false, visibility:true brings the graph paper).