### PR TITLE
Added blending modes, CSS filter

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -5,12 +5,8 @@ import type from './layer/layertype';
 function onChangeVisible(e) {
   const layer = e.target;
   setTimeout(() => {
-    if (layer.get('cssFilter')) {
-      document.getElementsByClassName(layer.getClassName())[0].style.filter = layer.get('cssFilter');
-    }
-
-    if (layer.get('blendingMode')) {
-      document.getElementsByClassName(layer.getClassName())[0].style.mixBlendMode = layer.get('blendingMode');
+    if (layer.get('css')) {
+      Object.assign(document.getElementsByClassName(layer.getClassName())[0].style, layer.get('css'));
     }
   });
 }
@@ -58,7 +54,7 @@ const Layer = function Layer(optOptions, viewer) {
 
   layerOptions.name = name.split(':').pop();
 
-  if (layerOptions.cssFilter || layerOptions.blendingMode) {
+  if (layerOptions.css) {
     layerOptions.className = layerOptions.cls || `o-layer-${layerOptions.name}`;
   }
 

--- a/src/layer.js
+++ b/src/layer.js
@@ -2,6 +2,19 @@ import mapUtils from './maputils';
 import group from './layer/group';
 import type from './layer/layertype';
 
+function onChangeVisible(e) {
+  const layer = e.target;
+  setTimeout(() => {
+    if (layer.get('cssFilter')) {
+      document.getElementsByClassName(layer.getClassName())[0].style.filter = layer.get('cssFilter');
+    }
+
+    if (layer.get('blendingMode')) {
+      document.getElementsByClassName(layer.getClassName())[0].style.mixBlendMode = layer.get('blendingMode');
+    }
+  });
+}
+
 const Layer = function Layer(optOptions, viewer) {
   const defaultOptions = {
     name: undefined,
@@ -45,8 +58,14 @@ const Layer = function Layer(optOptions, viewer) {
 
   layerOptions.name = name.split(':').pop();
 
+  if (layerOptions.cssFilter || layerOptions.blendingMode) {
+    layerOptions.className = layerOptions.cls || `o-layer-${layerOptions.name}`;
+  }
+
   if (layerOptions.type) {
-    return type[layerOptions.type](layerOptions, viewer);
+    const layer = type[layerOptions.type](layerOptions, viewer);
+    layer.once('postrender', onChangeVisible);
+    return layer;
   }
 
   throw new Error(`Layer type is missing or layer type is not correct. Check your layer definition: ${layerOptions}`);


### PR DESCRIPTION
Fixes #1212.

Just add `cssFilter` or `blendingMode` properties to any layer in the config. Please use the documentation on [CSS filters](https://developer.mozilla.org/en-US/docs/Web/CSS/filter) and [blending modes](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for guidance.

Examples:

~~`"cssFilter": "brightness(50%) contrast(10%)"`~~

~~or~~

~~`"blendingMode": "difference"`~~

"css": {"filter": "brightness(1.2) contrast(2)", "mix-blend-mode": "multiply"}

EDIT

Oh, and please note that IE is not particularly fond of any of this...