### PR TITLE
Get selection from api

### DIFF
--- a/src/selectionmanager.js
+++ b/src/selectionmanager.js
@@ -130,6 +130,13 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     return Style.createStyleRule(multiselectStyleOptions.selected);
   }
 
+  function createSelectionGroup(selectionGroup, selectionGroupTitle) {
+      const urvalLayer = featurelayer(null, map);
+      urvalLayer.setStyle(featureStyler);
+      urval.set(selectionGroup, urvalLayer);
+      infowindow.createUrvalElement(selectionGroup, selectionGroupTitle);
+  }
+
   function onItemAdded(event) {
     const item = event.element;
 
@@ -137,10 +144,7 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     const selectionGroupTitle = event.element.getSelectionGroupTitle();
 
     if (!urval.has(selectionGroup)) {
-      const urvalLayer = featurelayer(null, map);
-      urvalLayer.setStyle(featureStyler);
-      urval.set(selectionGroup, urvalLayer);
-      infowindow.createUrvalElement(selectionGroup, selectionGroupTitle);
+      createSelectionGroup(selectionGroup, selectionGroupTitle)
     }
 
     urval.get(selectionGroup).addFeature(item.getFeature());
@@ -186,6 +190,10 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     return selectedItems.getLength();
   }
 
+  function getUrval() {
+    return urval;
+  }
+
   return Component({
     name: 'selectionmanager',
     addItems,
@@ -194,10 +202,12 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     addOrHighlightItem,
     removeItemById,
     clearSelection,
+	createSelectionGroup,
     highlightFeature,
     highlightFeatureById,
     getNumberOfSelectedItems,
     getSelectedItemsForASelectionGroup,
+	getUrval,
     onInit() {
       selectedItems = new Collection([], { unique: true });
       urval = new Map();

--- a/src/selectionmanager.js
+++ b/src/selectionmanager.js
@@ -131,10 +131,10 @@ const Selectionmanager = function Selectionmanager(options = {}) {
   }
 
   function createSelectionGroup(selectionGroup, selectionGroupTitle) {
-      const urvalLayer = featurelayer(null, map);
-      urvalLayer.setStyle(featureStyler);
-      urval.set(selectionGroup, urvalLayer);
-      infowindow.createUrvalElement(selectionGroup, selectionGroupTitle);
+    const urvalLayer = featurelayer(null, map);
+    urvalLayer.setStyle(featureStyler);
+    urval.set(selectionGroup, urvalLayer);
+    infowindow.createUrvalElement(selectionGroup, selectionGroupTitle);
   }
 
   function onItemAdded(event) {
@@ -144,7 +144,7 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     const selectionGroupTitle = event.element.getSelectionGroupTitle();
 
     if (!urval.has(selectionGroup)) {
-      createSelectionGroup(selectionGroup, selectionGroupTitle)
+      createSelectionGroup(selectionGroup, selectionGroupTitle);
     }
 
     urval.get(selectionGroup).addFeature(item.getFeature());
@@ -202,12 +202,12 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     addOrHighlightItem,
     removeItemById,
     clearSelection,
-	createSelectionGroup,
+    createSelectionGroup,
     highlightFeature,
     highlightFeatureById,
     getNumberOfSelectedItems,
     getSelectedItemsForASelectionGroup,
-	getUrval,
+    getUrval,
     onInit() {
       selectedItems = new Collection([], { unique: true });
       urval = new Map();


### PR DESCRIPTION
Fixes #1275 and partially #1256.
Can be used like this to listen to changes in selection for a certain layer and deal with that, eg update an external table:

```
viewer.getSelectionManager().createSelectionGroup('layername', 'layertitle');
viewer.getSelectionManager().getUrval().get('layername').getSourceLayer().on('change', function(){runSomeFunction(this)});
```