### PR TITLE
Recalculate resolutions when entering print view

### DIFF
--- a/src/controls/print/index.js
+++ b/src/controls/print/index.js
@@ -47,7 +47,7 @@ const Print = function Print(options = {}) {
     leftFooterText = '',
     filename,
     mapInteractionsActive = false,
-    recalculateResolutions = false
+    supressResolutionsRecalculation = false
   } = options;
   let {
     showNorthArrow = true
@@ -105,7 +105,7 @@ const Print = function Print(options = {}) {
         rotationStep,
         leftFooterText,
         mapInteractionsActive,
-        recalculateResolutions
+        supressResolutionsRecalculation
       });
       mapMenu = viewer.getControlByName('mapmenu');
       menuItem = mapMenu.MenuItem({

--- a/src/controls/print/index.js
+++ b/src/controls/print/index.js
@@ -47,7 +47,7 @@ const Print = function Print(options = {}) {
     leftFooterText = '',
     filename,
     mapInteractionsActive = false,
-    supressResultionsRecalculation = false
+    supressResolutionsRecalculation = false
   } = options;
   let {
     showNorthArrow = true
@@ -105,7 +105,7 @@ const Print = function Print(options = {}) {
         rotationStep,
         leftFooterText,
         mapInteractionsActive,
-        supressResultionsRecalculation
+        supressResolutionsRecalculation
       });
       mapMenu = viewer.getControlByName('mapmenu');
       menuItem = mapMenu.MenuItem({

--- a/src/controls/print/index.js
+++ b/src/controls/print/index.js
@@ -46,7 +46,8 @@ const Print = function Print(options = {}) {
     rotationStep = 1,
     leftFooterText = '',
     filename,
-    mapInteractionsActive = false
+    mapInteractionsActive = false,
+    supressResultionsRecalculation = false
   } = options;
   let {
     showNorthArrow = true
@@ -103,7 +104,8 @@ const Print = function Print(options = {}) {
         rotation,
         rotationStep,
         leftFooterText,
-        mapInteractionsActive
+        mapInteractionsActive,
+        supressResultionsRecalculation
       });
       mapMenu = viewer.getControlByName('mapmenu');
       menuItem = mapMenu.MenuItem({

--- a/src/controls/print/index.js
+++ b/src/controls/print/index.js
@@ -47,7 +47,7 @@ const Print = function Print(options = {}) {
     leftFooterText = '',
     filename,
     mapInteractionsActive = false,
-    supressResolutionsRecalculation = false
+    recalculateResolutions = false
   } = options;
   let {
     showNorthArrow = true
@@ -105,7 +105,7 @@ const Print = function Print(options = {}) {
         rotationStep,
         leftFooterText,
         mapInteractionsActive,
-        supressResolutionsRecalculation
+        recalculateResolutions
       });
       mapMenu = viewer.getControlByName('mapmenu');
       menuItem = mapMenu.MenuItem({

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -4,6 +4,7 @@ import { getPointResolution } from 'ol/proj';
 import TileImage from 'ol/source/TileImage';
 import TileWMSSource from 'ol/source/TileWMS';
 import TileGrid from 'ol/tilegrid/TileGrid';
+import { Group } from 'ol/layer';
 import {
   Button, Component, cuid, dom
 } from '../../ui';
@@ -99,11 +100,28 @@ const PrintComponent = function PrintComponent(options = {}) {
     return retval;
   };
 
+  /**
+   * Recursively flattens group layers in an array of layers
+   * @param {any []} layers Array of layers
+   * @returns {any []} Array of layers with group layers flattened
+   */
+  const flattenLayers = function flattenLayers(layers) {
+    return layers.reduce((acc, currLayer) => {
+      if (currLayer instanceof Group) {
+        // eslint-disable-next-line no-param-reassign
+        acc = acc.concat(flattenLayers(currLayer.getLayers().getArray()));
+      } else {
+        acc.push(currLayer);
+      }
+      return acc;
+    }, []);
+  };
+
   /** Recalculate the grid of tiled layers when resolution has changed as more tiles may be needed to cover the extent */
   const updateTileGrids = function updateTileGrids() {
-    const layers = map.getLayers();
-    for (let i = 0; i < layers.getLength(); i += 1) {
-      const currLayer = layers.item(i);
+    const layers = flattenLayers(viewer.getLayers());
+    for (let i = 0; i < layers.length; i += 1) {
+      const currLayer = layers[i];
       if (currLayer.getSource() instanceof TileImage) {
         const grid = currLayer.getSource().getTileGrid();
         let needNewGrid = false;

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -45,7 +45,7 @@ const PrintComponent = function PrintComponent(options = {}) {
     rotationStep,
     leftFooterText,
     mapInteractionsActive,
-    recalculateResolutions
+    supressResolutionsRecalculation
   } = options;
 
   let {
@@ -359,7 +359,7 @@ const PrintComponent = function PrintComponent(options = {}) {
     },
     changeResolution(evt) {
       resolution = evt.resolution;
-      if (recalculateResolutions) {
+      if (!supressResolutionsRecalculation) {
         updateResolutions();
       }
 
@@ -394,7 +394,7 @@ const PrintComponent = function PrintComponent(options = {}) {
     },
     close() {
       // Restore scales
-      if (recalculateResolutions) {
+      if (!supressResolutionsRecalculation) {
         const viewerResolutions = viewer.getResolutions();
         for (let ix = 0; ix < viewerResolutions.length; ix += 1) {
           viewerResolutions[ix] = originalResolutions[ix];
@@ -407,7 +407,6 @@ const PrintComponent = function PrintComponent(options = {}) {
         // As we do a "dirty" update of resolutions we have to trigger a re-read of the limits, otherwise the outer limits still apply.
         map.getView().setMinZoom(0);
         map.getView().setMaxZoom(viewerResolutions.length - 1);
-        updateTileGrids();
         originalGrids.clear();
       }
       printMapComponent.removePrintControls();
@@ -488,7 +487,7 @@ const PrintComponent = function PrintComponent(options = {}) {
       map.setTarget(printMapComponent.getId());
       this.removeViewerControls();
       printMapComponent.addPrintControls();
-      if (recalculateResolutions) {
+      if (!supressResolutionsRecalculation) {
         updateResolutions();
       }
       printMapComponent.dispatch('change:toggleScale', { showScale });

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -41,7 +41,7 @@ const PrintComponent = function PrintComponent(options = {}) {
     rotationStep,
     leftFooterText,
     mapInteractionsActive,
-    supressResultionsRecalculation
+    supressResolutionsRecalculation
   } = options;
 
   let {
@@ -80,7 +80,7 @@ const PrintComponent = function PrintComponent(options = {}) {
 
   /** Recalculate the array of allowed zoomlevels to reflect changes in DPI */
   const recalculateResolutions = function recalculateResolutions() {
-    if (!supressResultionsRecalculation) {
+    if (!supressResolutionsRecalculation) {
       const viewerResolutions = viewer.getResolutions();
       viewerResolutions.forEach((currRes, ix) => {
         // Do the calculation the same way as when setting the scale. Otherwise there will be rounding errors and the scale bar will have another scale than selected
@@ -305,7 +305,7 @@ const PrintComponent = function PrintComponent(options = {}) {
     },
     close() {
       // Restore scales
-      if (!supressResultionsRecalculation) {
+      if (!supressResolutionsRecalculation) {
         const viewerResolutions = viewer.getResolutions();
         viewerResolutions.forEach((currRes, ix) => {
           viewerResolutions[ix] = originalResolutions[ix];

--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -66,6 +66,7 @@ const wms = function wms(layerOptions, viewer) {
     sourceOptions.tileGrid = viewer.getTileGrid();
 
     if (wmsOptions.extent) {
+      // FIXME: there is no "extent" property to set. Code has no effect. Probably must create a new grid from viewer.getTileGridSettings .
       sourceOptions.tileGrid.extent = wmsOptions.extent;
     }
   }


### PR DESCRIPTION
Fix for #1167. Recalculates the resolutions array when entering print preview and restores them when print component is closed. By doing this the scale selector and the print preview gets the same scale when _constrainResolution_ is set regardless of DPI setting. 

It also recalculates max zoom and min zoom to allow the print preview to zoom beyond the original limits to provide for other DPI settings. As an implementation note, temporarily setting _constrainResolution_ on the map is not sufficient to solve the min and max zoom problem, as that parameter only controls if zoom values between the defined levels are allowed.

The feature is opt-out as it is most likely how it should work, but if it just happens to destroy something else, it can be turned off by setting `"supressResolutionsRecalculation" : true` on the print component.

It also changes the print component to zoom to the closest defined _print scale_ instead of _map resolution_ as it probably more intuitive for the user (and easier to implement when calculating scale from resolution and vice versa) 

If the _print scales_ option is used on the print component and _constrainResolution_ is set to true, the resolution corresponding to the scale must exist in the _resolutions_ array, otherwise you still get the wrong scale.

If the map uses tiled services you probably need to set up tile grids that matches all corresponding print resolutions as well for each dpi. 

Maybe there should have been a default (90-ish) dpi option instead of 75 for those who really does not want to mess with the resolution/scale can of worms, but that is another issue...