### PR TITLE
Fixed editor bug after Jquery removal

### DIFF
--- a/src/controls/editor/editform.js
+++ b/src/controls/editor/editform.js
@@ -1,5 +1,5 @@
 const createForm = function createForm(obj) {
-  const id = obj.elId.slice(1);
+  const id = obj.elId;
   let cls = obj.cls || '';
   cls += id;
   cls += obj.isVisible ? '' : ' o-hidden';

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -344,26 +344,26 @@ function onAttributesSave(feature, attrs) {
     // Read values from form
     attrs.forEach((attribute) => {
       // Get the input container class
-      const containerClass = `.${attribute.elId.slice(1)}`;
+      const containerClass = `.${attribute.elId}`;
       // Get the input attributes
-      const inputType = document.getElementById(attribute.elId).attr('type');
-      const inputValue = document.getElementById(attribute.elId).val();
-      const inputName = document.getElementById(attribute.elId).attr('name');
-      const inputId = document.getElementById(attribute.elId).attr('id');
-      const inputRequired = document.getElementById(attribute.elId).attr('required');
+      const inputType = document.getElementById(attribute.elId).getAttribute('type');
+      const inputValue = document.getElementById(attribute.elId).value;
+      const inputName = document.getElementById(attribute.elId).getAttribute('name');
+      const inputId = document.getElementById(attribute.elId).getAttribute('id');
+      const inputRequired = document.getElementById(attribute.elId).getAttribute('required');
 
       // If hidden element it should be excluded
-      if (document.querySelector(containerClass)[0].includes('o-hidden') === false) {
+      if (!document.querySelector(containerClass) || document.querySelector(containerClass).classList.contains('o-hidden') === false) {
         // Check if checkbox. If checkbox read state.
         if (inputType === 'checkbox') {
-          editEl[attribute.name] = document.getElementById(attribute.elId).is(':checked') ? 1 : 0;
+          editEl[attribute.name] = document.getElementById(attribute.elId).checked ? 1 : 0;
         } else { // Read value from input text, textarea or select
           editEl[attribute.name] = inputValue;
         }
       }
       // Check if file. If file, read and trigger resize
       if (inputType === 'file') {
-        input = document.getElementById(attribute.elId)[0];
+        input = document.getElementById(attribute.elId);
         file = input.files[0];
 
         if (file) {
@@ -545,8 +545,8 @@ function onAttributesSave(feature, attrs) {
         attributesSaveHandler(feature, editEl);
       }
 
-      modal.closeModal();
       document.getElementById('o-save-button').blur();
+      modal.closeModal();
       e.preventDefault();
     }
   });
@@ -555,7 +555,7 @@ function onAttributesSave(feature, attrs) {
 function addListener() {
   const fn = (obj) => {
     document.getElementById(obj.elDependencyId).addEventListener(obj.eventType, () => {
-      const containerClass = `.${obj.elId.slice(1)}`;
+      const containerClass = `.${obj.elId}`;
       if (document.getElementById(`${obj.elDependencyId} option:selected`).textContent === obj.requiredVal) {
         document.querySelector(containerClass).classList.remove('o-hidden');
       } else {
@@ -570,25 +570,22 @@ function addListener() {
 function addImageListener() {
   const fn = (obj) => {
     const fileReader = new FileReader();
-    const containerClass = `.${obj.elId.slice(1)}`;
-    document.querySelector(obj.elId).addEventListener('change', (ev) => {
-      const { detail: { target: { files } } } = ev;
-      if (files && files[0]) {
+    const containerClass = `.${obj.elId}`;
+    document.querySelector(`#${obj.elId}`).addEventListener('change', (ev) => {
+      if (ev.target.files && ev.target.files[0]) {
         document.querySelector(`${containerClass} img`).classList.remove('o-hidden');
         document.querySelector(`${containerClass} input[type=button]`).classList.remove('o-hidden');
         fileReader.onload = (e) => {
-          const { detail: { target: result } } = e;
-          document.querySelector(`${containerClass} img`).setAttribute('src', result);
+          document.querySelector(`${containerClass} img`).setAttribute('src', e.target.result);
         };
-        fileReader.readAsDataURL(files[0]);
+        fileReader.readAsDataURL(ev.target.files[0]);
       }
     });
 
     document.querySelector(`${containerClass} input[type=button]`).addEventListener('click', (e) => {
-      const { detail: { target } } = e;
-      document.getElementById(obj.elId).setAttribute('value', '');
+      document.getElementById(obj.elId).value = '';
       document.querySelector(`${containerClass} img`).classList.add('o-hidden');
-      document.querySelector(target).classList.add('o-hidden');
+      e.target.classList.add('o-hidden');
     });
   };
 
@@ -624,18 +621,18 @@ function editAttributes(feat) {
             obj.requiredVal = constraintProps[2];
             obj.isVisible = obj.dependencyVal === obj.requiredVal;
             obj.addListener = addListener();
-            obj.elId = `#input-${obj.name}-${obj.requiredVal}`;
-            obj.elDependencyId = `#input-${constraintProps[1]}`;
+            obj.elId = `input-${obj.name}-${obj.requiredVal}`;
+            obj.elDependencyId = `input-${constraintProps[1]}`;
           } else {
             alert('Villkor verkar inte vara rätt formulerat. Villkor formuleras enligt principen change:attribute:value');
           }
         } else if (obj.type === 'image') {
           obj.isVisible = true;
-          obj.elId = `#input-${obj.name}`;
+          obj.elId = `input-${obj.name}`;
           obj.addListener = addImageListener();
         } else {
           obj.isVisible = true;
-          obj.elId = `#input-${obj.name}`;
+          obj.elId = `input-${obj.name}`;
         }
 
         obj.formElement = editForm(obj);

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -683,7 +683,7 @@ function onToggleEdit(e) {
   } else if (tool === 'delete') {
     onDeleteSelected();
   } else if (tool === 'edit') {
-    setEditLayer(e.currentLayer);
+    setEditLayer(e.detail.currentLayer);
   } else if (tool === 'cancel') {
     removeInteractions();
   } else if (tool === 'save') {

--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -27,6 +27,7 @@ function render() {
 function toggleToolbar(state) {
   if (state) {
     const enableInteraction = new CustomEvent('enableInteraction', {
+      bubbles: true,
       detail: {
         interaction: 'editor'
       }
@@ -34,6 +35,7 @@ function toggleToolbar(state) {
     document.querySelectorAll('.o-map')[0].dispatchEvent(enableInteraction);
   } else {
     const enableInteraction = new CustomEvent('enableInteraction', {
+      bubbles: true,
       detail: {
         interaction: 'featureInfo'
       }

--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -118,7 +118,7 @@ function onChangeEdit(e) {
 function toggleSave(e) {
   const { detail: { edits } } = e;
   if (edits) {
-    if ($editSave.classList.includes(disableClass)) {
+    if ($editSave.classList.contains(disableClass)) {
       $editSave.classList.remove(disableClass);
     }
   } else {

--- a/src/controls/editor/editsstore.js
+++ b/src/controls/editor/editsstore.js
@@ -73,16 +73,16 @@ export default function editsStore() {
   }
 
   function addEdit(e) {
-    if (e.action === 'insert') {
-      addFeature('insert', e.feature, e.layerName);
-    } else if (e.action === 'update') {
-      if (hasFeature('insert', e.feature, e.layerName) === false) {
-        addFeature('update', e.feature, e.layerName);
+    if (e.detail.action === 'insert') {
+      addFeature('insert', e.detail.feature, e.detail.layerName);
+    } else if (e.detail.action === 'update') {
+      if (hasFeature('insert', e.detail.feature, e.detail.layerName) === false) {
+        addFeature('update', e.detail.feature, e.detail.layerName);
       }
-    } else if (e.action === 'delete') {
-      if (removeFeature('insert', e.feature, e.layerName) === false) {
-        removeFeature('update', e.feature, e.layerName);
-        addFeature('delete', e.feature, e.layerName);
+    } else if (e.detail.action === 'delete') {
+      if (removeFeature('insert', e.detail.feature, e.detail.layerName) === false) {
+        removeFeature('update', e.detail.feature, e.detail.layerName);
+        addFeature('delete', e.detail.feature, e.detail.layerName);
       }
     }
     if (hasEdits() === true) {
@@ -93,8 +93,8 @@ export default function editsStore() {
   }
 
   function removeEdit(e) {
-    if (e.feature.length) {
-      e.feature.forEach(feature => removeFeature(e.action, feature, e.layerName));
+    if (e.detail.feature.length) {
+      e.detail.feature.forEach(feature => removeFeature(e.detail.action, feature, e.detail.layerName));
     }
     if (hasEdits() === false) {
       dispatcher.emitEditsChange(0);


### PR DESCRIPTION
Fixes #1090.

Instead of using `bubbles: true` to fix the non-responding editor button issue, another solution would be to dispatch the `enableInteraction` event directly on `document`. Not sure if that would cause other problems or not, though.