### PR TITLE
Introduces 'o' for opacity url param in shared maps

### DIFF
--- a/src/permalink/permalinkparser.js
+++ b/src/permalink/permalinkparser.js
@@ -9,6 +9,10 @@ const layerModel = {
   s: {
     name: 'legend',
     dataType: 'boolean'
+  },
+  o: {
+    name: 'opacity',
+    dataType: 'number'
   }
 };
 
@@ -27,9 +31,12 @@ const layers = function layers(layersStr) {
     });
     Object.getOwnPropertyNames(layerObject).forEach((prop) => {
       const val = layerObject[prop];
-      if (Object.prototype.hasOwnProperty.call(layerModel, prop)) {
+      if (Object.prototype.hasOwnProperty.call(layerModel, prop) && prop !== 'o') {
         const attribute = layerModel[prop];
         obj[attribute.name] = urlparser.strBoolean(val);
+      } else if (prop === 'o') {
+        const attribute = layerModel[prop];
+        obj[attribute.name] = Number(val) / 100;
       } else {
         obj[prop] = val;
       }

--- a/src/permalink/permalinkstore.js
+++ b/src/permalink/permalinkstore.js
@@ -10,6 +10,7 @@ function getSaveLayers(layers) {
     const saveLayer = {};
     saveLayer.v = layer.getVisible() === true ? 1 : 0;
     saveLayer.s = layer.get('legend') === true ? 1 : 0;
+    saveLayer.o = Number(layer.get('opacity')) * 100;
     if (saveLayer.s || saveLayer.v) {
       saveLayer.name = layer.get('name');
       saveLayers.push(urlparser.stringify(saveLayer, {


### PR DESCRIPTION
Proposes a fix for issue #978 

Appears to work for the mapState strategy too. Default increments for the opac slider are by 10% and the opac slider will pick the nearest 10% step. I am not certain of what dataTypes are available for the layerModel in permalinkparser.js, the suggested fix may have room for discussion : ) 