### PR TITLE
Expose the embedded status of the viewer

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -254,6 +254,10 @@ const Viewer = function Viewer(targetOption, options = {}) {
 
   const getMain = () => main;
 
+  const isNotEmbedded = function isNotEmbedded() {
+    return !isEmbedded(this.getTarget());
+  };
+
   const mergeSavedLayerProps = (initialLayerProps, savedLayerProps) => {
     if (savedLayerProps) {
       const mergedLayerProps = initialLayerProps.reduce((acc, initialProps) => {
@@ -535,7 +539,8 @@ const Viewer = function Viewer(targetOption, options = {}) {
     removeGroup,
     removeOverlays,
     zoomToExtent,
-    getSelectionManager
+    getSelectionManager,
+    isNotEmbedded
   });
 };
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -254,8 +254,8 @@ const Viewer = function Viewer(targetOption, options = {}) {
 
   const getMain = () => main;
 
-  const isNotEmbedded = function isNotEmbedded() {
-    return !isEmbedded(this.getTarget());
+  const getEmbedded = function getEmbedded() {
+    return isEmbedded(this.getTarget());
   };
 
   const mergeSavedLayerProps = (initialLayerProps, savedLayerProps) => {
@@ -540,7 +540,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
     removeOverlays,
     zoomToExtent,
     getSelectionManager,
-    isNotEmbedded
+    getEmbedded
   });
 };
 


### PR DESCRIPTION
Fixes #1239 . (Negation is because of eslint(no-shadow))

Plugins can be added if isNotEmbedded is true or not depending on whether if one wishes them when the map is embedded or not
`
      origo.on('load', function (viewer) {
	  if (viewer.isNotEmbedded()) {
        var draw = Draw({..`