### PR TITLE
Possibility to shut of special mapinteractions for embedded maps

### DIFF
--- a/src/controls/print/print-interaction-toggle.js
+++ b/src/controls/print/print-interaction-toggle.js
@@ -11,7 +11,7 @@ export default function PrintInteractionToggle(options = {}) {
     mapInteractionsActive
   } = options;
 
-  const interactions = mapInteractions({ target });
+  const interactions = mapInteractions({ target, mapInteractions: {} });
   let mapInteractionToggleButton;
 
   const toggleState = function toggleState() {

--- a/src/map.js
+++ b/src/map.js
@@ -3,7 +3,7 @@ import OlView from 'ol/View';
 import mapInteractions from './mapinteractions';
 
 const Map = (options = {}) => {
-  const interactions = mapInteractions({ target: options.target });
+  const interactions = mapInteractions({ target: options.target, mapInteractions: options.pageSettings.mapInteractions });
   const mapOptions = Object.assign(options, { interactions });
   delete mapOptions.layers;
   mapOptions.controls = [];

--- a/src/mapinteractions.js
+++ b/src/mapinteractions.js
@@ -3,7 +3,8 @@ import { noModifierKeys, platformModifierKeyOnly, touchOnly } from 'ol/events/co
 import isEmbedded from './utils/isembedded';
 
 const MapInteractions = function MapInteractions(options = {}) {
-  if (isEmbedded(`#${options.target}`)) {
+  const mapInteractions = options.mapInteractions ? options.mapInteractions : { embedded: true };
+  if (isEmbedded(`#${options.target}`) && mapInteractions.embedded) {
     let timeout;
     const mapEl = document.getElementById(options.target);
     const divID = `${options.target}-embedded-overlay`;


### PR DESCRIPTION
Closes #1244

Usage for turning of embedded mapinteractions from config:
```
"pageSettings": {
    "mapInteractions": {
      "embedded": false
    }
},
```