### PR TITLE
Added an animation for non hover devices

### DIFF
--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -1,3 +1,7 @@
+@keyframes fadeout {
+  to {opacity: 0}
+}
+
 /*Tooltip arrow*/
 .o-tooltip {
   overflow: visible;
@@ -8,10 +12,7 @@
   height: 0;
   opacity: 0;
   position: absolute;
-  transition: opacity 0.2s ease 1s;
-  transition: opacity 0.2s ease 1s;
-  transition: opacity 0.2s ease 1s;
-  transition: opacity 0.2s ease 1s;
+  transition: opacity 0.2s ease 0s;
   visibility: hidden;  /*display:non can't be used with transition*/
   width: 0;
 }
@@ -38,6 +39,12 @@
   white-space: nowrap;
   width: auto;
   z-index: 100;
+}
+
+@media (hover: none) {
+  .o-tooltip:hover span[data-tooltip] {
+    animation: 0.2s linear 3s forwards fadeout;
+  }
 }
 
 .o-tooltip:hover span[data-tooltip][data-placement='east'] {

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -18,15 +18,13 @@
 }
 
 .o-tooltip:hover span[data-tooltip] {
-  display: block;
+  display: inline-block;
   opacity: 1;
   visibility: visible;
 }
 
 .o-tooltip:hover span[data-tooltip]::after {
   background: rgba(51, 51, 51, 0.85);
-  border-radius: 4px;
-  border-radius: 4px;
   border-radius: 4px;
   border-width: 10px;
   color: #fff;
@@ -49,7 +47,7 @@
 
 .o-tooltip:hover span[data-tooltip][data-placement='east'] {
   border-color: transparent rgba(51, 51, 51, 0.85) transparent transparent;
-  margin-top: -13px;
+  margin-top: 5px;
   right: -10px;
 }
 
@@ -60,7 +58,7 @@
 .o-tooltip span[data-tooltip][data-placement='west'] {
   border-color: transparent transparent transparent rgba(51, 51, 51, 0.85);
   left: -10px;
-  margin-top: -13px;
+  margin-top: 5px;
 }
 
 .o-tooltip:hover span[data-tooltip][data-placement='west']::after {
@@ -78,8 +76,6 @@
   margin-left: 0;
   margin-top: -24px;
   transform: translate(-50%, 0);
-  transform: translate(-50%, 0);
-  transform: translate(-50%, 0);
 }
 
 .o-tooltip span[data-tooltip][data-placement='south'] {
@@ -91,7 +87,5 @@
 .o-tooltip:hover span[data-tooltip][data-placement='south']::after {
   margin-left: 0;
   margin-top: 4px;
-  transform: translate(-50%, 0);
-  transform: translate(-50%, 0);
   transform: translate(-50%, 0);
 }


### PR DESCRIPTION
Fixes #1166 
Shows the tooltip for 3 seconds on touch devices unless other interaction occurs. Changes also shows tooltips with shorter delay.