### PR TITLE
Possible for plugins to add params to mapstate

### DIFF
--- a/src/controls/sharemap.js
+++ b/src/controls/sharemap.js
@@ -32,6 +32,9 @@ const ShareMap = function ShareMap(options = {}) {
 
   return Component({
     name: 'sharemap',
+    addParamsToGetMapState(key, callback) {
+      permalink.addParamsToGetMapState(key, callback);
+    },
     onInit() {
       if (storeMethod && serviceEndpoint) {
         permalink.setSaveOnServerServiceEndpoint(serviceEndpoint);

--- a/src/permalink/permalink.js
+++ b/src/permalink/permalink.js
@@ -56,10 +56,14 @@ export default (() => ({
         .then((data) => {
           const mapObj = {};
           Object.keys(data).forEach(key => {
-            mapObj[key] = permalinkParser[key](data[key]);
+            if (permalinkParser[key]) mapObj[key] = permalinkParser[key](data[key]);
+            else mapObj[key] = data[key];
           });
           return mapObj;
         });
     }
+  },
+  addParamsToGetMapState: function addParamsToGetMapState(key, callback) {
+    permalinkStore.AddExternalParams(key, callback);
   }
 }))();

--- a/src/permalink/permalinkstore.js
+++ b/src/permalink/permalinkstore.js
@@ -2,6 +2,7 @@ import urlparser from '../utils/urlparser';
 
 let getPin;
 const permalinkStore = {};
+const additionalMapStateParams = {};
 
 function getSaveLayers(layers) {
   const saveLayers = [];
@@ -52,12 +53,18 @@ permalinkStore.getState = function getState(viewer, isExtended) {
     state.map = viewer.getMapName().split('.')[0];
   }
 
+  Object.keys(additionalMapStateParams).forEach((key) => additionalMapStateParams[key](state));
+
   return state;
 };
 
 permalinkStore.getUrl = function getUrl(viewer) {
   const url = viewer.getUrl();
   return url;
+};
+
+permalinkStore.AddExternalParams = function AddExternalParams(key, callback) {
+  if (!additionalMapStateParams[key]) additionalMapStateParams[key] = callback;
 };
 
 export default permalinkStore;


### PR DESCRIPTION
resolves #959 

Tested by having added layers (added with layermanager) in a map and then sharing the map to see if the added layers are still in the map. Sharemap used "storeMethod": "saveStateToServer".

The changes done in the Origo core can be seen in the commit, but the plugin needs to take advantage of them for it to work.

Example usage with specific code from Eskilstuna's layermanager:

Gets the sharemap controller and adds a key and a callback function.
![image](https://user-images.githubusercontent.com/34093582/85542622-9052bb00-b619-11ea-8051-eb3eeeb3eae0.png)

Callback function assumes the state object as parameter.
![image](https://user-images.githubusercontent.com/34093582/85542916-dd369180-b619-11ea-9a60-ae9a78ad5ad3.png)

Gets the mapstate params through viewer and uses them as needed.
![image](https://user-images.githubusercontent.com/34093582/85543229-27b80e00-b61a-11ea-8308-e3b082754ab5.png)
