### PR TITLE
Adds attribute option for title of modal displaying iframe.

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -200,7 +200,7 @@ const Featureinfo = function Featureinfo(options = {}) {
         }
       }
       Modal({
-        title: targ.href,
+        title: targ.title,
         content: `<iframe src="${targ.href}" class=""style="width:100%;height:99%"></iframe>`,
         target: viewer.getId(),
         style: modalStyle,

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -26,6 +26,7 @@ const getContent = {
         } else if (isUrl(attribute.url)) {
           url = attribute.url;
         } else return false;
+        const aTitle = attribute.title || url;
         let aTarget = '_blank';
         let aCls = 'o-identify-link';
         if (attribute.target === 'modal') {
@@ -35,7 +36,7 @@ const getContent = {
           aTarget = 'modal-full';
           aCls = 'o-identify-link-modal';
         }
-        val = `<a class="${aCls}" target="${aTarget}" href="${url}">${feature.get(attribute.name)}</a>`;
+        val = `<a class="${aCls}" target="${aTarget}" href="${url}" title="${aTitle}">${feature.get(attribute.name)}</a>`;
       }
     }
     const newElement = document.createElement('li');
@@ -52,6 +53,7 @@ const getContent = {
       url = attribute.url;
     } else return false;
     const text = attribute.html || attribute.title || attribute.url;
+    const aTitle = attribute.title || url;
     let aTarget = '_blank';
     let aCls = 'o-identify-link';
     if (attribute.target === 'modal') {
@@ -61,7 +63,7 @@ const getContent = {
       aTarget = 'modal-full';
       aCls = 'o-identify-link-modal';
     }
-    val = `<a class="${aCls}" target="${aTarget}" href="${url}">${text}</a>`;
+    val = `<a class="${aCls}" target="${aTarget}" href="${url}" title="${aTitle}">${text}</a>`;
     const newElement = document.createElement('li');
     newElement.classList.add(attribute.cls);
     newElement.innerHTML = val;

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -26,7 +26,7 @@ const getContent = {
         } else if (isUrl(attribute.url)) {
           url = attribute.url;
         } else return false;
-        const aTitle = attribute.title || url;
+        const aTargetTitle = replacer.replace(attribute.targetTitle, attributes) || url;
         let aTarget = '_blank';
         let aCls = 'o-identify-link';
         if (attribute.target === 'modal') {
@@ -36,7 +36,7 @@ const getContent = {
           aTarget = 'modal-full';
           aCls = 'o-identify-link-modal';
         }
-        val = `<a class="${aCls}" target="${aTarget}" href="${url}" title="${aTitle}">${feature.get(attribute.name)}</a>`;
+        val = `<a class="${aCls}" target="${aTarget}" href="${url}" title="${aTargetTitle}">${feature.get(attribute.name)}</a>`;
       }
     }
     const newElement = document.createElement('li');
@@ -53,7 +53,7 @@ const getContent = {
       url = attribute.url;
     } else return false;
     const text = attribute.html || attribute.title || attribute.url;
-    const aTitle = attribute.title || url;
+    const aTargetTitle = replacer.replace(attribute.targetTitle, attributes) || url;
     let aTarget = '_blank';
     let aCls = 'o-identify-link';
     if (attribute.target === 'modal') {
@@ -63,7 +63,7 @@ const getContent = {
       aTarget = 'modal-full';
       aCls = 'o-identify-link-modal';
     }
-    val = `<a class="${aCls}" target="${aTarget}" href="${url}" title="${aTitle}">${text}</a>`;
+    val = `<a class="${aCls}" target="${aTarget}" href="${url}" title="${aTargetTitle}">${text}</a>`;
     const newElement = document.createElement('li');
     newElement.classList.add(attribute.cls);
     newElement.innerHTML = val;


### PR DESCRIPTION
Fixes #1082

This adds the option to set title in modal titlebar to static text, attribute value or URL of iframe.
This also adds a hint on the link that opens the modal.

New attribute option is added:
targetTitle (is used together with "target": "modal" or "target": "modal-full").

If targetTitle is not added the function would be the same as in current version, i.e URL of iframe is displayed.
Can be used with braces to show attribute value of geometry.