### PR TITLE
Add buttons to legend tools, available for plugins

### DIFF
--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -31,6 +31,7 @@ const Legend = function Legend(options = {}) {
   let layerButton;
   let layerButtonEl;
   let isExpanded;
+  let toolsCmp;
   const cls = `${clsSettings} control bottom-right box overflow-hidden flex row o-legend`.trim();
   const style = dom.createStyle(Object.assign({}, { width: 'auto' }, styleSettings));
 
@@ -157,6 +158,19 @@ const Legend = function Legend(options = {}) {
 
   return Component({
     name,
+    addButtonToTools(button) {
+      const toolsEl = document.getElementById(toolsCmp.getId());
+      toolsEl.classList.remove('hidden');
+      if (toolsCmp.getComponents().length > 0) {
+        toolsEl.style.justifyContent = 'space-between';
+        toolsEl.insertBefore(dom.html(divider.render()), toolsEl.firstChild);
+        toolsEl.insertBefore(dom.html(button.render()), toolsEl.firstChild);
+      } else {
+        toolsEl.appendChild(dom.html(button.render()));
+      }
+      toolsCmp.addComponent(button);
+      button.onRender();
+    },
     onInit() {
       this.on('render', this.onRender);
     },
@@ -185,6 +199,8 @@ const Legend = function Legend(options = {}) {
         toggleVisibility();
       });
       window.addEventListener('resize', updateMaxHeight);
+      if (turnOffLayersControl) this.addButtonToTools(turnOffLayersButton);
+      if (layerManagerControl) this.addButtonToTools(addButton);
     },
     render() {
       const size = viewer.getSize();
@@ -195,32 +211,15 @@ const Legend = function Legend(options = {}) {
         viewer, cls: contentCls, style: contentStyle, labelOpacitySlider
       });
       const baselayerCmps = [toggleGroup];
-      const toolsCmps = [];
-      let toolsCmp;
-      let toolsCmpsLayoutStrategy;
-      let mainContainerComponents;
 
-      if (layerManagerControl || turnOffLayersControl) {
-        if (layerManagerControl && turnOffLayersControl) {
-          toolsCmps.push(addButton, divider, turnOffLayersButton);
-          toolsCmpsLayoutStrategy = 'space-between';
-        } else if (layerManagerControl && !turnOffLayersControl) {
-          toolsCmps.push(addButton);
-          toolsCmpsLayoutStrategy = 'flex-start';
-        } else if (!layerManagerControl && turnOffLayersControl) {
-          toolsCmps.push(turnOffLayersButton);
-          toolsCmpsLayoutStrategy = 'flex-end';
+      toolsCmp = El({
+        cls: 'flex padding-small no-shrink hidden',
+        style: {
+          'background-color': '#fff',
+          'justify-content': 'flex-end',
+          height: '40px'
         }
-        toolsCmp = El({
-          cls: 'flex padding-small no-shrink',
-          style: {
-            'background-color': '#fff',
-            'justify-content': toolsCmpsLayoutStrategy,
-            height: '40px'
-          },
-          components: toolsCmps
-        });
-      }
+      });
 
       const baselayersCmp = El({
         cls: 'flex padding-small no-shrink',
@@ -233,11 +232,7 @@ const Legend = function Legend(options = {}) {
         components: baselayerCmps
       });
 
-      if (toolsCmp) {
-        mainContainerComponents = [overlaysCmp, toolsCmp, baselayersCmp];
-      } else {
-        mainContainerComponents = [overlaysCmp, baselayersCmp];
-      }
+      const mainContainerComponents = [overlaysCmp, toolsCmp, baselayersCmp];
 
       mainContainerCmp = El({
         cls: 'flex column overflow-hidden relative',


### PR DESCRIPTION
resolves #964 

Instead of creating a getter for the component, as described in the issue, I went with an add function instead.
The addButtonToTools()-function handles logic depending on how many buttons has been added. If there is only one button it will be to the right in Legend, but additional buttons will fill from the left. The tools component will be added regardless if any buttons will be added, but it will be hidden until a button is added.

As can be seen in the commit, the button in legend.js can also use the function.

No buttons:
![image](https://user-images.githubusercontent.com/34093582/85547810-8da69480-b61e-11ea-8480-42c23562b383.png)

One button:
![image](https://user-images.githubusercontent.com/34093582/85546588-571c4a00-b61d-11ea-9f8e-ca87b2f7663d.png)

![image](https://user-images.githubusercontent.com/34093582/85547864-9b5c1a00-b61e-11ea-83f6-db4600cf66fe.png)

Two buttons:
![image](https://user-images.githubusercontent.com/34093582/85546658-6ac7b080-b61d-11ea-956c-ef69dbab9c65.png)

Four buttons:
![image](https://user-images.githubusercontent.com/34093582/85546806-90ed5080-b61d-11ea-84de-0ab365776f63.png)

How a plugin can add a button:
![image](https://user-images.githubusercontent.com/34093582/85546905-ab272e80-b61d-11ea-9ea5-8da35412e402.png)
