### PR TITLE
Fix the title/tooltip in Legend control "Turn Off Layers" button

### DIFF
--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -100,7 +100,8 @@ const Legend = function Legend(options = {}) {
   });
 
   const turnOffLayersButton = Button({
-    cls: 'round compact icon-small margin-x-smaller\'title=\'Släck alla lager',
+    cls: 'round compact icon-small margin-x-smaller',
+    title: 'Släck alla lager',
     click() {
       viewer.dispatch('active:turnofflayers');
     },

--- a/src/ui/icon.js
+++ b/src/ui/icon.js
@@ -23,8 +23,14 @@ export default function Icon(options = {}) {
         `;
       }
       if (iconType === 'sprite') {
+        let titleEl = '';
+        if (title) {
+          titleEl = `
+            <title>${title}</title>
+            `;
+        }
         return `
-          <svg id="${this.getId()}" class="${cls}" style="${style}">
+          <svg id="${this.getId()}" class="${cls}" style="${style}">${titleEl}
             <use xlink:href=${icon}></use>
           </svg>
         `;


### PR DESCRIPTION
Fixes #1093.

Correcting its title definition and generally letting SVG sprite Icons have their title elements set gives the "Turn Off Layers" button the same type of tooltip as the background buttons.

![image](https://user-images.githubusercontent.com/2445979/104593593-33c7f380-5670-11eb-8c06-61c1fa822f9e.png)
