### PR TITLE
Introduces a positional memory property for the legend's scrollbar

### DIFF
--- a/src/controls/legend/overlays.js
+++ b/src/controls/legend/overlays.js
@@ -62,7 +62,8 @@ const Overlays = function Overlays(options) {
   const slidenav = Slidenav({
     mainComponent: groupContainer,
     secondaryComponent: layerProps,
-    cls: 'right flex width-100'
+    cls: 'right flex width-100',
+    legendSlideNav: true
   });
 
   const navContainer = Component({
@@ -86,6 +87,7 @@ const Overlays = function Overlays(options) {
   });
 
   const overlaysCollapse = Collapse({
+    legendCollapse: true,
     bubble: true,
     collapseX: false,
     cls: 'flex column overflow-hidden width-100',

--- a/src/ui/collapse.js
+++ b/src/ui/collapse.js
@@ -7,6 +7,7 @@ export default function Collapse(options = {}) {
     expanded = false
   } = options;
   const {
+    legendCollapse = false,
     bubble = false,
     cls = '',
     collapseX = true,
@@ -25,7 +26,7 @@ export default function Collapse(options = {}) {
   const contentStyle = createStyle(contentStyleOptions);
   const toggleEvent = 'collapse:toggle';
   const collapseEvent = 'collapse:collapse';
-  const containerId = cuid();
+  let containerId = cuid();
   let collapseEl;
   let containerEl;
   let contentEl;
@@ -110,6 +111,9 @@ export default function Collapse(options = {}) {
       const isExpanded = expanded ? 'expanded' : '';
       const header = headerComponent ? headerComponent.render() : '';
       const footer = footerComponent ? footerComponent.render() : '';
+      if (legendCollapse) {
+        containerId = 'legendCollapse';
+      }
       return `<${tagName} id="${this.getId()}" class="collapse ${cls} ${isExpanded}" style="${style}">
                 ${header}
                 <div id="${containerId}" class="collapse-container ${contentCls}" style="${height} ${width} ${contentStyle}">

--- a/src/ui/slidenav.js
+++ b/src/ui/slidenav.js
@@ -16,7 +16,8 @@ export default function Slidenav(options = {}) {
     cls: clsOption = 'right',
     mainComponent,
     secondaryComponent,
-    style: styleSettings
+    style: styleSettings,
+    legendSlideNav = false
   } = options;
 
   const style = createStyle(styleSettings);
@@ -35,6 +36,8 @@ export default function Slidenav(options = {}) {
   let header;
   let secondaryContainer;
   let secondaryLabelCls = '';
+  let posMem = 0;
+
 
   /**
    * Toggle position between absolute and relative,
@@ -46,6 +49,9 @@ export default function Slidenav(options = {}) {
     slidenavEl.style.height = null;
     mainEl.classList.toggle('absolute');
     secondaryEl.classList.toggle('absolute');
+    if (legendSlideNav) {
+      document.getElementById('legendCollapse').scrollTop = posMem;
+    }
   };
 
   const animateHeight = function animateHeight(currentSlide, newSlide) {
@@ -95,6 +101,9 @@ export default function Slidenav(options = {}) {
   };
 
   const slideToSecondary = function slideToSecondary() {
+    if (legendSlideNav) {
+      posMem = document.getElementById('legendCollapse').scrollTop;
+    }
     slidenavEl.classList.add('slide-secondary');
     animateHeight(mainEl, secondaryEl);
     slidenavEl.addEventListener('transitionend', onTransitionEnd);


### PR DESCRIPTION
First suggestion, rough draft .. 
fixes #691 , kind of : ) 

This is how it currently is:
![pre_position](https://user-images.githubusercontent.com/5138906/82999051-c431c500-a008-11ea-9c83-a39bf4e08a54.gif)

Compared to what this patch does:
![post_position](https://user-images.githubusercontent.com/5138906/82999025-bed47a80-a008-11ea-8af1-836ea5374d25.gif)


