### PR TITLE
fix: incorrect triggering toggleFeatureinfo event

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -102,6 +102,16 @@ const Featureinfo = function Featureinfo(options = {}) {
     return title;
   };
 
+  const dispatchToggleFeatureEvent = function dispatchToggleFeatureEvent(currentItem) {
+    const toggleFeatureinfo = new CustomEvent('toggleFeatureinfo', {
+      detail: {
+        type: 'toggleFeatureinfo',
+        currentItem
+      }
+    });
+    document.dispatchEvent(toggleFeatureinfo);
+  };
+
   // TODO: direct access to feature and layer should be converted to getFeature and getLayer methods on currentItem
   const callback = function callback(evt) {
     const currentItemIndex = evt.item.index;
@@ -122,13 +132,7 @@ const Featureinfo = function Featureinfo(options = {}) {
         sidebar.setTitle(title);
       }
 
-      const toggleFeatureinfo = new CustomEvent('toggleFeatureinfo', {
-        detail: {
-          type: 'toggleFeatureinfo',
-          currentItem
-        }
-      });
-      document.dispatchEvent(toggleFeatureinfo);
+      dispatchToggleFeatureEvent(currentItem);
     }
   };
 
@@ -344,6 +348,7 @@ const Featureinfo = function Featureinfo(options = {}) {
     for (let i = 0; i < modalLinks.length; i += 1) {
       addLinkListener(modalLinks[i]);
     }
+    dispatchToggleFeatureEvent(items[0]);
   };
 
   const onClick = function onClick(evt) {

--- a/src/oglide.js
+++ b/src/oglide.js
@@ -111,7 +111,7 @@ function OGlide(options) {
 
   if (oiContent.length > 0) {
     el.mount();
-    el.on('move', () => {
+    el.on('run.after', () => {
       callback({ item: { index: el.index, count: oiContent.length } });
     });
   }


### PR DESCRIPTION
[Fix for issue 1310](https://github.com/origo-map/origo/issues/1310)

Two problems:
1) The toggle feature event was not triggered when the first feature is loaded
2) It was triggered too early and excessively. For example on carousell click irrespective of whether the click triggers the next feature in the carrousell or not.

This is most noteable when using the voting section of the dialogue-plugin.

These problems are solved by 
1) Always triggering the toggleFeatureinfo event when the first or a single feature is loaded.
2) Changing the glidejs event from 'move' to 'run.after', which is triggered only after a new feature is loaded in the carousell.
[glidejs events](https://glidejs.com/docs/events/)