### PR TITLE
Share wfs layer selection amelioration

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -150,6 +150,10 @@ const Featureinfo = function Featureinfo(options = {}) {
       selection.coordinates = firstFeature.getGeometry().getCoordinates();
       selection.id = firstFeature.getId() != null ? firstFeature.getId() : firstFeature.ol_uid;
       selection.type = typeof selectionLayer.getSourceLayer() === 'string' ? selectionLayer.getFeatureLayer().type : selectionLayer.getSourceLayer().get('type');
+      if (selection.type === 'WFS') {
+        const idSuffix = selection.id.substring(selection.id.lastIndexOf('.') + 1, selection.id.length);
+        selection.id = `${selectionLayer.getSourceLayer().get('name')}.${idSuffix}`;
+      }
       if (selection.type !== 'WFS') {
         const name = typeof selectionLayer.getSourceLayer() === 'string' ? selectionLayer.getSourceLayer() : selectionLayer.getSourceLayer().get('name');
         const id = firstFeature.getId() || selection.id;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -406,7 +406,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
       });
 
       if (urlParams.feature) {
-        const featureId = urlParams.feature;
+        let featureId = urlParams.feature;
         const layerName = featureId.split('.')[0];
         const layer = getLayer(layerName);
         const type = layer.get('type');
@@ -420,9 +420,10 @@ const Viewer = function Viewer(targetOption, options = {}) {
             if (type === 'WFS' && clusterSource) {
               feature = clusterSource.getFeatureById(featureId);
             } else if (type === 'WFS') {
+              if (featureId.includes('__')) {
+                featureId = featureId.replace(featureId.substring(featureId.lastIndexOf('__'), featureId.lastIndexOf('.')), '');
+              }
               feature = layer.getSource().getFeatureById(featureId);
-              const newfeatureId = featureId.replace(featureId.substring(featureId.lastIndexOf('__'), featureId.lastIndexOf('.')), '');
-              feature = layer.getSource().getFeatureById(newfeatureId);
             } else if (clusterSource) {
               feature = clusterSource.getFeatureById(id);
             } else {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -421,6 +421,8 @@ const Viewer = function Viewer(targetOption, options = {}) {
               feature = clusterSource.getFeatureById(featureId);
             } else if (type === 'WFS') {
               feature = layer.getSource().getFeatureById(featureId);
+              const newfeatureId = featureId.replace(featureId.substring(featureId.lastIndexOf('__'), featureId.lastIndexOf('.')), '');
+              feature = layer.getSource().getFeatureById(newfeatureId);
             } else if (clusterSource) {
               feature = clusterSource.getFeatureById(id);
             } else {


### PR DESCRIPTION
Fixes #969  (well it's something to talk about and limited in scope, see below)

 It targets wfs layers with the "__" naming scheme as shown in the origo layer documentation.

WFS layers because I have been unable to reproduce the issue with the default geojson layer, as mentioned in the related issue. WMS layers don't get to have selections with info popups in shared maps and other layers would need to be tested, but the suggested changes should only affect WFS layers because it seemed they primarily are treated special and are mentioned in the docs  (("__") I mean. Well, besides WMS layers but as mentioned they don't count)

It seems to work when I define the same wfs layer twice in a group layer, suffixing the names with "__rust" and "__11" 

