### PR TITLE
Slugify on constraint, so don't fail on spaces in class name

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -15,6 +15,7 @@ import getImageOrientation from '../../utils/getimageorientation';
 import shapes from './shapes';
 import searchList from './addons/searchList/searchList';
 import validate from '../../utils/validate';
+import slugify from '../../utils/slugify';
 
 const editsStore = store();
 let editLayers = {};
@@ -660,7 +661,7 @@ function editAttributes(feat) {
             obj.requiredVal = constraintProps[2];
             obj.isVisible = obj.dependencyVal === obj.requiredVal;
             obj.addListener = addListener();
-            obj.elId = `input-${obj.name}-${obj.requiredVal}`;
+            obj.elId = `input-${obj.name}-${slugify(obj.requiredVal)}`;
             obj.elDependencyId = `input-${constraintProps[1]}`;
           } else {
             alert('Villkor verkar inte vara rätt formulerat. Villkor formuleras enligt principen change:attribute:value');

--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -1,0 +1,14 @@
+export default function slugify(text) {
+  const a = 'àáäâèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧ·/_,:;';
+  const b = 'aaaaeeeeiiiioooouuuuncsyoarsnpwgnmuxzh------';
+  const p = new RegExp(a.split('').join('|'), 'g');
+
+  return text.toString().toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special chars
+    .replace(/&/g, '-and-') // Replace & with 'and'
+    .replace(/[^\w-]+/g, '') // Remove all non-word chars
+    .replace(/--+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
+}


### PR DESCRIPTION
Fixes #627 

Example configuration:
```
{
  "name": "topptavla",
  "title": "Stolpe, topptavla: ",
  "type": "dropdown",
  "maxLength": 30,
  "options": [
    "På stolpe",
    "På väderskydd",
    "Annan plats",
    "Finns ej"
  ]
},
{
  "name": "topptavla_skick",
  "title": "Topptavla skick: ",
  "type": "dropdown",
      "maxLength": 30,
  "constraint": "change:topptavla:På stolpe",
  "options": [
    "Bra",
    "Dålig "
  ]
},
```