### PR TITLE
Batch edit attributes

### DIFF
--- a/src/controls/editor/editform.js
+++ b/src/controls/editor/editform.js
@@ -32,7 +32,7 @@ const createForm = function createForm(obj) {
       break;
     case 'checkbox':
       checked = val ? ' checked' : '';
-      el = `<div class="o-form-checkbox ${cls}"><label>${label}</label><input type="checkbox" id="${id}" value="${val}"${checked}${disabled}></div>`;
+      el = `<div class="o-form-checkbox ${cls}"><label for="${id}">${label}</label><input type="checkbox" id="${id}" value="${val}"${checked}${disabled}></div>`;
       break;
     case 'dropdown':
       if (val) {

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -144,9 +144,14 @@ function saveFeatures() {
   });
 }
 
-function saveFeature(change) {
+/**
+ * Adds changed feature to the editstore and if config parameter autoSave is set, also triggers a transaction.
+ * @param {any} change The feature and change type
+ * @param {any} ignoreAutoSave Optional argument that overrides autoSave configuration parameter. Used to prevent numerous transactions in batch mode.
+ */
+function saveFeature(change, ignoreAutoSave) {
   dispatcher.emitChangeFeature(change);
-  if (autoSave) {
+  if (autoSave && !ignoreAutoSave) {
     saveFeatures(change);
   }
 }
@@ -550,27 +555,41 @@ function cancelAttribute() {
   dispatcher.emitChangeEdit('attribute', false);
 }
 
-function attributesSaveHandler(feature, formEl) {
-  // get DOM values and set attribute values to feature
-  attributes.forEach((attribute) => {
-    if (Object.prototype.hasOwnProperty.call(formEl, attribute.name)) {
-      feature.set(attribute.name, formEl[attribute.name]);
-    }
+/**
+ * Reads the new attribute values from from DOM and saves to feature
+ * @param {any} features The features to save
+ * @param {any} formEl The attributes to set on features
+ */
+function attributesSaveHandler(features, formEl) {
+  features.forEach(feature => {
+    // get DOM values and set attribute values to feature
+    attributes.forEach((attribute) => {
+      if (Object.prototype.hasOwnProperty.call(formEl, attribute.name)) {
+        feature.set(attribute.name, formEl[attribute.name]);
+      }
+    });
+    saveFeature({
+      feature,
+      layerName: currentLayer,
+      action: 'update'
+    }, true);
   });
-  saveFeature({
-    feature,
-    layerName: currentLayer,
-    action: 'update'
-  });
+  //Take control of auto save here to avoid one transaction per feature when batch editing
+  if (autoSave) {
+    saveFeatures();
+  }
 }
 
-function onAttributesSave(feature, attrs) {
+/**
+ * Sets up an eventlistener on the attribute editor form save button.
+ * @param {Collection} features The features that should be updated 
+ * @param {any} attrs Array of attributes whih values to set
+ */
+function onAttributesSave(features, attrs) {
   document.getElementById('o-save-button').addEventListener('click', (e) => {
     const editEl = {};
     const valid = {};
     const fileReaders = [];
-
-    // Read values from form
     attrs.forEach((attribute) => {
       // Get the input container class
       const containerClass = `.${attribute.elId}`;
@@ -582,6 +601,8 @@ function onAttributesSave(feature, attrs) {
       const inputRequired = document.getElementById(attribute.elId).getAttribute('required');
 
       // If hidden element it should be excluded
+      // By sheer luck, this prevents attributes to be changed in batch edit mode when checkbox is not checked.
+      // If this code is changed, it may be necessary to excplict check if the batch edit checkbox is checked for this attribute.
       if (!document.querySelector(containerClass) || document.querySelector(containerClass).classList.contains('o-hidden') === false) {
         // Check if checkbox. If checkbox read state.
         if (inputType === 'checkbox') {
@@ -769,10 +790,10 @@ function onAttributesSave(feature, attrs) {
     if (valid.validates) {
       if (fileReaders.length > 0 && fileReaders.every(reader => reader.readyState === 1)) {
         document.addEventListener('imageresized', () => {
-          attributesSaveHandler(feature, editEl);
+          attributesSaveHandler(features, editEl);
         });
       } else {
-        attributesSaveHandler(feature, editEl);
+        attributesSaveHandler(features, editEl);
       }
 
       document.getElementById('o-save-button').blur();
@@ -830,24 +851,57 @@ function addImageListener() {
   return fn;
 }
 
+/**
+ * Returns a click handler that should be attached to batch edit checkboxes to show or hide the input field
+ * */
+function addBatchEditListener() {
+  const fn = (obj) => {
+    document.getElementById(obj.elId).addEventListener('click', (ev) => {
+      let classList = document.querySelector(`.${obj.relatedAttrId}`).classList;
+      if (ev.target.checked) {
+        classList.remove('o-hidden');
+      } else {
+        classList.add('o-hidden');
+      }
+    });
+  }
+  return fn;
+}
+
+/**
+ * Edits the attributes for given feature or selection from interaction
+ * @param {any} feat Feature to edit attributes for. If omitted selection will be used instead
+ */
 function editAttributes(feat) {
-  let feature = feat;
+  let feature;
   let attributeObjects;
+  /** Array of batch edit checkbox models */
+  let batchEditBoxes = [];
+  /** OL Collection */
   let features;
+  let dlgTitle;
 
   // Get attributes from the created, or the selected, feature and fill DOM elements with the values
-  if (feature) {
+  if (feat) {
     features = new Collection();
-    features.push(feature);
+    features.push(feat);
   } else {
+    //Interaction is set up to only select for edited layer, so no need to check layer.
     features = select.getFeatures();
   }
-  if (features.getLength() === 1) {
+  const isBatchEdit = features.getLength() > 1;
+  dlgTitle = isBatchEdit ? `Batch edit ${title}.<br>(${features.getLength()} objekt)` : title;
+
+  /**Filtered list of attributes containing only those that should be displayed */
+  const editableAttributes = attributes.filter(attr => !isBatchEdit || isBatchEdit && attr.allowBatchEdit);
+
+  if (features.getLength() > 0) {
     dispatcher.emitChangeEdit('attribute', true);
+    //Pick first feature to extract some properties from.
     feature = features.item(0);
-    if (attributes.length > 0) {
+    if (editableAttributes.length > 0) {
       // Create an array of defined attributes and corresponding values from selected feature
-      attributeObjects = attributes.map((attributeObject) => {
+      attributeObjects = editableAttributes.map((attributeObject) => {
         const obj = {};
         Object.assign(obj, attributeObject);
         obj.val = feature.get(obj.name) !== undefined ? feature.get(obj.name) : '';
@@ -879,8 +933,27 @@ function editAttributes(feat) {
           obj.isVisible = true;
           obj.elId = `input-${obj.name}`;
         }
+        if (isBatchEdit) {
+          //Create an additional ckeckbox, that controls if this attribute should be changed
+          const batchObj = {};
+          batchObj.isVisible = true;
+          batchObj.title = `Ändra ${obj.title}`;
+          batchObj.elId = `${obj.elId}-batch`;
+          batchObj.type = 'checkbox';
+          batchObj.relatedAttrId = obj.elId;
+          //Hide the attribute that this checkbox is connected to so it won't be changed unless user checks the box first.
+          obj.isVisible = false;
+          //Inject the checkbox next to the attribute
+          obj.formElement = editForm(batchObj) + editForm(obj);
 
-        obj.formElement = editForm(obj);
+          //Defer adding click handler until element exists in DOM
+          batchObj.addListener = addBatchEditListener();
+
+          batchEditBoxes.push(batchObj);
+        }
+        else {
+          obj.formElement = editForm(obj);
+        }
         return obj;
       });
     }
@@ -889,7 +962,7 @@ function editAttributes(feat) {
     const form = `<div id="o-form">${formElement}<br><div class="o-form-save"><input id="o-save-button" type="button" value="Ok"></input></div></div>`;
 
     modal = Modal({
-      title,
+      title: dlgTitle,
       content: form,
       static: true,
       target: viewer.getId()
@@ -901,7 +974,14 @@ function editAttributes(feat) {
       }
     });
 
-    onAttributesSave(feature, attributeObjects);
+    //Add the deferred click handlers
+    batchEditBoxes.forEach((obj) => {
+      if ('addListener' in obj) {
+        obj.addListener(obj);
+      }
+    });
+
+    onAttributesSave(features, attributeObjects);
   }
 }
 


### PR DESCRIPTION
Solves #1316. Makes it possible to batch edit attributes using the normal attribute editor form.

To batch edit attributes, the attribute must be configured with `"allowBatchEdit": true` in the _attributes_ section of the layer configuration.

If more than one feature is selected when the attribute edit form is opened, there will be a checkbox for each attribute that can be changed. Upon completion, all selected features will receive the new value for the attributes that have been checked.

To select multiple features use shift-click in the map.