### PR TITLE
Fix for SVG errors when printing to PDF with featureinfo overlay

### DIFF
--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -128,7 +128,10 @@ export const printToScalePDF = async function printToScalePDF({
   // See: https://github.com/bubkoo/html-to-image#options
   const exportOptions = {
     filter(element) {
-      const className = element.className || '';
+      let className = element.className || '';
+      if (typeof className === 'object' && element.classList) {
+        className = `${element.classList}`;
+      }
       return (
         className.indexOf('o-print') === -1
         || className.indexOf('o-print-header') > -1


### PR DESCRIPTION
Fixes #1285.

The print filter checks the `className` property of each DOM element supplied using `indexOf()` which assumes that `className` is always a string. In the case of the close button of the featureinfo overlay, its `<svg>` and `<use>` elements have objects as their `className` property.

In these cases, classes set on those elements can instead be accessed through their `classList` property.