### PR TITLE
fixes #1013 brings the mapmenu to the top

### DIFF
--- a/src/controls/mapmenu.js
+++ b/src/controls/mapmenu.js
@@ -118,7 +118,7 @@ const Mapmenu = function Mapmenu({
         }
       });
       mapMenu = El({
-        cls: 'absolute flex column top-right control box bg-white overflow-hidden faded',
+        cls: 'absolute flex column top-right control box bg-white overflow-hidden z-index-top faded',
         collapseX: true,
         components: [headerComponent, contentComponent]
       });


### PR DESCRIPTION
Solves the problem of placing the menu below the legend.
![menu_over_legend](https://user-images.githubusercontent.com/31125392/97283428-20ab4180-1840-11eb-9b22-1b42dad21f98.gif)
