### PR TITLE
Fix for IE 11 legend scroll issue

### DIFF
--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -32,7 +32,7 @@ const Legend = function Legend(options = {}) {
   let layerButtonEl;
   let isExpanded;
   let toolsCmp;
-  const cls = `${clsSettings} control bottom-right box overflow-hidden inline-block row o-legend`.trim();
+  const cls = `${clsSettings} control bottom-right box overflow-hidden flex row o-legend`.trim();
   const style = dom.createStyle(Object.assign({}, { width: 'auto' }, styleSettings));
 
   const addBackgroundButton = function addBackgroundButton(layer) {


### PR DESCRIPTION
Fixes #1017. 

Reverted the legend `display` property back from `inline-block` to the original `flex` setting, thus _undoing_ part of the fix that solved #955. Curiously enough, it did not bring back the abstract flutter issue, at least not what I can see.

Please, when testing this, also try to reproduce the background maps abstract flutter issue, just to make sure I didn't manage to reintroduce that issue. Please note that the fluttering was mainly a Chrome issue.