### PR TITLE
Merge (assign) config options for default controls

### DIFF
--- a/src/loadresources.js
+++ b/src/loadresources.js
@@ -62,10 +62,18 @@ const loadResources = async function loadResources(mapOptions, config) {
       }
       baseUrl = config.baseUrl || '';
       map.options = Object.assign(config, mapOptions);
+      map.options.controls = config.defaultControls || [];
       if (mapOptions.controls) {
-        map.options.controls = config.defaultControls.concat(mapOptions.controls);
-      } else {
-        map.options.controls = config.defaultControls;
+        mapOptions.controls.forEach((control) => {
+          const matchingControlIndex = map.options.controls.findIndex(
+            (defaultControl) => (defaultControl.name === control.name)
+          );
+          if (matchingControlIndex !== -1) {
+            Object.assign(map.options.controls[matchingControlIndex], control);
+          } else {
+            map.options.controls.push(control);
+          }
+        });
       }
       map.options.url = getUrl();
       map.options.map = undefined;
@@ -107,10 +115,18 @@ const loadResources = async function loadResources(mapOptions, config) {
           .then(res => res.json())
           .then((data) => {
             map.options = Object.assign(config, data);
+            map.options.controls = config.defaultControls || [];
             if (data.controls) {
-              map.options.controls = config.defaultControls.concat(data.controls);
-            } else {
-              map.options.controls = config.defaultControls;
+              data.controls.forEach((control) => {
+                const matchingControlIndex = map.options.controls.findIndex(
+                  (defaultControl) => (defaultControl.name === control.name)
+                );
+                if (matchingControlIndex !== -1) {
+                  Object.assign(map.options.controls[matchingControlIndex], control);
+                } else {
+                  map.options.controls.push(control);
+                }
+              });
             }
             map.options.url = mapUrl;
             map.options.map = json;


### PR DESCRIPTION
Fixes #1109.

Loops through the controls from the config and adds them to the array of default controls, unless the control is already among the defaults. If a control in the config is also among the default controls, they are merged.

This is to produce the following behavior:

- If, in the future, a default controls is defined with default options, then those options should be included
- If a default control is also defined in the config, the options in the config should be combined with the default options
- If the default definition and the config define the same option, the value in the config will overwrite the default value.