### PR TITLE
Proposed workaround for missed scales when constrainResolution:true

### DIFF
--- a/src/controls/zoom.js
+++ b/src/controls/zoom.js
@@ -14,13 +14,17 @@ const Zoom = function Zoom(options = {}) {
   const zoomByDelta = function zoomByDelta(deltaValue) {
     const map = viewer.getMap();
     const view = map.getView();
-    if (view.getAnimating()) {
-      view.cancelAnimations();
+    if (map.getView().options_.constrainResolution === true) {
+      view.setZoom(view.getZoom() + deltaValue);
+    } else {
+      if (view.getAnimating()) {
+        view.cancelAnimations();
+      }
+      view.animate({
+        zoom: view.getZoom() + deltaValue,
+        duration
+      });
     }
-    view.animate({
-      zoom: view.getZoom() + deltaValue,
-      duration
-    });
   };
 
   return Component({

--- a/src/controls/zoom.js
+++ b/src/controls/zoom.js
@@ -14,7 +14,7 @@ const Zoom = function Zoom(options = {}) {
   const zoomByDelta = function zoomByDelta(deltaValue) {
     const map = viewer.getMap();
     const view = map.getView();
-    if (view.options_.constrainResolution === true) {
+    if (view.getConstrainResolution() === true) {
       view.setZoom(view.getZoom() + deltaValue);
     } else {
       if (view.getAnimating()) {

--- a/src/controls/zoom.js
+++ b/src/controls/zoom.js
@@ -14,7 +14,7 @@ const Zoom = function Zoom(options = {}) {
   const zoomByDelta = function zoomByDelta(deltaValue) {
     const map = viewer.getMap();
     const view = map.getView();
-    if (map.getView().options_.constrainResolution === true) {
+    if (view.options_.constrainResolution === true) {
       view.setZoom(view.getZoom() + deltaValue);
     } else {
       if (view.getAnimating()) {


### PR DESCRIPTION
Further partially fixes #984 (see the last comment there).

If constrainResolution:true for a map and the plus or minus zoom buttons are clicked repeatedly in quick succession the viewer will end up at a scale not defined in the list of resolutions given for the map. If the scale control is employed this will result in 1:529 for example instead of the preset 1:500 and the WMS background map will be a bit blurry. The map view including the scale will correct themselves if the map is panned but a user won't always do that before zooming in and out further (which doesn't generally help).

The issue seems to be because of the animate() method for the zoom buttons and its duration of 250msecs. There's a check and a cancellation of running animations that triggers if you zoom in repeatedly faster than the animation duration but it isn't helping in regards to this issue.  AdjustZoom(), even if always given a delta of +1 or -1, has issues when the map is max or min zoomed.

So this proposed fix is a workaround. The animation is still present (and works well) with scrollwheel zooming and it is never skipped if constrainResolution:false (which is default).

Accessing view.options_ is a linter error, a fix is on the way (a getConstrainResolution() https://github.com/openlayers/openlayers/blob/main/src/ol/View.js )


Before:
![prefix](https://user-images.githubusercontent.com/5138906/105503534-00681300-5cc7-11eb-88e3-700d48396e51.gif)


After:
![postfix](https://user-images.githubusercontent.com/5138906/105503570-0b22a800-5cc7-11eb-9e7b-57298daaf206.gif)
