### PR TITLE
FeatureInfo API

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -34,6 +34,8 @@ const Featureinfo = function Featureinfo(options = {}) {
   let popup;
   let viewer;
   let selectionManager;
+  /** The featureinfo component itself */
+  let component;
 
   const pinStyle = Style.createStyleRule(pinStyleOptions)[0];
   const selectionStyles = selectionStylesOptions ? Style.createGeometryStyle(selectionStylesOptions) : Style.createEditStyle();
@@ -68,6 +70,7 @@ const Featureinfo = function Featureinfo(options = {}) {
     }
   };
 
+  // FIXME: overly complex. Don't think layer can be a string anymore
   const getTitle = function getTitle(item) {
     let featureinfoTitle;
     let title;
@@ -102,6 +105,14 @@ const Featureinfo = function Featureinfo(options = {}) {
     return title;
   };
 
+  /**
+ * Dispatches an "official" api event.
+ * @param {SelectedItem} item The currently selected item
+ */
+  const dispatchNewSelection = function dispachtNewSelection(item) {
+    component.dispatch('changeselection', item);
+  };
+
   const dispatchToggleFeatureEvent = function dispatchToggleFeatureEvent(currentItem) {
     const toggleFeatureinfo = new CustomEvent('toggleFeatureinfo', {
       detail: {
@@ -109,7 +120,10 @@ const Featureinfo = function Featureinfo(options = {}) {
         currentItem
       }
     });
+    // FIXME: should be deprecated
     document.dispatchEvent(toggleFeatureinfo);
+    // Also emit an API-event
+    dispatchNewSelection(currentItem);
   };
 
   // TODO: direct access to feature and layer should be converted to getFeature and getLayer methods on currentItem
@@ -119,6 +133,7 @@ const Featureinfo = function Featureinfo(options = {}) {
       const currentItem = items[currentItemIndex];
       const clone = currentItem.feature.clone();
       clone.setId(currentItem.feature.getId());
+      // FIXME: Should be taken from layer name
       clone.layerName = currentItem.name;
       selectionLayer.clearAndAdd(
         clone,
@@ -173,6 +188,7 @@ const Featureinfo = function Featureinfo(options = {}) {
     return selectionLayer.getFeatureLayer();
   }
 
+  // FIXME: Can't handle selectionmanager (infowindow)
   function getSelection() {
     const selection = {};
     const firstFeature = selectionLayer.getFeatures()[0];
@@ -180,12 +196,14 @@ const Featureinfo = function Featureinfo(options = {}) {
       selection.geometryType = firstFeature.getGeometry().getType();
       selection.coordinates = firstFeature.getGeometry().getCoordinates();
       selection.id = firstFeature.getId() != null ? firstFeature.getId() : firstFeature.ol_uid;
+      // FIXME: typeof layer can not be string, and if it is it would probably not have a property called type that is set to WFS
       selection.type = typeof selectionLayer.getSourceLayer() === 'string' ? selectionLayer.getFeatureLayer().type : selectionLayer.getSourceLayer().get('type');
       if (selection.type === 'WFS') {
         const idSuffix = selection.id.substring(selection.id.lastIndexOf('.') + 1, selection.id.length);
         selection.id = `${selectionLayer.getSourceLayer().get('name')}.${idSuffix}`;
       }
       if (selection.type !== 'WFS') {
+        // FIXME: typeof layer can not be string
         const name = typeof selectionLayer.getSourceLayer() === 'string' ? selectionLayer.getSourceLayer() : selectionLayer.getSourceLayer().get('name');
         const id = firstFeature.getId() || selection.id;
         selection.id = `${name}.${id}`;
@@ -238,6 +256,7 @@ const Featureinfo = function Featureinfo(options = {}) {
     const map = viewer.getMap();
     items = identifyItems;
     clear();
+    // FIXME: variable is overwritten in next row
     let content = items.map((i) => i.content).join('');
     content = '<div id="o-identify"><div id="o-identify-carousel" class="flex"></div></div>';
     switch (target) {
@@ -264,6 +283,7 @@ const Featureinfo = function Featureinfo(options = {}) {
         const geometry = firstFeature.getGeometry();
         const clone = firstFeature.clone();
         clone.setId(firstFeature.getId());
+        // FIXME: should be layer name, not feature name
         clone.layerName = firstFeature.name;
         selectionLayer.clearAndAdd(
           clone,
@@ -320,6 +340,7 @@ const Featureinfo = function Featureinfo(options = {}) {
         const geometry = firstFeature.getGeometry();
         const clone = firstFeature.clone();
         clone.setId(firstFeature.getId());
+        // FIXME: should be layer name
         clone.layerName = firstFeature.name;
         selectionLayer.clearAndAdd(
           clone,
@@ -348,7 +369,32 @@ const Featureinfo = function Featureinfo(options = {}) {
     for (let i = 0; i < modalLinks.length; i += 1) {
       addLinkListener(modalLinks[i]);
     }
-    dispatchToggleFeatureEvent(items[0]);
+    // Don't send event for infowindow. Infowindow will send an event that triggers sending the event later.
+    if (target === 'overlay' || target === 'sidebar') {
+      dispatchToggleFeatureEvent(items[0]);
+    }
+  };
+
+  /**
+  * Shows the featureinfo popup/sidebar/infowindow for the provided features. Only vector layers are supported.
+  * @param {any} fidsbylayer An object containing layer names as keys with a list of feature ids for each layer
+  * @param {any} opts An object containing options. Supported options are : coordinate, the coordinate where popup will be shown. If omitted first feature is used.
+  * @returns nothing
+  */
+  const showInfo = function showInfo(fidsbylayer, opts = {}) {
+    const newItems = [];
+    const grouplayers = viewer.getGroupLayers();
+    const map = viewer.getMap();
+    const keys = Object.keys(fidsbylayer);
+    keys.forEach(layername => {
+      fidsbylayer[layername].forEach(currFeatureId => {
+        const layer = viewer.getLayer(layername);
+        const f = layer.getSource().getFeatureById(currFeatureId);
+        const newItem = getFeatureInfo.createSelectedItem(f, layer, map, grouplayers);
+        newItems.push(newItem);
+      });
+    });
+    render(newItems, identifyTarget, opts.coordinate || maputils.getCenter(newItems[0].getFeature().getGeometry()));
   };
 
   const onClick = function onClick(evt) {
@@ -415,11 +461,17 @@ const Featureinfo = function Featureinfo(options = {}) {
     getSelection,
     addAttributeType,
     onAdd(e) {
+      // Keep a reference to "ourselves"
+      component = this;
       viewer = e.target;
       const map = viewer.getMap();
       setUIoutput(viewer);
       selectionLayer = featurelayer(savedFeature, map);
       selectionManager = viewer.getSelectionManager();
+      // Re dispatch selectionmanager's event as our own
+      if (selectionManager) {
+        selectionManager.on('highlight', evt => dispatchToggleFeatureEvent(evt));
+      }
       map.on(clickEvent, onClick);
       viewer.on('toggleClickInteraction', (detail) => {
         if ((detail.name === 'featureinfo' && detail.active) || (detail.name !== 'featureinfo' && !detail.active)) {
@@ -429,7 +481,8 @@ const Featureinfo = function Featureinfo(options = {}) {
         }
       });
     },
-    render
+    render,
+    showInfo
   });
 };
 

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -268,6 +268,7 @@ function getFeaturesAtPixel({
 }
 
 export default {
+  createSelectedItem,
   getFeaturesFromRemote,
   getFeaturesAtPixel
 };

--- a/src/selectionmanager.js
+++ b/src/selectionmanager.js
@@ -16,11 +16,15 @@ const Selectionmanager = function Selectionmanager(options = {}) {
   let urval;
   let map;
   let infowindow;
+  /** The selectionmanager component itself */
+  let component;
 
   const multiselectStyleOptions = options.multiSelectionStyles || styleTypes.getStyle('multiselection');
   const isInfowindow = options.infowindow === 'infowindow' || false;
 
   function alreadyExists(item) {
+    // FIXME: Take into consideration which layer? Also affects remove and all other by id functions.
+    // Right now, if several layers use the same source, a feature can only be selected in one layer (the first attempted)
     return selectedItems.getArray().some((i) => item.getId() === i.getId());
   }
 
@@ -64,12 +68,20 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     });
   }
 
+  /**
+   * Highlights the feature with fid id.
+   * All other items are un-highlighted
+   * Emits event 'highlight' with highlighted SelectedItem
+   * @param {any} id
+   */
   function highlightFeatureById(id) {
     selectedItems.forEach((item) => {
       const feature = item.getFeature();
       if (item.getId() === id) {
         feature.set('state', 'selected');
+        component.dispatch('highlight', item);
       } else {
+        // FIXME: Second argument should be a bool. Change to true to intentionally supress event, or remove second arg to emit the event. May affect the all other layers refresh below
         feature.unset('state', 'selected');
       }
     });
@@ -88,6 +100,7 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     infowindow.highlightListElement(featureId);
   }
 
+  // FIXME: does almost exactly the same as highlightAndExpandItem
   function highlightItem(item) {
     const featureId = item.getId();
     highlightFeatureById(featureId);
@@ -165,6 +178,7 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     const selectionGroupTitle = event.element.getSelectionGroupTitle();
 
     const feature = item.getFeature();
+    // FIXME: second argument should be a bool. True supresses event. 'selected' will be treated as true. Maybe correct, but not obvious.
     feature.unset('state', 'selected');
 
     urval.get(selectionGroup).removeFeature(feature);
@@ -182,6 +196,10 @@ const Selectionmanager = function Selectionmanager(options = {}) {
     }
   }
 
+  /**
+   * Highlights a feature. All other highlights remain and list is not affected.
+   * @param {any} feature The feature to highlight
+   */
   function highlightFeature(feature) {
     feature.set('state', 'selected');
   }
@@ -215,6 +233,8 @@ const Selectionmanager = function Selectionmanager(options = {}) {
       selectedItems.on('remove', onItemRemoved);
     },
     onAdd(e) {
+      // Keep a reference to "ourselves"
+      component = this;
       viewer = e.target;
       map = viewer.getMap();
       infowindow = infowindowManager.init(options);


### PR DESCRIPTION
Resolves #1256.  Adds an event `changeselection` on the FeatureInfo component. The event is emitted when a new selection is made in FeatureInfo regardless of which infowindow is used. For overlay and sidebar the event will be triggered on opening the dialog and when the carousel changes visible item. For infowindow the event is emitted when a new row is highlighted. The event data contain a SelectedItem with the selected item.  The `toggleFeatureinfo` custom event dispatched on the global _document_ object is also dispatched in the exact same way containing the same data, but is not considered a part of the API and should not be used outside origo.

Intended usage: 
```
var origo = Origo('index.json');
origo.api().getFeatureinfo().on('changeselection', evt => doWhatever(evt))
```

Also adds a method `showInfo` on the featureinfo api to display the featureinfo dialog programatically with a list of features. List is actually an object with layer name as keys and value a list of feature ids. Inteded usage:
```
let fmap = {}
fmap[layerName] = [firstFeatureId, secondFeatureId]
origo.api().getFeatureinfo().showInfo(fmap);
```

As an implementation bonus the selection manager emits a `highlight` event when highlight changes. It can be used to get highlight directly if using SelectionManager without Featureinfo.

Bonus 2: I've added a bunch of FIXMEs to the code to be fixed later to improve code quality and maintainability.
