### PR TITLE
Multiple alternative will show a field

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -595,7 +595,14 @@ function addListener() {
   const fn = (obj) => {
     document.getElementById(obj.elDependencyId).addEventListener(obj.eventType, () => {
       const containerClass = `.${obj.elId}`;
-      if (document.getElementById(obj.elDependencyId).value === obj.requiredVal) {
+      if (obj.requiredVal.startsWith('[')) {
+        const tmpArray = obj.requiredVal.replace('[', '').replace(']', '').split(',');
+        if (tmpArray.includes(document.getElementById(obj.elDependencyId).value)) {
+          document.querySelector(containerClass).classList.remove('o-hidden');
+        } else {
+          document.querySelector(containerClass).classList.add('o-hidden');
+        }
+      } else if (document.getElementById(obj.elDependencyId).value === obj.requiredVal) {
         document.querySelector(containerClass).classList.remove('o-hidden');
       } else {
         document.querySelector(containerClass).classList.add('o-hidden');
@@ -659,7 +666,14 @@ function editAttributes(feat) {
             obj.eventType = constraintProps[0];
             obj.dependencyVal = feature.get(constraintProps[1]);
             obj.requiredVal = constraintProps[2];
-            obj.isVisible = obj.dependencyVal === obj.requiredVal;
+            if (constraintProps[2].startsWith('[')) {
+              const tmpArray = constraintProps[2].replace('[', '').replace(']', '').split(',');
+              if (tmpArray.includes(obj.dependencyVal)) {
+                obj.isVisible = true;
+              }
+            } else {
+              obj.isVisible = obj.dependencyVal === obj.requiredVal;
+            }
             obj.addListener = addListener();
             obj.elId = `input-${obj.name}-${slugify(obj.requiredVal)}`;
             obj.elDependencyId = `input-${constraintProps[1]}`;


### PR DESCRIPTION
Closes #878 

Makes it possible to specify multiple alternative that will show a field in editor popup
Example config:
```
{
  "name": "topptavla",
  "title": "Stolpe, topptavla: ",
  "type": "dropdown",
  "maxLength": 30,
  "options": [
    "På stolpe",
    "På väderskydd",
    "Annan plats",
    "Finns ej"
  ]
},
{
  "name": "topptavla_skick",
  "title": "Topptavla skick: ",
  "type": "dropdown",
      "maxLength": 30,
  "constraint": "change:topptavla:[På stolpe,På väderskydd,Annan plats]",
  "options": [
    "Bra",
    "Dålig "
  ]
},
```