### PR TITLE
Added toggleFeatureinfo event

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -121,6 +121,14 @@ const Featureinfo = function Featureinfo(options = {}) {
       } else if (identifyTarget === 'sidebar') {
         sidebar.setTitle(title);
       }
+
+      const toggleFeatureinfo = new CustomEvent('toggleFeatureinfo', {
+        detail: {
+          type: 'toggleFeatureinfo',
+          currentItem
+        }
+      });
+      document.dispatchEvent(toggleFeatureinfo);
     }
   };
 


### PR DESCRIPTION
An event is triggered when featureinfo is triggered. The event carries the currently displayed featureinfo item as a parameter.

Fixes #923.