### PR TITLE
Copy geometry

### DIFF
--- a/src/controls/editor/copyTool.js
+++ b/src/controls/editor/copyTool.js
@@ -1,12 +1,15 @@
 import Select from 'ol/interaction/Select';
 import Feature from 'ol/Feature';
+import { MultiPolygon, MultiLineString, MultiPoint } from 'ol/geom';
 import dispatcher from './editdispatcher';
 
 // Point of entry. Create on of these each time the tool is selected
 //  viewer: the viewer
+//  editLayer: the destination layer for edits
 //  options: the current drawTools configuration for this layer
-const copyTool = function copyTool(viewer, options) {
+const copyTool = function copyTool(viewer, editLayer, options) {
   const map = viewer.getMap();
+  const destinationLayer = editLayer;
   let selectLayers = [];
   let hasGoups = false;
 
@@ -63,16 +66,30 @@ const copyTool = function copyTool(viewer, options) {
   function onSelect(e) {
     // TODO: when multiple hits show dropdown
     //       Right now interaction is configured for single select, but using multiple could resolve overlapping features
-    // TODO: test / correct geometry type to conform to edit layer
-    //       right now it will fail in edit handler if geometry is incorrect type
-    //       This is probably only a problem when using groups or no layer configuration at all as we then do not know
-    //       the geometry type beforehand. When configuring layers, just avoid configuring incompatible types...
 
     // The event is actually fired on deselect as well
     if (e.selected.length > 0) {
       const accept = window.confirm('Kopiera vald geometri? Avbryt för att välja en annan');
       if (accept) {
         const f = new Feature(e.selected[0].getGeometry().clone());
+        const featureGeometryType = f.getGeometry().getType();
+        const layerGeometryType = destinationLayer.get('geometryType');
+        //  Correct geometry type to conform to edit layer
+        //  it will fail in edit handler if geometry is incorrect type
+        if (featureGeometryType !== layerGeometryType) {
+          if (featureGeometryType === 'Polygon' && layerGeometryType === 'MultiPolygon') {
+            const multiPoly = new MultiPolygon([f.getGeometry()]);
+            f.setGeometry(multiPoly);
+          }
+          if (featureGeometryType === 'LineString' && layerGeometryType === 'MultiLineString') {
+            const multiLine = new MultiLineString([f.getGeometry()]);
+            f.setGeometry(multiLine);
+          }
+          if (featureGeometryType === 'Point' && layerGeometryType === 'MultiPoint') {
+            const multiPoint = new MultiPoint([f.getGeometry()]);
+            f.setGeometry(multiPoint);
+          }
+        }
         cancelTool();
         // Important! Remove handler so it won't linger
         document.removeEventListener('toggleEdit', onToggleEdit, { once: true });

--- a/src/controls/editor/copyTool.js
+++ b/src/controls/editor/copyTool.js
@@ -1,0 +1,90 @@
+import Select from 'ol/interaction/Select';
+import Feature from 'ol/Feature';
+import dispatcher from './editdispatcher';
+
+// Point of entry. Create on of these each time the tool is selected
+//  viewer: the viewer
+//  options: the current drawTools configuration for this layer
+const copyTool = function copyTool(viewer, options) {
+  const map = viewer.getMap();
+  let selectLayers = [];
+  let hasGoups = false;
+
+  // Add configured layers
+  if (options.layers && options.layers.length > 0) {
+    selectLayers = options.layers.map((layerName) => viewer.getLayer(layerName));
+  }
+
+  // Groups are mainly intended for drag-and-drop layers when we don't know the name of the layer at config time
+  // But we can take a legend group and add all layers from the group.
+  // TODO: make group lookup recursive?
+  if (options.groups && options.groups.length > 0) {
+    hasGoups = true;
+    options.groups.forEach((groupName) => {
+      const currLayers = viewer.getLayers().filter((layer) => layer.get('group') === groupName);
+      if (currLayers && currLayers.length) {
+        selectLayers.push(...currLayers);
+      }
+    });
+  }
+
+  // Abort if there are no eligible layers, otherwise user can not do anything anyway
+  if (hasGoups && selectLayers.length === 0) {
+    alert('Det finns inga lager att välja från');
+    dispatcher.emitCustomDrawEnd();
+    return;
+  }
+
+  const selectOptions = {};
+  // Add all configured layers as the only possible to select.
+  // If no layers are configured all layers are eligible
+  if (selectLayers.length > 0) {
+    selectOptions.layers = selectLayers;
+  }
+
+  // Set up the OL interaction that makes it possible to select a feature
+  let select = new Select(selectOptions);
+  map.addInteraction(select);
+
+  // Helper that cleans up after us
+  function cancelTool() {
+    // Remove the interaction (and the handler goes as well)
+    map.removeInteraction(select);
+    select = null;
+  }
+
+  // Called when another menu is selected. Should clean up as we are no longer active
+  function onToggleEdit() {
+    cancelTool();
+  }
+
+  // Eventhandler called when OL has selected something.
+  // To abort, the user has to click the menu as select event won't be fired unless a feature is clicked
+  function onSelect(e) {
+    // TODO: when multiple hits show dropdown
+    //       Right now interaction is configured for single select, but using multiple could resolve overlapping features
+    // TODO: test / correct geometry type to conform to edit layer
+    //       right now it will fail in edit handler if geometry is incorrect type
+    //       This is probably only a problem when using groups or no layer configuration at all as we then do not know
+    //       the geometry type beforehand. When configuring layers, just avoid configuring incompatible types...
+
+    // The event is actually fired on deselect as well
+    if (e.selected.length > 0) {
+      const accept = window.confirm('Kopiera vald geometri? Avbryt för att välja en annan');
+      if (accept) {
+        const f = new Feature(e.selected[0].getGeometry().clone());
+        cancelTool();
+        // Important! Remove handler so it won't linger
+        document.removeEventListener('toggleEdit', onToggleEdit, { once: true });
+        dispatcher.emitCustomDrawEnd(f);
+      }
+    }
+  }
+
+  // Hook up some callbacks and just wait for user to select a feature
+  select.on('select', onSelect);
+  // Makes it possible to abort
+  document.addEventListener('toggleEdit', onToggleEdit, { once: true });
+};
+
+export default copyTool;

--- a/src/controls/editor/drawtools.js
+++ b/src/controls/editor/drawtools.js
@@ -6,6 +6,7 @@ import copyTool from './copyTool';
 const createElement = utils.createElement;
 
 let viewer;
+let layer;
 
 const drawToolsSelector = function drawToolsSelector(tools, defaultLayer, v) {
   const toolNames = {
@@ -72,7 +73,7 @@ const drawToolsSelector = function drawToolsSelector(tools, defaultLayer, v) {
           // Copy tool is handled entirely in copyTool. Only notify edithandler to back off
           // and call copyTool to do its stuff.
           dispatcher.emitChangeEditorShapes('custom');
-          copyTool(viewer, drawTools.find((tool) => tool.toolName === 'Copy'));
+          copyTool(viewer, layer, drawTools.find((tool) => tool.toolName === 'Copy'));
           break;
         default:
           // This is an OL shape tool. Let edithandler handle it
@@ -112,7 +113,7 @@ const drawToolsSelector = function drawToolsSelector(tools, defaultLayer, v) {
   }
 
   function setDrawTools(layerName) {
-    const layer = viewer.getLayer(layerName);
+    layer = viewer.getLayer(layerName);
     let geometryType;
     drawTools = layer.get('drawTools') || [];
     if (layer.get('drawTools')) {

--- a/src/controls/editor/editdispatcher.js
+++ b/src/controls/editor/editdispatcher.js
@@ -68,6 +68,15 @@ function emitChangeOfflineEdits(edits, layerName) {
   document.dispatchEvent(changeOfflineEdits);
 }
 
+function emitCustomDrawEnd(feature) {
+  const changeOfflineEdits = new CustomEvent('customDrawEnd', {
+    detail: {
+      feature
+    }
+  });
+  document.dispatchEvent(changeOfflineEdits);
+}
+
 export default {
   emitChangeEdit,
   emitChangeFeature,
@@ -75,5 +84,6 @@ export default {
   emitEnableInteraction,
   emitEditsChange,
   emitChangeEditorShapes,
-  emitChangeOfflineEdits
+  emitChangeOfflineEdits,
+  emitCustomDrawEnd
 };

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -57,6 +57,11 @@ function setActive(editType) {
       modify.setActive(true);
       select.setActive(false);
       break;
+    case 'custom':
+      draw.setActive(false);
+      modify.setActive(false);
+      select.setActive(false);
+      break;
     default:
       draw.setActive(false);
       hasDraw = false;
@@ -141,8 +146,8 @@ function onModifyEnd(evt) {
   });
 }
 
-function onDrawEnd(evt) {
-  const feature = evt.feature;
+// Helper for adding new features. Typically called from various eventhandlers
+function addFeature(feature) {
   const layer = viewer.getLayer(currentLayer);
   const defaultAttributes = getDefaultValues(layer.get('attributes'));
   feature.setProperties(defaultAttributes);
@@ -160,6 +165,26 @@ function onDrawEnd(evt) {
     // eslint-disable-next-line no-use-before-define
     editAttributes(feature);
   }
+}
+
+// Handler for OL Draw interaction
+function onDrawEnd(evt) {
+  addFeature(evt.feature);
+}
+
+// Handler for external draw. It just adds a new feature to the layer, no questions asked.
+// Intended usage is creating a feature in a drawTool custom tool
+// event contains the new feature to be added.
+// if no feature is provided action is aborted.
+function onCustomDrawEnd(e) {
+  // Check if a feature has been created, or tool canceled
+  if (e.detail.feature) {
+    if (e.detail.feature.getGeometry().getType() !== editLayers[currentLayer].get('geometryType')) {
+      alert('Kan inte lägga till en geometri av den typen i det lagret');
+    }
+    addFeature(e.detail.feature);
+  }
+  setActive();
 }
 
 function addSnapInteraction(sources) {
@@ -309,9 +334,15 @@ function cancelDraw() {
   dispatcher.emitChangeEdit('draw', false);
 }
 
+// Event from drawTools
 function onChangeShape(e) {
-  setInteractions(e.detail.shape);
-  startDraw();
+  // Custom shapes are handled entirely in drawTools, just wait for a feature to land in onCustomDrawEnd
+  if (e.detail.shape === 'custom') {
+    setActive('custom');
+  } else {
+    setInteractions(e.detail.shape);
+    startDraw();
+  }
 }
 
 function cancelAttribute() {
@@ -717,4 +748,5 @@ export default function editHandler(options, v) {
   document.addEventListener('toggleEdit', onToggleEdit);
   document.addEventListener('changeEdit', onChangeEdit);
   document.addEventListener('editorShapes', onChangeShape);
+  document.addEventListener('customDrawEnd', onCustomDrawEnd);
 }

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -178,11 +178,19 @@ function onDrawEnd(evt) {
 // if no feature is provided action is aborted.
 function onCustomDrawEnd(e) {
   // Check if a feature has been created, or tool canceled
-  if (e.detail.feature) {
-    if (e.detail.feature.getGeometry().getType() !== editLayers[currentLayer].get('geometryType')) {
+  const feature = e.detail.feature;
+  if (feature) {
+    if (feature.getGeometry().getType() !== editLayers[currentLayer].get('geometryType')) {
       alert('Kan inte lägga till en geometri av den typen i det lagret');
+    } else {
+      // Must move geometry to correct property. Setting geometryName is not enough.
+      if (editLayers[currentLayer].get('geometryName') !== feature.getGeometryName()) {
+        feature.set(editLayers[currentLayer].get('geometryName'), feature.getGeometry());
+        feature.unset(feature.getGeometryName());
+        e.detail.feature.setGeometryName(editLayers[currentLayer].get('geometryName'));
+      }
+      addFeature(e.detail.feature);
     }
-    addFeature(e.detail.feature);
   }
   setActive();
 }

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1,1 +1,1 @@
-//export { default as Olms } from './extensions/olms';
+// export { default as Olms } from './extensions/olms';


### PR DESCRIPTION
Implementation for #1223. Possibility to copy a geometry from one layer to another.

Instead of polluting edithandler with if:s everywhere, as the copy tool does not work like openlayers draw interaction, I have introduced the concept of _custom draw tools_, external to open layers. What it basically means is that it is possible to send an event containing a new feature to edithandler and it will be added just as if a new feature had been created inside the edithandler. With this framework in place it is possible to add more tools without having to change edithandler.

The actual copying is performed in a new tool: copyTool, that is added to the drawTools menu using configuration. The implementation is rather rudimentary and can only select one feature from one of the configured source layers. It uses openlayers select interaction for selecting in the map and the eventhandler performs the coping and sends a feature as an event that is handled by edithandler.

In order to make _custom draw tools_ work with the drawTools menu, the drawTools has been changed to handle more complex configuration than the previous openlayers shape tools, but for backwards compability reasons, the old shape name still works. It also have to call the actual tool when selected.  


Example configuration of a layer using copyTool:
```
"drawTools": [
        "Polygon",
        {
          "toolName": "Copy",
          "layers": [ "To2018_Swe99TM__Y", "SketchPoly" ],
          "groups": [ "drag-and-drop-layers" ]
        }
      ],
```
Where _toolName_ is required and at least a _layers_ or _groups_ array should to be specified. The _layers_ array specifies which layers are available for copying from. If the _groups_ array is specified all layers within that legend group will be available as source. Groups are not recursive. If neither _layers_ nor _groups_ are specified, all feature layers will be used as source.