### PR TITLE
Adds visual indication on groups with active layers

### DIFF
--- a/index.json
+++ b/index.json
@@ -39,7 +39,8 @@
     {
       "name": "legend",
       "options": {
-        "labelOpacitySlider": "Opacity"
+        "labelOpacitySlider": "Opacity",
+        "useGroupIndication" : true
       }
     },
     {

--- a/scss/ui/_group-indication.scss
+++ b/scss/ui/_group-indication.scss
@@ -1,0 +1,9 @@
+.group-indication {
+	border-left: medium solid $primary-color;
+	transition: border-left 0.3s linear;
+}
+
+.no-group-indication {
+	border-left: 0px solid $primary-color;
+	transition: border-left 0.3s linear;
+}

--- a/scss/ui/_ui.scss
+++ b/scss/ui/_ui.scss
@@ -19,6 +19,7 @@
   @import './slidenav';
   @import './scrollbar';
   @import './helpers/helpers';
+  @import './group-indication';
   font-family: $font-family-base;
   font-size: $font-size-base;
   font-weight: $font-weight-base;

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -16,7 +16,8 @@ const Legend = function Legend(options = {}) {
     turnOffLayersControl = false,
     layerManagerControl = false,
     name = 'legend',
-    labelOpacitySlider = ''
+    labelOpacitySlider = '',
+    useGroupIndication = true
   } = options;
 
   let viewer;
@@ -158,6 +159,7 @@ const Legend = function Legend(options = {}) {
 
   return Component({
     name,
+    getuseGroupIndication() { return useGroupIndication; },
     addButtonToTools(button) {
       const toolsEl = document.getElementById(toolsCmp.getId());
       toolsEl.classList.remove('hidden');

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -149,6 +149,14 @@ const Group = function Group(options = {}, viewer) {
     groupList.removeGroup(group);
   };
 
+  const updateGroupIndication = function updateGroupIndication() {
+    if (groupList.getVisible() === 'none') {
+      groupEl.firstElementChild.style.borderLeft = '';
+    } else {
+      groupEl.firstElementChild.style.borderLeft = 'solid #008ff5';
+    }
+  };
+  
   return Component({
     addOverlay,
     getEl,
@@ -227,7 +235,17 @@ const Group = function Group(options = {}, viewer) {
     },
     onRender() {
       groupEl = document.getElementById(collapse.getId());
-
+      if (viewer.getControlByName('legend').getuseGroupIndication() && type === 'group') {
+        updateGroupIndication();
+        this.on('add:overlay', () => {
+          updateGroupIndication();
+        });
+        groupEl.addEventListener('change:visible', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          updateGroupIndication();
+        });
+      }
       // only listen to tick changes for subgroups
       if (type === 'grouplayer') {
         groupEl.addEventListener('tick:all', (e) => {

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -151,12 +151,14 @@ const Group = function Group(options = {}, viewer) {
 
   const updateGroupIndication = function updateGroupIndication() {
     if (groupList.getVisible() === 'none') {
-      groupEl.firstElementChild.style.borderLeft = '';
+      groupEl.firstElementChild.classList.add('no-group-indication');
+      groupEl.firstElementChild.classList.remove('group-indication');
     } else {
-      groupEl.firstElementChild.style.borderLeft = 'solid #008ff5';
+      groupEl.firstElementChild.classList.add('group-indication');
+      groupEl.firstElementChild.classList.remove('no-group-indication');
     }
   };
-  
+
   return Component({
     addOverlay,
     getEl,


### PR DESCRIPTION
fixes #970 
Implementation of visual suggestion nr 3 with option to turn it off via index.json.

```
   {
      "name": "legend", 
      "options": {
        "labelOpacitySlider": "Opacity",
        "useGroupIndication" : false
      }
    }
```

