### PR TITLE
Use text for legend layer header as last resort

### DIFF
--- a/src/utils/legendmaker.js
+++ b/src/utils/legendmaker.js
@@ -36,12 +36,12 @@ export const findStyleType = function findStyleType(styles) {
     return 'Line';
   } else if (styleTypes.circle) {
     return 'Circle';
-  } else if (styleTypes.text) {
-    return 'Text';
   } else if (styleTypes.icon) {
     return 'Icon';
   } else if (styleTypes.image) {
     return 'Image';
+  } else if (styleTypes.text) {
+    return 'Text';
   }
   return null;
 };


### PR DESCRIPTION
Fixes #1290.

Pretty self-explanatory. If a style object has multiple style types combined, the text style should have the lowest priority when it comes to selecting icons for the legend.