### PR TITLE
Update origo.js

### DIFF
--- a/origo.js
+++ b/origo.js
@@ -21,6 +21,7 @@ import { renderSvgIcon } from './src/utils/legendmaker';
 import '@babel/polyfill';
 
 const Origo = function Origo(configPath, options = {}) {
+  let viewer;
   const origoConfig = {
     controls: [],
     crossDomain: true,
@@ -66,9 +67,11 @@ const Origo = function Origo(configPath, options = {}) {
     return controls;
   };
 
+  const api = () => viewer;
   const getConfig = () => origoConfig;
 
   return ui.Component({
+    api,
     getConfig,
     onInit() {
       const defaultConfig = Object.assign({}, origoConfig, options);
@@ -78,7 +81,7 @@ const Origo = function Origo(configPath, options = {}) {
           const viewerOptions = data.options;
           viewerOptions.controls = initControls(viewerOptions.controls);
           const target = viewerOptions.target;
-          const viewer = Viewer(target, viewerOptions);
+          viewer = Viewer(target, viewerOptions);
           this.dispatch('load', viewer);
         });
       }


### PR DESCRIPTION
Fixes #1011 
Then you can easily turn the map upside down as a funny joke by simply:
origo.api().getMap().getView().setRotation(Math.PI);

Or other, more useful, stuff.