### PR TITLE
Exclude print footer from filter (so it prints)

### DIFF
--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -136,6 +136,8 @@ export const printToScalePDF = async function printToScalePDF({
         || className.indexOf('padding-right-small') > -1
         || className.indexOf('padding-bottom-small') > -1
         || className.indexOf('o-print-description') > -1
+        || className.indexOf('o-print-footer') > -1
+        || className.indexOf('o-print-footer-left') > -1
         || className.indexOf('o-print-created') > -1
         || (className.indexOf('print-attribution') > -1
           && className.indexOf('ol-uncollapsible'))


### PR DESCRIPTION
Fixes #1282.

The print control uses the [printToScalePDF()](https://github.com/origo-map/origo/blob/d279d9c1f3d230c97a7af77e08b2bd7a2cb4c744/src/utils/download.js#L116) function in [utils/download.js](https://github.com/origo-map/origo/blob/master/src/utils/download.js) to generate downloadable PDFs.

This adds the elements `o-print-footer` and `o-print-footer-left` to the list of `o-print`-related elements that _should_ be included in the print (i e not excluded by the filter).