### PR TITLE
Tries to check whether mapStateID is employed for embedded map when f…

### DIFF
--- a/src/controls/fullscreen.js
+++ b/src/controls/fullscreen.js
@@ -13,8 +13,8 @@ const Fullscreen = function Fullscreen(options = {}) {
   const goFullScreen = function goFullScreen() {
     let url = '';
     if (window.location.href.indexOf('?mapStateId=') > 0) {
-      url =  window.location.href;      
-    } else {url = permalink.getPermalink(viewer); }
+      url = window.location.href;
+    } else { url = permalink.getPermalink(viewer); }
     window.open(url);
   };
 

--- a/src/controls/fullscreen.js
+++ b/src/controls/fullscreen.js
@@ -11,7 +11,10 @@ const Fullscreen = function Fullscreen(options = {}) {
   let fullscreenButton;
 
   const goFullScreen = function goFullScreen() {
-    const url = permalink.getPermalink(viewer);
+    let url = '';
+    if (window.location.href.indexOf('?mapStateId=') > 0) {
+      url =  window.location.href;      
+    } else {url = permalink.getPermalink(viewer); }
     window.open(url);
   };
 


### PR DESCRIPTION
…ullscreen is activated and if so uses that (url) when opening a new tab/window.

Fixes #912 

This is a rather simple fix that seems to work for (our) iframes at the very least, i.e if the embedded map url contains a ?mapstate= then that url is used when clicking the fullscreen button, else the hash is calculated and used. The only method to ascertain a current mapStateID that I managed to find was getQueryVariable(  ) in loadresources. It relies on window.location too and I was hesitant to add a reference to loadresources in fullscreen. 

Feel free to test/comment.