### PR TITLE
Make getLayers aware of layers in groups

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -161,19 +161,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
 
   const getMap = () => map;
 
-  const getLayers = function getLayers() {
-    const arr = [];
-    const layerArray = map.getLayers().getArray();
-    layerArray.forEach((element) => {
-      arr.push(element);
-      if (element.get('type') === 'GROUP') {
-        element.getLayers().getArray().forEach((layerInGroup) => {
-          arr.push(layerInGroup);
-        });
-      }
-    });
-    return arr;
-  };
+  const getLayers = () => map.getLayers().getArray();
 
   const getLayersByProperty = function getLayersByProperty(key, val, byName) {
     const layers = map.getLayers().getArray().filter(layer => layer.get(key) && layer.get(key) === val);
@@ -184,7 +172,17 @@ const Viewer = function Viewer(targetOption, options = {}) {
     return layers;
   };
 
-  const getLayer = layerName => getLayers().filter(layer => layer.get('name') === layerName)[0];
+  const getLayer = function getLayer(layerName) {
+    const layerArray = getLayers();
+    if (layerArray.some(layer => layer.get('name') === layerName)) {
+      return layerArray.find(layer => layer.get('name') === layerName);
+    } else if (layerArray.some(layer => layer.get('type') === 'GROUP')) {
+      const groupLayerArray = layerArray.filter(layer => layer.get('type') === 'GROUP');
+      const layersFromGroupLayersArray = groupLayerArray.map(groupLayer => groupLayer.getLayers().getArray());
+      return layersFromGroupLayersArray.flat().find(layer => layer.get('name') === layerName);
+    }
+    return undefined;
+  };
 
   const getQueryableLayers = function getQueryableLayers() {
     const queryableLayers = getLayers().filter(layer => layer.get('queryable') && layer.getVisible());

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -161,7 +161,20 @@ const Viewer = function Viewer(targetOption, options = {}) {
 
   const getMap = () => map;
 
-  const getLayers = () => map.getLayers().getArray();
+  const getLayers = function getLayers() {
+    const arr = [];
+    const layerArray = map.getLayers().getArray();
+    layerArray.forEach((element) => {
+      if (element.get('layerType') === 'group') {
+        element.getLayers().getArray().forEach((layerInGroup) => {
+          arr.push(layerInGroup);
+        });
+      } else {
+        arr.push(element);
+      }
+    });
+    return arr;
+  };
 
   const getLayersByProperty = function getLayersByProperty(key, val, byName) {
     const layers = map.getLayers().getArray().filter(layer => layer.get(key) && layer.get(key) === val);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -166,6 +166,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
     const layerArray = map.getLayers().getArray();
     layerArray.forEach((element) => {
       if (element.get('type') === 'GROUP') {
+        arr.push(element);
         element.getLayers().getArray().forEach((layerInGroup) => {
           arr.push(layerInGroup);
         });

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -165,13 +165,11 @@ const Viewer = function Viewer(targetOption, options = {}) {
     const arr = [];
     const layerArray = map.getLayers().getArray();
     layerArray.forEach((element) => {
+      arr.push(element);
       if (element.get('type') === 'GROUP') {
-        arr.push(element);
         element.getLayers().getArray().forEach((layerInGroup) => {
           arr.push(layerInGroup);
         });
-      } else {
-        arr.push(element);
       }
     });
     return arr;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -165,7 +165,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
     const arr = [];
     const layerArray = map.getLayers().getArray();
     layerArray.forEach((element) => {
-      if (element.get('layerType') === 'group') {
+      if (element.get('type') === 'GROUP') {
         element.getLayers().getArray().forEach((layerInGroup) => {
           arr.push(layerInGroup);
         });


### PR DESCRIPTION
Fixes #1197 
The getLayers function in viewer will instead of returning a layerGroup return the individual layers in the group. I have not thoroughly tested how this affect other tools but I am not aware of any that uses the getLayers in that way.