### PR TITLE
Fixes geojson feature ids

### DIFF
--- a/src/layer/geojson.js
+++ b/src/layer/geojson.js
@@ -12,7 +12,13 @@ function createSource(options) {
         const numFeatures = vectorSource.getFeatures().length;
         for (let i = 0; i < numFeatures; i += 1) {
           vectorSource.forEachFeature((feature) => {
-            feature.setId(i);
+            if (!feature.getId()) {
+              if (feature.get(options.idField)) {
+                feature.setId(feature.get(options.idField));
+              } else {
+                feature.setId(1000000 + i);
+              }
+            }
             i += 1;
           });
         }
@@ -34,6 +40,7 @@ const geojson = function geojson(layerOptions, viewer) {
   const sourceOptions = {};
   sourceOptions.attribution = geojsonOptions.attribution;
   sourceOptions.projectionCode = viewer.getProjectionCode();
+  sourceOptions.idField = layerOptions.idField || 'id';
   if (geojsonOptions.projection) {
     sourceOptions.dataProjection = geojsonOptions.projection;
   } else if (sourceOptions.projection) {


### PR DESCRIPTION
Fixes #1232
Geojson features gets ID in this order:
1. The id property of the feature object (this is the correct geojson way of doing it)
2. The id property of the properties object (can be set to a different property on layer level, defaults to "idField": "id")
3. Incremented value starting at 1000000

This feature will get id 1:
{ "type": "Feature", "id": 1, "properties": { "id": 12, "name": "Karlstad" }, "geometry": { "type": "Point", "coordinates": [ 1503136, 8262205 ] } }
