### PR TITLE
Fixed broken legend animation

### DIFF
--- a/scss/ui/_collapse.scss
+++ b/scss/ui/_collapse.scss
@@ -1,11 +1,4 @@
 .collapse-container {
-  height: 100%;
-  overflow: hidden;
-  position: relative;
-  transition: all 0.3s;
-}
-
-.collapse-container-no-height {
   overflow: hidden;
   position: relative;
   transition: all 0.3s;
@@ -21,7 +14,7 @@
   }
 
   &.expanded > .collapse-header {
-    border-bottom: 'none';
+    border-bottom: none;
 
     .rotate {
       &.icon {

--- a/scss/ui/_dropdown.scss
+++ b/scss/ui/_dropdown.scss
@@ -9,7 +9,7 @@
   width: 100%;
 }
 
-.dropdown .collapse-container-no-height {
+.dropdown .collapse-container {
   position: absolute;
   width: 100%;
 }

--- a/src/controls/print/print-settings.js
+++ b/src/controls/print/print-settings.js
@@ -134,6 +134,7 @@ const PrintSettings = function PrintSettings({
       contentComponent.addComponents([customSizeControl, marginControl, orientationControl, sizeControl, titleControl, descriptionControl, createdControl, northArrowControl, rotationControl, setScaleControl, resolutionControl, showScaleControl]);
       printSettingsContainer = Collapse({
         cls: 'no-print fixed flex column top-left rounded box-shadow bg-white overflow-hidden z-index-ontop-top',
+        containerCls: 'collapse-container no-margin height-full',
         collapseX: true,
         collapseY: true,
         headerComponent,

--- a/src/ui/dropdown.js
+++ b/src/ui/dropdown.js
@@ -7,7 +7,7 @@ import { html, createStyle } from './dom/dom';
 export default function Dropdown(options = {}) {
   const {
     cls = '',
-    containerCls = 'collapse-container-no-height',
+    containerCls = 'collapse-container',
     contentCls = 'bg-white',
     buttonCls = 'padding-small rounded light box-shadow',
     buttonIconCls = '',


### PR DESCRIPTION
Fixes #1114.

Animation broke due to changes for the print control (#1037), which also affected the legend and any component using the `collapse-container` class.