### PR TITLE
Addmarker

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge;chrome=1">
-	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src *; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; style-src 'unsafe-inline'; style-src-elem 'self'; base-uri 'self'; form-action 'self';">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src * data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; style-src 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self';">
 	<meta name="referrer" content="same-origin">
 	<title>Origo exempel</title>
 	<link href="css/style.css" rel="stylesheet">

--- a/src/maputils.js
+++ b/src/maputils.js
@@ -175,7 +175,6 @@ const maputils = {
     popup.setTitle(title);
     popup.setVisibility(true);
     const popupEl = popup.getEl();
-    console.log(popupEl);
     const popupHeight = document.querySelector('.o-popup').offsetHeight + 10;
     popupEl.style.height = `${popupHeight}px`;
     const overlay = new Overlay({

--- a/src/maputils.js
+++ b/src/maputils.js
@@ -3,10 +3,14 @@ import TileGrid from 'ol/tilegrid/TileGrid';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 import Vector from 'ol/source/Vector';
+import VectorLayer from 'ol/layer/Vector';
+import Overlay from 'ol/Overlay';
 import GeoJSON from 'ol/format/GeoJSON';
 import { getTopLeft, getBottomLeft } from 'ol/extent';
 import WKT from 'ol/format/WKT';
 import numberFormatter from './utils/numberformatter';
+import Style from './style';
+import Popup from './popup';
 
 const maputils = {
   isWithinVisibleScales: function isWithinVisibleScales(scale, maxScale, minScale) {
@@ -130,6 +134,63 @@ const maputils = {
       scaleValue += (10 - differens);
     }
     return scaleValue;
+  },
+  createMarker: function createMarker(coordinates, title, content, viewer) {
+    const featureStyles = {
+      stroke: {
+        color: [100, 149, 237, 1],
+        width: 4,
+        lineDash: null
+      },
+      fill: {
+        color: [100, 149, 237, 0.2]
+      },
+      circle: {
+        radius: 7,
+        stroke: {
+          color: [100, 149, 237, 1],
+          width: 2
+        },
+        fill: {
+          color: [255, 255, 255, 1]
+        }
+      }
+    };
+    const vectorStyles = Style.createStyleRule(featureStyles);
+    const layer = new VectorLayer({
+      source: new Vector({
+        features: [
+          new Feature({
+            geometry: new Point(coordinates)
+          })
+        ]
+      }),
+      style: vectorStyles
+    });
+    const popup = Popup(`#${viewer.getId()}`);
+    popup.setContent({
+      content,
+      title
+    });
+    popup.setTitle(title);
+    popup.setVisibility(true);
+    const popupEl = popup.getEl();
+    console.log(popupEl);
+    const popupHeight = document.querySelector('.o-popup').offsetHeight + 10;
+    popupEl.style.height = `${popupHeight}px`;
+    const overlay = new Overlay({
+      element: popupEl,
+      autoPan: {
+        margin: 55,
+        animation: {
+          duration: 500
+        }
+      },
+      positioning: 'bottom-center'
+    });
+    viewer.getMap().addOverlay(overlay);
+    overlay.setPosition(coordinates);
+    return layer;
   }
 };
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -440,6 +440,11 @@ const Viewer = function Viewer(targetOption, options = {}) {
     }
   };
 
+  const addMarker = function addMarker(coordinates, title, content) {
+    const layer = maputils.createMarker(coordinates, title, content, this);
+    map.addLayer(layer);
+  };
+
   const getUrlParams = function getUrlParams() {
     return urlParams;
   };
@@ -556,6 +561,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
     addLayers,
     addSource,
     addStyle,
+    addMarker,
     getBreakPoints,
     getCenter,
     getClusterOptions,


### PR DESCRIPTION
Closes #1299 

Makes it possible to show a marker via Origo API.

Example:
`origo.api().addMarker([1737367,8724008],'Test','Testing')`
