### PR TITLE
Added geoposition tracking mode

### DIFF
--- a/css/svg/material-icons.svg
+++ b/css/svg/material-icons.svg
@@ -18,6 +18,7 @@
   <symbol viewBox="0 0 24 24" id="ic_mode_edit_24px"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a.996.996 0 0 0 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></symbol>
   <!-- maps-symbol -->
   <symbol viewBox="0 0 24 24" id="ic_layers_24px"><path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"/></symbol>
+  <symbol viewBox="0 0 24 24" id="ic_navigation_24px"><path d="M12 2L4.5 20.29l.71.71L12 18l6.79 3 .71-.71z"/></symbol>
   <symbol viewBox="0 0 24 24" id="ic_near_me_24px"><path d="M21 3L3 10.53v.98l6.84 2.65L12.48 21h.98L21 3z"/></symbol>
   <symbol viewBox="0 0 24 24" id="ic_place_24px"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 0 1 0-5 2.5 2.5 0 0 1 0 5z"/></symbol>
   <!-- navigation-symbol -->

--- a/scss/ui/_icon.scss
+++ b/scss/ui/_icon.scss
@@ -83,6 +83,10 @@ button svg {
 button.active svg {
   fill: $icon-active-color;
 }
+.button.tracking svg,
+button.tracking svg {
+  fill: $icon-active-color;
+}
 .button.inactive svg,
 button.inactive svg {
   fill: $icon-inactive-color;

--- a/src/ui/button.js
+++ b/src/ui/button.js
@@ -20,7 +20,7 @@ export default function Button(options = {}) {
     tooltipText,
     title = '',
     tooltipPlacement = 'east',
-    validStates = ['initial', 'active', 'disabled', 'inactive', 'loading'],
+    validStates = ['initial', 'active', 'disabled', 'inactive', 'loading', 'tracking'],
     ariaLabel = tooltipText || title || ''
   } = options;
 


### PR DESCRIPTION
Fixes #1036.

Add the option `enableTracking: true` to, well, enable tracking. Just like this:
```
{
  "name": "geoposition",
  "options": {
    "enableTracking": true
  }
}
```

The geolocation control now has three modes - _Initial_, _Active_ and _Tracking_.

How to use it:

1. Press the Geolocation button once to enable geolocation (_Active Mode_)
2. Press the button again to activate tracking (note the subtle icon change) (_Tracking Mode_)
3. Press the button a third time to disable geolocation (_Initial Mode_)

Please note that if you drag the map while in _Tracking Mode_, the control will automatically switch back to _Active Mode_. This allows the user to pan around the map and then resume tracking by clicking the Geolocation button again.