### PR TITLE
Removed jquery selected nonsense

### DIFF
--- a/src/controls/editor/editform.js
+++ b/src/controls/editor/editform.js
@@ -36,9 +36,9 @@ const createForm = function createForm(obj) {
       break;
     case 'dropdown':
       if (val) {
-        firstOption = `<option value="${val}" selected>${val}</option>`;
+        firstOption = `<option value="${val}">${val}</option>`;
       } else {
-        firstOption = '<option value="" selected>Välj</option>';
+        firstOption = '<option value="">Välj</option>';
       }
       el = `<div class="${cls}"><label>${label}</label><br><select id=${id}${disabled}>${firstOption}`;
       for (let i = 0; i < dropdownOptions.length; i += 1) {

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -555,7 +555,7 @@ function addListener() {
   const fn = (obj) => {
     document.getElementById(obj.elDependencyId).addEventListener(obj.eventType, () => {
       const containerClass = `.${obj.elId}`;
-      if (document.getElementById(`${obj.elDependencyId} option:selected`).textContent === obj.requiredVal) {
+      if (document.getElementById(obj.elDependencyId).value === obj.requiredVal) {
         document.querySelector(containerClass).classList.remove('o-hidden');
       } else {
         document.querySelector(containerClass).classList.add('o-hidden');


### PR DESCRIPTION
Fixes #1183. It seems a few badly translated jquery crumbs got left behind.

Oh, you can use the config snippet below for testing. Just change `attributes` for the `editor_point` layer into this:

```
"attributes": [
          {
            "name": "name",
            "title": "Name: ",
            "type": "text",
            "maxLength": 50
          },
          {
            "name": "type",
            "title": "category: ",
            "type": "dropdown",
            "options": [ "category_1", "category_2", "category_3" ]
          },
          {
            "name": "comments",
            "title": "subcategory: ",
            "type": "dropdown",
            "constraint": "change:type:category_1",
            "options": [ "subcategory_1", "subcategory_2", "subcategory_3" ]
          }
      ]
```