### PR TITLE
Segment labels don't show on single segment

### DIFF
--- a/src/controls/measure.js
+++ b/src/controls/measure.js
@@ -229,6 +229,26 @@ const Measure = function Measure({
     labelOverlay.setPosition(oo);
     measureElement.innerHTML = formatLength(/** @type {LineString} */(segment));
     map.addOverlay(labelOverlay);
+    if (coords.length < 6 && showSegmentLengths) {
+      switch (type) {
+        case 'LineString':
+          if (coords.length === 3) {
+            document.getElementById('measure_3').style.display = 'none';
+          } else {
+            document.getElementById('measure_3').style.display = 'block';
+          }
+          break;
+        case 'Polygon':
+          if (coords.length === 4) {
+            document.getElementById('measure_4').style.display = 'none';
+          } else {
+            document.getElementById('measure_4').style.display = 'block';
+          }
+          break;
+        default:
+          break;
+      }
+    }
   }
 
   function centerSketch() {


### PR DESCRIPTION
Demo of label not added until more than one segment is added:
![SegmentLabelSingle](https://user-images.githubusercontent.com/48793206/130245191-ede035d7-f59d-4ce9-a6fe-5f308109a16a.gif)
