### PR TITLE
New config option to close the bookmarks popup when clicking on a link on small screens

### DIFF
--- a/src/controls/bookmarks.js
+++ b/src/controls/bookmarks.js
@@ -8,7 +8,8 @@ const Bookmarks = function Bookmarks(options = {}) {
     duration = 300,
     closeIcon = '#ic_close_24px',
     bookmarksIcon = '#ic_bookmark_24px',
-    title = 'Bokmärken'
+    title = 'Bokmärken',
+    autoClose = false
   } = options;
   let {
     isActive = false
@@ -129,6 +130,12 @@ const Bookmarks = function Bookmarks(options = {}) {
           bookmarkTitle: item.name,
           click() {
             goToBookmark(item);
+            if (autoClose) {
+              const size = viewer.getSize();
+              if (size === 'm' || size === 's' || size === 'xs') {
+                toggle();
+              }
+            }
           }
         });
         items.push(bm);


### PR DESCRIPTION
Fixes #1300.

Adds a new config option to the bookmarks control: `autoClose`. When set to `true` and using screen size `m`, `s` or `xs`, the popup will close after clicking on a bookmarks link. Default is `false`.

Example config:

```
{
  "name": "bookmarks",
  "options": {
    "title": "Bookmarks",
    "isActive": true,
    "duration": 1000,
    "autoClose": true,
    "items": [
      {
        "name": "Hudiksvall",
        "coordinates": [1904063, 8794995]
      },
      {
        "name": "Karlstad",
        "coordinates": [1503136, 8262205]
      },
      {
        "name": "Sigtuna",
        "coordinates": [1986473, 8315061],
        "zoomLevel": 10
      }
    ]
  }
}
```