### PR TITLE
Added option to disable the subgroup toggle-all function

### DIFF
--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -19,7 +19,8 @@ const Group = function Group(options = {}, viewer) {
     position = 'top',
     type = 'group',
     autoExpand = true,
-    exclusive = false
+    exclusive = false,
+    toggleAll = true
   } = options;
 
   const stateCls = {
@@ -47,7 +48,7 @@ const Group = function Group(options = {}, viewer) {
 
   const getVisible = () => visibleState;
 
-  const tickButton = !exclusive ? Button({
+  const tickButton = !exclusive && toggleAll ? Button({
     cls: 'icon-smaller round small',
     click() {
       const eventType = visibleState === 'all' ? 'untick:all' : 'tick:all';


### PR DESCRIPTION
Fixes #502.

Adds the option `toggleAll` to (sub)groups. Default is `true`.

Setting `toggleAll` to false on a subgroup will remove the group toggle ability. Unlike the `exclusive` option, this will not restrict the ability to toggle individual layers on/off at will.

![toggle_all_false](https://user-images.githubusercontent.com/15725608/126121911-9ceab74e-8ad6-48c4-be92-cb8c8273f2ad.gif)
