### PR TITLE
Adds the exclusive option for groups

### DIFF
--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -43,6 +43,12 @@ const OverlayLayer = function OverlayLayer(options) {
   const getLayer = () => layer;
 
   const toggleVisible = function toggleVisible(visible) {
+    const layerGroup = layer.get('group');
+    const groupExclusive = viewer.getGroup(layerGroup).exclusive;
+    if (!visible && groupExclusive) {
+      const layers = viewer.getLayersByProperty('group', layerGroup);
+      layers.forEach(l => l.setVisible(false));
+    }
     layer.setVisible(!visible);
     return !visible;
   };


### PR DESCRIPTION
Fixes #796 
Setting "exclusive": true for a group will only allow one layer to be visible at a time. Except when loading the map, that is.