### PR TITLE
Link pointer when hovering over clickable feature in map.

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -423,6 +423,26 @@ const Featureinfo = function Featureinfo(options = {}) {
           setActive(false);
         }
       });
+
+      // Change mouse pointer when hovering over a clickable feature
+      if (viewer.getViewerOptions().featureinfoOptions.linkPointer) {
+        let pointerActive = true;
+        document.addEventListener('enableInteraction', evt => {
+          pointerActive = evt.detail.interaction !== 'editor';
+          // Avoid getting stuck in pointer mode if user manages to enable editing while having pointer over a clickable feature.
+          // If the user manages to disable editing while standing on a clickable feature, it will remain arrow until moved. (Sorry)
+          map.getViewport().style.cursor = '';
+        });
+
+        // Check if there is a clickable feature when mouse is moved.
+        map.on('pointermove', evt => {
+          if (!pointerActive || evt.dragging) return;
+          // Just check if there is a pixel here. Pretty annoying on hatched symbols or hollow areas.
+          // Note that forEachLayerAtPixel requires that layers have unique class names to work correct.
+          // Hit tolerence seems to be ignored. It would probably look funny anyway.
+          map.getViewport().style.cursor = map.forEachLayerAtPixel(evt.pixel, () => true, { layerFilter: (l) => l.get('queryable') }) ? 'pointer' : '';
+        });
+      }
     },
     render
   });

--- a/src/layer.js
+++ b/src/layer.js
@@ -54,7 +54,8 @@ const Layer = function Layer(optOptions, viewer) {
 
   layerOptions.name = name.split(':').pop();
 
-  if (layerOptions.css) {
+  // Some features require that each layer has a unique class name. Set one if not provided.
+  if (layerOptions.css || (viewer.getViewerOptions().featureinfoOptions.linkPointer && layerOptions.queryable)) {
     layerOptions.className = layerOptions.cls || `o-layer-${layerOptions.name}`;
   }
 


### PR DESCRIPTION
Implementation for #1259

Changes the mouse pointer to link pointer when hovering over a feature that can be queried for feature info.

Feature is opt in to be backwards compatible and is activated by adding `"linkPointer": true` to _featureInfoOptions_.

Make sure to turn off _queryable_ on background maps, as _queryable_ is default _true_ and would quite spoil the usefulness of this feature.

The solution is based on [forEachLayerAtPixel](https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html#forEachLayerAtPixel) to detect features from WMS as well. As _forEachLayerAtPixel_ requries that each layer has a unique css class, a class is added to each queryable layer if the layer does not have one and the feature is activated.


