### PR TITLE
fix: correct the two instances of ~getCenter() to handle multiPoint g…

### DIFF
--- a/src/geometry/getcenter.js
+++ b/src/geometry/getcenter.js
@@ -18,7 +18,7 @@ export default function getCenter(geometryIn, destination, axisOrientation, map)
       center = geometry.getCoordinates();
       break;
     case 'MultiPoint':
-      center = geometry[0].getCoordinates();
+      center = geometry.getPoint(0).getCoordinates();
       break;
     case 'LineString':
       center = geometry.getCoordinateAt(0.5);

--- a/src/maputils.js
+++ b/src/maputils.js
@@ -90,7 +90,7 @@ const maputils = {
         center = geometry.getCoordinates();
         break;
       case 'MultiPoint':
-        center = geometry[0].getCoordinates();
+        center = geometry.getPoint(0).getCoordinates();
         break;
       case 'LineString':
         center = geometry.getCoordinateAt(0.5);


### PR DESCRIPTION
…eometry presumably anew

Fixes #1288 , Well, only getcenter.js is used in the search-multipoint-geom-and-click-search-hit scenario described in the issue, maputils.js has the same function though more or less and seems to make the same assumption about the incoming geom so my suggestion is to update that too, if somewhat blindly.