### PR TITLE
Makes a shared map's floating zoom respected.

### DIFF
--- a/src/permalink/permalinkparser.js
+++ b/src/permalink/permalinkparser.js
@@ -47,7 +47,7 @@ const layers = function layers(layersStr) {
 };
 
 const zoom = function zoom(zoomStr) {
-  return parseInt(zoomStr, 10);
+  return parseFloat(zoomStr);
 };
 
 const center = function center(centerStr) {


### PR DESCRIPTION
Partially fixes #984  : a zoom of 9.763 in a shared link now produces that view, not zoom 9's.