### PR TITLE
New option hideWhenEmbedded for all controls, by including control options in Viewer's addControl

### DIFF
--- a/origo.js
+++ b/origo.js
@@ -66,6 +66,7 @@ const Origo = function Origo(configPath, options = {}) {
         const controlOptions = def.options || {};
         if (controlName in origoControls) {
           const control = origoControls[controlName](controlOptions);
+          control.options = control.options || controlOptions || {};
           controls.push(control);
         }
       }

--- a/origo.js
+++ b/origo.js
@@ -66,7 +66,7 @@ const Origo = function Origo(configPath, options = {}) {
         const controlOptions = def.options || {};
         if (controlName in origoControls) {
           const control = origoControls[controlName](controlOptions);
-          control.options = control.options || controlOptions || {};
+          control.options = Object.assign(control.options || {}, controlOptions);
           controls.push(control);
         }
       }

--- a/src/controls/splash.js
+++ b/src/controls/splash.js
@@ -1,4 +1,5 @@
 import { Component, Button, Modal } from '../ui';
+import isEmbedded from '../utils/isembedded';
 
 const Splash = function Splash(options = {}) {
   const defaultTitle = 'Om kartan';
@@ -20,7 +21,8 @@ const Splash = function Splash(options = {}) {
   } = options;
 
   const {
-    url
+    url,
+    hideWhenEmbedded = false
   } = options;
 
   const addButton = function addButton() {
@@ -99,19 +101,21 @@ const Splash = function Splash(options = {}) {
       if (!title) title = defaultTitle;
       if (!content) content = defaultContent;
 
-      if (url) {
-        const fullUrl = viewer.getBaseUrl() + url;
-        const req = new Request(`${fullUrl}`);
-        fetch(req).then(response => response.text().then((text) => {
-          createModal(text);
+      if (!hideWhenEmbedded || !isEmbedded(viewer.getTarget())) {
+        if (url) {
+          const fullUrl = viewer.getBaseUrl() + url;
+          const req = new Request(`${fullUrl}`);
+          fetch(req).then(response => response.text().then((text) => {
+            createModal(text);
+            if (modal) {
+              this.addComponent(modal);
+            }
+          }));
+        } else {
+          createModal(content);
           if (modal) {
             this.addComponent(modal);
           }
-        }));
-      } else {
-        createModal(content);
-        if (modal) {
-          this.addComponent(modal);
         }
       }
     }

--- a/src/controls/splash.js
+++ b/src/controls/splash.js
@@ -1,5 +1,4 @@
 import { Component, Button, Modal } from '../ui';
-import isEmbedded from '../utils/isembedded';
 
 const Splash = function Splash(options = {}) {
   const defaultTitle = 'Om kartan';
@@ -71,6 +70,7 @@ const Splash = function Splash(options = {}) {
 
   return Component({
     name: 'splash',
+    hideWhenEmbedded,
     onInit() {
       if (!title) title = defaultTitle;
       if (!content) content = defaultContent;
@@ -101,21 +101,19 @@ const Splash = function Splash(options = {}) {
       if (!title) title = defaultTitle;
       if (!content) content = defaultContent;
 
-      if (!hideWhenEmbedded || !isEmbedded(viewer.getTarget())) {
-        if (url) {
-          const fullUrl = viewer.getBaseUrl() + url;
-          const req = new Request(`${fullUrl}`);
-          fetch(req).then(response => response.text().then((text) => {
-            createModal(text);
-            if (modal) {
-              this.addComponent(modal);
-            }
-          }));
-        } else {
-          createModal(content);
+      if (url) {
+        const fullUrl = viewer.getBaseUrl() + url;
+        const req = new Request(`${fullUrl}`);
+        fetch(req).then(response => response.text().then((text) => {
+          createModal(text);
           if (modal) {
             this.addComponent(modal);
           }
+        }));
+      } else {
+        createModal(content);
+        if (modal) {
+          this.addComponent(modal);
         }
       }
     }

--- a/src/controls/splash.js
+++ b/src/controls/splash.js
@@ -20,8 +20,7 @@ const Splash = function Splash(options = {}) {
   } = options;
 
   const {
-    url,
-    hideWhenEmbedded = false
+    url
   } = options;
 
   const addButton = function addButton() {
@@ -70,7 +69,6 @@ const Splash = function Splash(options = {}) {
 
   return Component({
     name: 'splash',
-    hideWhenEmbedded,
     onInit() {
       if (!title) title = defaultTitle;
       if (!content) content = defaultContent;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -83,7 +83,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
 
   const addControl = function addControl(control) {
     if (control.onAdd && control.dispatch) {
-      if (!control.hideWhenEmbedded || !isEmbedded(this.getTarget())) {
+      if (!control.options.hideWhenEmbedded || !isEmbedded(this.getTarget())) {
         this.addComponent(control);
       }
     } else {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -15,6 +15,7 @@ import Footer from './components/footer';
 import flattenGroups from './utils/flattengroups';
 import getAttributes from './getattributes';
 import getcenter from './geometry/getcenter';
+import isEmbedded from './utils/isembedded';
 
 const Viewer = function Viewer(targetOption, options = {}) {
   let map;
@@ -82,7 +83,9 @@ const Viewer = function Viewer(targetOption, options = {}) {
 
   const addControl = function addControl(control) {
     if (control.onAdd && control.dispatch) {
-      this.addComponent(control);
+      if (!control.hideWhenEmbedded || !isEmbedded(this.getTarget())) {
+        this.addComponent(control);
+      }
     } else {
       throw new Error('Valid control must have onAdd and dispatch methods');
     }


### PR DESCRIPTION
Fixes #1092.

Adds a new option to the Splash control; `hideWhenEmbedded` which defaults to false.

If set to true, the modal is not displayed when the map is embedded.

Example config:

```
{
      "name": "splash",
      "options": {
        "title": "hideWhenEmbedded",
        "url": "splash/splash-content.html",
        "hideButton": {
          "visible": true
        },
        "hideWhenEmbedded": true
      }
},
```