### PR TITLE
#1314 Attachments

### DIFF
--- a/src/controls/editor/attachmentsform.js
+++ b/src/controls/editor/attachmentsform.js
@@ -1,97 +1,89 @@
+import createElement from '../../ui/dom/createelement';
 import attachmentclient from '../../utils/attachmentclient';
 
 /**
  * Creates complete HTML for the attachment edit form including eventhandlers and what not. Asynchronously populates its container when result is received from the server
  * @param {any} layer The layer to create form for
  * @param {any} feature The feature to create form for
- * @param {any} containerId DOM id for a tag that this function will set the innerHTML to.
+ * @param {any} el DOM element that this function will set the innerHTML to.
  * @returns A Promise when resolved returns nothing at all really.
  */
-const attachmentsform = function attachmentsform(layer, feature, containerId) {
-  let str = '<h4>Bilagor</h4><br/>';
-
-  // Create the repo. No network traffic yet
+const attachmentsform = function attachmentsform(layer, feature, el) {
+  // Create the repo. No network traffic yet it just reads config
   const ac = attachmentclient(layer);
   const groups = ac.getGroups();
 
+  // Shortest code to clear a node
+  // eslint-disable-next-line no-param-reassign
+  el.innerHTML = '';
+  el.appendChild(createElement('label', `${layer.get('attachments').formTitle || 'Bilagor'}`));
+  el.appendChild(document.createElement('br'));
+  el.appendChild(createElement('p', 'Hämtar ...'));
+
   // Get from repo
-  return ac.getAttachments(feature).then(data => {
+  ac.getAttachments(feature).then(data => {
+    el.removeChild(el.lastChild);
     groups.forEach(group => {
       if (group.title) {
-        str += `<b>${group.title}</b>`;
+        el.appendChild(createElement('b', `${group.title}`));
       }
+
       if (data.has(group.name)) {
         const value = data.get(group.name);
         value.forEach(link => {
           // Display the link and add a delete button
-          str += `<div style="display: flex;align-items: center;">
-                    <a style="flex-grow: 1;" href="${link.url}" target="_blank">${link.filename}</a>
-                    <button class="o-button-lg" id="o-attachid-${link.id}"><svg class="o-icon-24"><use xlink:href="#ic_delete_24px"></use></svg></button>
-                  </div>`;
-        });
-      }
-      // Add an add button. Do some silly css stuff to hide the actual file input as it is very ugly and use the label instead
-      // and even stupidier css stuff to make the button inside the label not act like a button. But it's there to steal the button style
-      let acceptstring = '';
-      if (group.allowedFiles) {
-        acceptstring = `accept="${group.allowedFiles}"`;
-      }
-      str += `<div>
-                <label  for="o-attach-${group.name}" style= "cursor: pointer;display: block;">
-                  <button class="o-button-lg" style="pointer-events: none;">
-                    <svg class="o-icon-24"><use xlink:href="#ic_add_24px"></use></svg>
-                  </button>
-                </label>
-                <input type="file" id="o-attach-${group.name}" ${acceptstring} style="opacity: 0; width: 0; height:0; padding: 0; border:0;"/>
-              </div>`;
-    });
-
-    // Set the content on our container. It just happens to acually create the DOM objects as well
-    document.getElementById(containerId).innerHTML = str;
-    // Elements exist now, add handlers.
-    // Maybe build content using Element instead to make it easier to attach handlers
-    groups.forEach(currGroup => {
-      const key = currGroup.name;
-
-      // Add an add event listener for each group
-      const elm = document.getElementById(`o-attach-${key}`);
-      elm.addEventListener('change', ev => {
-        ac.addAttachment(feature, ev.target.files[0], key)
-          .then(() => {
-            // Kinda looks like it is recursive, but it's not. It just schedules a promise to refresh the from content
-            attachmentsform(layer, feature, containerId);
-          })
-          .catch(err => {
-            const errorMessage = `<p>Misslyckades med att spara: ${err}</p>`;
-            document.getElementById(containerId).innerHTML = errorMessage;
-          });
-      });
-      // Only look for remove buttons in groups that actually have attachments
-      if (data.has(key)) {
-        const links = data.get(key);
-        // Add a delete eventhandler for each attachment
-        links.forEach(link => {
-          const deleteButtonElm = document.getElementById(`o-attachid-${link.id}`);
-          deleteButtonElm.addEventListener('click', () => {
+          const rowEl = createElement('div', `<a class="grow" href="${link.url}" target="_blank">${link.filename}</a>`, { cls: 'flex row padding-x padding-y-smaller' });
+          const deleteButtonEl = createElement('button', '<span class="icon-smaller"><svg class="o-icon-24"><use xlink:href="#ic_delete_24px"></use></svg></span><span data-tooltip="Ta bort"></span>', { cls: 'icon-smaller compact o-tooltip hover', 'aria-label': 'Ta bort' });
+          deleteButtonEl.addEventListener('click', () => {
             if (window.confirm(`Är du säker att du vill ta bort filen ${link.filename}`)) {
               ac.deleteAttachment(feature, link.id)
                 .then(() => {
                   // Kinda looks like it is recursive, but it's not. It just schedules a promise to re-read attachements
-                  attachmentsform(layer, feature, containerId);
+                  attachmentsform(layer, feature, el);
                 })
                 .catch(err => {
-                  const errorMessage = `<p>Misslyckades med att ta bort: ${err}</p>`;
-                  document.getElementById(containerId).innerHTML = errorMessage;
+                  const errorMessageEl = createElement('p', `Misslyckades med att ta bort: ${err}`);
+                  el.appendChild(errorMessageEl);
                 });
             }
           });
+          rowEl.appendChild(deleteButtonEl);
+          el.appendChild(rowEl);
         });
       }
+      // Add an add button.
+
+      // Set up file browsing filter
+      let acceptstring = '*';
+      if (group.allowedFiles) {
+        acceptstring = group.allowedFiles;
+      }
+      const rowEl = createElement('div', '', { cls: 'flex row padding-x padding-y-smaller row-reverse' });
+      const labelEl = createElement('label', '', { style: 'cursor: pointer;', cls: 'hover' });
+      const addButtonEl = createElement('button', '<span data-tooltip="Lägg till ny"></span><span class="icon-smaller"><svg class="o-icon-24"><use xlink:href="#ic_add_24px"></use></svg></span>', { cls: 'compact o-tooltip hover', 'aria-label': 'Lägg till', style: 'pointer-events: none;' });
+      // Do some silly css stuff to hide the actual file input as it is very ugly and use the label instead
+      const inputEl = createElement('input', '', { type: 'file', accept: `${acceptstring}`, style: 'opacity: 0; width: 0; height:0; padding: 0; border:0;' });
+      labelEl.appendChild(inputEl);
+      labelEl.appendChild(addButtonEl);
+      rowEl.appendChild(labelEl);
+
+      inputEl.addEventListener('change', ev => {
+        ac.addAttachment(feature, ev.target.files[0], group.name)
+          .then(() => {
+            // Kinda looks like it is recursive, but it's not. It just schedules a promise to refresh the form content
+            attachmentsform(layer, feature, el);
+          })
+          .catch(err => {
+            const errorMessageEl = createElement('p', `Misslyckades med att ta spara: ${err}`);
+            el.appendChild(errorMessageEl);
+          });
+      });
+      el.appendChild(rowEl);
     });
   })
     .catch(err => {
-      const errorMessage = `<p>Misslyckades med att hämta attachments: ${err}</p>`;
-      document.getElementById(containerId).innerHTML = errorMessage;
+      const errorMessageEl = createElement('p', `Misslyckades med att hämta bilagor: ${err}`);
+      el.appendChild(errorMessageEl);
     });
 };
 

--- a/src/controls/editor/attachmentsform.js
+++ b/src/controls/editor/attachmentsform.js
@@ -1,0 +1,97 @@
+import attachmentclient from '../../utils/attachmentclient';
+
+/**
+ * Creates complete HTML for the attachment edit form including eventhandlers and what not. Asynchronously populates its container when result is received from the server
+ * @param {any} layer The layer to create form for
+ * @param {any} feature The feature to create form for
+ * @param {any} containerId DOM id for a tag that this function will set the innerHTML to.
+ * @returns A Promise when resolved returns nothing at all really.
+ */
+const attachmentsform = function attachmentsform(layer, feature, containerId) {
+  let str = '<h4>Bilagor</h4><br/>';
+
+  // Create the repo. No network traffic yet
+  const ac = attachmentclient(layer);
+  const groups = ac.getGroups();
+
+  // Get from repo
+  return ac.getAttachments(feature).then(data => {
+    groups.forEach(group => {
+      if (group.title) {
+        str += `<b>${group.title}</b>`;
+      }
+      if (data.has(group.name)) {
+        const value = data.get(group.name);
+        value.forEach(link => {
+          // Display the link and add a delete button
+          str += `<div style="display: flex;align-items: center;">
+                    <a style="flex-grow: 1;" href="${link.url}" target="_blank">${link.filename}</a>
+                    <button class="o-button-lg" id="o-attachid-${link.id}"><svg class="o-icon-24"><use xlink:href="#ic_delete_24px"></use></svg></button>
+                  </div>`;
+        });
+      }
+      // Add an add button. Do some silly css stuff to hide the actual file input as it is very ugly and use the label instead
+      // and even stupidier css stuff to make the button inside the label not act like a button. But it's there to steal the button style
+      let acceptstring = '';
+      if (group.allowedFiles) {
+        acceptstring = `accept="${group.allowedFiles}"`;
+      }
+      str += `<div>
+                <label  for="o-attach-${group.name}" style= "cursor: pointer;display: block;">
+                  <button class="o-button-lg" style="pointer-events: none;">
+                    <svg class="o-icon-24"><use xlink:href="#ic_add_24px"></use></svg>
+                  </button>
+                </label>
+                <input type="file" id="o-attach-${group.name}" ${acceptstring} style="opacity: 0; width: 0; height:0; padding: 0; border:0;"/>
+              </div>`;
+    });
+
+    // Set the content on our container. It just happens to acually create the DOM objects as well
+    document.getElementById(containerId).innerHTML = str;
+    // Elements exist now, add handlers.
+    // Maybe build content using Element instead to make it easier to attach handlers
+    groups.forEach(currGroup => {
+      const key = currGroup.name;
+
+      // Add an add event listener for each group
+      const elm = document.getElementById(`o-attach-${key}`);
+      elm.addEventListener('change', ev => {
+        ac.addAttachment(feature, ev.target.files[0], key)
+          .then(() => {
+            // Kinda looks like it is recursive, but it's not. It just schedules a promise to refresh the from content
+            attachmentsform(layer, feature, containerId);
+          })
+          .catch(err => {
+            const errorMessage = `<p>Misslyckades med att spara: ${err}</p>`;
+            document.getElementById(containerId).innerHTML = errorMessage;
+          });
+      });
+      // Only look for remove buttons in groups that actually have attachments
+      if (data.has(key)) {
+        const links = data.get(key);
+        // Add a delete eventhandler for each attachment
+        links.forEach(link => {
+          const deleteButtonElm = document.getElementById(`o-attachid-${link.id}`);
+          deleteButtonElm.addEventListener('click', () => {
+            // TODO:: Add confirm
+            ac.deleteAttachment(feature, link.id)
+              .then(() => {
+                // Kinda looks like it is recursive, but it's not. It just schedules a promise to re-read attachements
+                attachmentsform(layer, feature, containerId);
+              })
+              .catch(err => {
+                const errorMessage = `<p>Misslyckades med att ta bort: ${err}</p>`;
+                document.getElementById(containerId).innerHTML = errorMessage;
+              });
+          });
+        });
+      }
+    });
+  });
+  // .catch(err => {
+  //  const errorMessage = `<p>Misslyckades med att hämta attachments: ${err}</p>`;
+  //  document.getElementById(containerId).innerHTML = errorMessage;
+  // });
+};
+
+export default attachmentsform;

--- a/src/controls/editor/attachmentsform.js
+++ b/src/controls/editor/attachmentsform.js
@@ -33,7 +33,7 @@ const attachmentsform = function attachmentsform(layer, feature, el) {
         value.forEach(link => {
           // Display the link and add a delete button
           const rowEl = createElement('div', `<a class="grow" href="${link.url}" target="_blank">${link.filename}</a>`, { cls: 'flex row padding-x padding-y-smaller' });
-          const deleteButtonEl = createElement('button', '<span class="icon-smaller"><svg class="o-icon-24"><use xlink:href="#ic_delete_24px"></use></svg></span><span data-tooltip="Ta bort"></span>', { cls: 'icon-smaller compact o-tooltip hover', 'aria-label': 'Ta bort' });
+          const deleteButtonEl = createElement('button', '<span class="icon"><svg class="o-icon-24"><use xlink:href="#ic_delete_24px"></use></svg></span><span data-tooltip="Ta bort"></span>', { cls: 'compact o-tooltip hover', 'aria-label': 'Ta bort' });
           deleteButtonEl.addEventListener('click', () => {
             if (window.confirm(`Är du säker att du vill ta bort filen ${link.filename}`)) {
               ac.deleteAttachment(feature, link.id)
@@ -59,10 +59,10 @@ const attachmentsform = function attachmentsform(layer, feature, el) {
         acceptstring = group.allowedFiles;
       }
       const rowEl = createElement('div', '', { cls: 'flex row padding-x padding-y-smaller row-reverse' });
-      const labelEl = createElement('label', '', { style: 'cursor: pointer;', cls: 'hover' });
-      const addButtonEl = createElement('button', '<span data-tooltip="Lägg till ny"></span><span class="icon-smaller"><svg class="o-icon-24"><use xlink:href="#ic_add_24px"></use></svg></span>', { cls: 'compact o-tooltip hover', 'aria-label': 'Lägg till', style: 'pointer-events: none;' });
+      const labelEl = createElement('label', '<span data-tooltip="Lägg till"></span>', { style: 'cursor: pointer;', cls: 'hover o-tooltip' });
+      const addButtonEl = createElement('button', '<span class="icon"><svg class="o-icon-24"><use xlink:href="#ic_add_24px"></use></svg></span>', { cls: 'compact', 'aria-label': 'Lägg till', style:'pointer-events:none;' });
       // Do some silly css stuff to hide the actual file input as it is very ugly and use the label instead
-      const inputEl = createElement('input', '', { type: 'file', accept: `${acceptstring}`, style: 'opacity: 0; width: 0; height:0; padding: 0; border:0;' });
+      const inputEl = createElement('input', '', { type: 'file', accept: `${acceptstring}`, style: 'opacity: 0; width: 1px; height:1px; padding: 0; border:0;' });
       labelEl.appendChild(inputEl);
       labelEl.appendChild(addButtonEl);
       rowEl.appendChild(labelEl);

--- a/src/controls/editor/attachmentsform.js
+++ b/src/controls/editor/attachmentsform.js
@@ -73,25 +73,26 @@ const attachmentsform = function attachmentsform(layer, feature, containerId) {
         links.forEach(link => {
           const deleteButtonElm = document.getElementById(`o-attachid-${link.id}`);
           deleteButtonElm.addEventListener('click', () => {
-            // TODO:: Add confirm
-            ac.deleteAttachment(feature, link.id)
-              .then(() => {
-                // Kinda looks like it is recursive, but it's not. It just schedules a promise to re-read attachements
-                attachmentsform(layer, feature, containerId);
-              })
-              .catch(err => {
-                const errorMessage = `<p>Misslyckades med att ta bort: ${err}</p>`;
-                document.getElementById(containerId).innerHTML = errorMessage;
-              });
+            if (window.confirm(`Är du säker att du vill ta bort filen ${link.filename}`)) {
+              ac.deleteAttachment(feature, link.id)
+                .then(() => {
+                  // Kinda looks like it is recursive, but it's not. It just schedules a promise to re-read attachements
+                  attachmentsform(layer, feature, containerId);
+                })
+                .catch(err => {
+                  const errorMessage = `<p>Misslyckades med att ta bort: ${err}</p>`;
+                  document.getElementById(containerId).innerHTML = errorMessage;
+                });
+            }
           });
         });
       }
     });
-  });
-  // .catch(err => {
-  //  const errorMessage = `<p>Misslyckades med att hämta attachments: ${err}</p>`;
-  //  document.getElementById(containerId).innerHTML = errorMessage;
-  // });
+  })
+    .catch(err => {
+      const errorMessage = `<p>Misslyckades med att hämta attachments: ${err}</p>`;
+      document.getElementById(containerId).innerHTML = errorMessage;
+    });
 };
 
 export default attachmentsform;

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -980,7 +980,7 @@ function editAttributes(feat) {
 
     let attachmentsForm = '';
     if (layer.get('attachments') && !isBatchEdit) {
-      attachmentsForm = '<div id="o-attach-form"></div>';
+      attachmentsForm = `<div id="o-attach-form-${currentLayer}"></div>`;
     }
     const form = `<div id="o-form">${formElement}${attachmentsForm}<br><div class="o-form-save"><input id="o-save-button" type="button" value="Ok"></input></div></div>`;
 
@@ -996,10 +996,12 @@ function editAttributes(feat) {
     // Lucky for us when the form is saved, that handler only looks for attributes in the attributesObjects array, so we don't
     // have to bother filter out attachment inputs.
     if (attachmentsForm) {
+      const attachmentEl = document.getElementById(`o-attach-form-${currentLayer}`);
       if (editsStore.hasFeature('insert', feature, currentLayer)) {
-        document.getElementById('o-attach-form').innerHTML = '<h3>Bilagor</h3><p>Du måste spara innan du kan lägga till bilagor.</p>';
+        attachmentEl.innerHTML = `<label>${layer.get('attachments').formTitle || 'Bilagor'}</label><p>Du måste spara innan du kan lägga till bilagor.</p>`;
       } else {
-        attachmentsform(layer, feature, 'o-attach-form').then(res => { console.log(res); });
+        // Async fire and forget. Populates the form placeholder.
+        attachmentsform(layer, feature, attachmentEl);
       }
     }
 

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -11,6 +11,7 @@ import getFeatureInfo from './getfeatureinfo';
 import replacer from './utils/replacer';
 import SelectedItem from './models/SelectedItem';
 import { getContent } from './getattributes';
+import attachmentclient from './utils/attachmentclient';
 
 const styleTypes = StyleTypes();
 let selectionLayer;
@@ -252,7 +253,13 @@ const Featureinfo = function Featureinfo(options = {}) {
     });
   };
 
-  const render = function render(identifyItems, target, coordinate) {
+  /**
+   * Internal helper that performs the actual rendering
+   * @param {any} identifyItems
+   * @param {any} target
+   * @param {any} coordinate
+   */
+  const doRender = function doRender(identifyItems, target, coordinate) {
     const map = viewer.getMap();
     items = identifyItems;
     clear();
@@ -374,7 +381,40 @@ const Featureinfo = function Featureinfo(options = {}) {
       dispatchToggleFeatureEvent(items[0]);
     }
   };
+  /**
+   * Renders the feature info window. Consider using showInfo instead if calling using api.
+   * @param {any} identifyItems Array of SelectedItems
+   * @param {any} target Name of infoWindow type
+   * @param {any} coordinate Coordinate where to show pop up.
+   */
+  const render = function render(identifyItems, target, coordinate) {
+    // Append attachments (if any) to the SelectedItems
+    const requests = [];
+    identifyItems.forEach(currItem => {
+      // At least search can call render without SelectedItem as Items, it just sends an object with the least possible fields render uses
+      // so we need to exclude those from attachment handling, as we know nothing about them
+      if (currItem instanceof SelectedItem) {
+        const layer = currItem.getLayer();
+        const attachments = layer.get('attachments');
+        if (attachments && attachments.groups.some(g => g.linkAttribute || g.fileNameAttribute)) {
+          const ac = attachmentclient(layer);
+          // This actually adds attributes to the feature
+          requests.push(ac.populatePseudoAttributes(currItem, viewer.getMap()));
+        }
+      }
+    });
 
+    // Wait for all requests. If there are no attachments it just calls .then() without waiting.
+    Promise.all(requests)
+      .then(() => {
+        doRender(identifyItems, target, coordinate);
+      })
+      .catch(() => {
+        alert('Kunde inte hämta bilagor. Fält från bilagor kommer att vara tomma.');
+        // Show without attachments
+        doRender(identifyItems, target, coordinate);
+      });
+  };
   /**
   * Shows the featureinfo popup/sidebar/infowindow for the provided features. Only vector layers are supported.
   * @param {any} fidsbylayer An object containing layer names as keys with a list of feature ids for each layer

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -9,7 +9,7 @@ function createUrl(prefix, suffix, url) {
   return p + url + s;
 }
 
-function parseUrl(urlattr, feature, attribute, attributes, map) {
+function parseUrl(urlattr, feature, attribute, attributes, map, linktext) {
   let val = '';
   let url;
   if (urlattr) {
@@ -17,7 +17,7 @@ function parseUrl(urlattr, feature, attribute, attributes, map) {
   } else if (isUrl(attribute.url)) {
     url = attribute.url;
   } else return '';
-  const text = feature.get(attribute.name) || attribute.html || attribute.title || urlattr;
+  const text = linktext || feature.get(attribute.name) || attribute.html || attribute.title || urlattr;
   const aTargetTitle = replacer.replace(attribute.targetTitle, attributes) || url;
   let aTarget = '_blank';
   let aCls = 'o-identify-link';
@@ -38,6 +38,33 @@ function parseUrl(urlattr, feature, attribute, attributes, map) {
   return val;
 }
 
+/**
+ * Creates HTML containing clickable links from attribute content. Internal helper.
+ * @param {any} feature The feature in question
+ * @param {any} attribute The current attribute configuration to format
+ * @param {any} attributes All other attribute configurations
+ * @param {any} map The map
+ */
+function buildUrlContent(feature, attribute, attributes, map) {
+  if (attribute.splitter) {
+    let val = '';
+    const urlArr = feature.get(attribute.url).split(attribute.splitter);
+    let linkArr;
+    if (attribute.linktext) {
+      linkArr = feature.get(attribute.linktext).split(attribute.splitter);
+    }
+    if (urlArr[0] !== '') {
+      urlArr.forEach((url, ix) => {
+        // Assume linkText array is same size as links array.
+        const linkText = linkArr ? linkArr[ix] : null;
+        val += `<p>${parseUrl(url, feature, attribute, attributes, map, linkText)}</p>`;
+      });
+    }
+    return val;
+  }
+  return parseUrl(feature.get(attribute.url), feature, attribute, attributes, map);
+}
+
 const getContent = {
   name(feature, attribute, attributes, map) {
     let val = '';
@@ -49,16 +76,7 @@ const getContent = {
         title = `<b>${attribute.title}</b>`;
       }
       if (attribute.url) {
-        if (attribute.splitter) {
-          const urlArr = feature.get(attribute.url).split(attribute.splitter);
-          if (urlArr[0] !== '') {
-            urlArr.forEach((url) => {
-              val += `<p>${parseUrl(url, feature, attribute, attributes, map)}</p>`;
-            });
-          }
-        } else {
-          val = parseUrl(feature.get(attribute.url), feature, attribute, attributes, map);
-        }
+        val = buildUrlContent(feature, attribute, attributes, map);
       }
     }
     const newElement = document.createElement('li');
@@ -70,16 +88,11 @@ const getContent = {
   },
   url(feature, attribute, attributes, map) {
     let val = '';
-    if (attribute.splitter) {
-      const urlArr = feature.get(attribute.url).split(attribute.splitter);
-      if (urlArr[0] !== '') {
-        urlArr.forEach((url) => {
-          val += `<p>${parseUrl(url, feature, attribute, attributes, map)}</p>`;
-        });
-      }
-    } else {
-      val = parseUrl(feature.get(attribute.url), feature, attribute, attributes, map);
+    // Use a common title for all links. If no splitter only one link is assumed and title is used as link text instead.
+    if (attribute.title && attribute.splitter) {
+      val = `<b>${attribute.title}</b>`;
     }
+    val += buildUrlContent(feature, attribute, attributes, map);
     const newElement = document.createElement('li');
     if (typeof (attribute.cls) !== 'undefined') {
       newElement.classList.add(attribute.cls);

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -25,6 +25,19 @@ function createSelectedItem(feature, layer, map, groupLayers) {
     selectionGroupTitle = layer.get('title');
   }
 
+  // Add pseudo attributes to make sure they exist when featureinfo shows them
+  // Ideally we would also populate here, but that is an async operation and will break the api.
+  const attachments = layer.get('attachments');
+  if (attachments) {
+    attachments.groups.forEach(a => {
+      if (a.linkAttribute) {
+        feature.set(a.linkAttribute, '');
+      }
+      if (a.fileNameAttribute) {
+        feature.set(a.fileNameAttribute, '');
+      }
+    });
+  }
   return new SelectedItem(feature, layer, map, selectionGroup, selectionGroupTitle);
 }
 

--- a/src/layer.js
+++ b/src/layer.js
@@ -34,7 +34,8 @@ const Layer = function Layer(optOptions, viewer) {
     type: undefined,
     extent: undefined,
     attributes: undefined,
-    tileSize: viewer.getTileSize()
+    tileSize: viewer.getTileSize(),
+    attachments: undefined
   };
   const projection = viewer.getProjection();
   const options = optOptions || {};

--- a/src/utils/attachmentclient.js
+++ b/src/utils/attachmentclient.js
@@ -1,0 +1,214 @@
+/*
+ * Repository to communicate with an attachment server. The server should be implemented according to ArcGis server attachment services specifications.
+ * In addition to the ArcGis specification the server may support optional features if configured with format='origo'
+ */
+
+import getAttributes from '../getattributes';
+import groupBy from './groupby';
+
+/** Just about anything for creating a dummy group */
+const ARCGIS_DEFAULT_GROUP = 'default';
+/**
+ * Creates an instance of the attachment client using layer's configuration
+ * @param {any} layer An OL layer with attachment configuration
+ * @returns An object containing the functions that can be performed on the attachmentclient
+ */
+const attachmentclient = function attachmentclient(layer) {
+  const config = layer.get('attachments');
+  let stripLayerNameFromId = false;
+  const urlbase = config.url;
+  // Only strip if using id. If an attribute is used it is not useful
+  // It is only to tidy up wfs layers from geoserver
+  if ((config.stripLayerNameFromId === undefined || config.stripLayerNameFromId === true) && !config.foreignKey) {
+    stripLayerNameFromId = true;
+  }
+  const layerId = encodeURIComponent(config.layerId || layer.get('id'));
+  const format = config.format || 'origo';
+
+  const groups = config.groups.map(group => {
+    // ArcGis does not have the concept of groups. Use just any name and assume only one config
+    const name = format === 'arcgis' ? ARCGIS_DEFAULT_GROUP : group.name;
+    const title = format === 'arcgis' ? null : group.title || group.name;
+    return {
+      name,
+      title,
+      linkAttribute: group.linkAttribute,
+      fileNameAttribute: group.fileNameAttribute,
+      allowedFiles: group.allowedFiles
+    };
+  });
+
+  /**
+   * Gets the configured groups
+   * @returns An array of the configured groups
+   * */
+  const getGroups = function getGroups() {
+    return groups;
+  };
+
+  /**
+   * Internal function for getting id from layer
+   * @param {any} feature
+   */
+  function getId(feature) {
+    if (config.foreignKey) {
+      return encodeURIComponent(feature.get(config.foreignKey));
+    }
+    let id = feature.getId();
+    if (stripLayerNameFromId) {
+      const s = id.split('.');
+      id = s.pop();
+    }
+    return encodeURIComponent(id);
+  }
+
+  /**
+   * Fetches a list of all attachments for given feature from the server
+   * @param {any} feature
+   * @returns A promise when resolved yields an array of attachments infos
+   */
+  const getAttachments = function getAttachments(feature) {
+    const relativeUrl = `${layerId}/${getId(feature)}/attachments`;
+    const url = new URL(relativeUrl, urlbase);
+
+    // Do the actual call to server
+    const retval = fetch(url)
+      .then(res => res.json())
+      .then(res => {
+        const allAttachments = new Map();
+        if (res.attachmentInfos) {
+          let groupedInfos;
+          if (format === 'origo') {
+            groupedInfos = groupBy(res.attachmentInfos, info => info.group);
+          } else {
+            // Create a dymmy group for arcgis. It makes everything so much easier later on
+            groupedInfos = new Map([[ARCGIS_DEFAULT_GROUP, res.attachmentInfos]]);
+          }
+          // Create the return value. Create absolute links for each attachment
+          groupedInfos.forEach((value, key) => {
+            const fixedInfo = value.map(item => {
+              const itemRelativeUrl = `${layerId}/${getId(feature)}/attachments/${item.id}`;
+              return {
+                url: new URL(itemRelativeUrl, urlbase).href,
+                id: item.id,
+                filename: item.name
+              };
+            });
+            allAttachments.set(key, fixedInfo);
+          });
+        }
+        return allAttachments;
+      });
+      // .catch(err => {
+      //  console.log(err);
+      // });
+    // No error handling. Let caller deal with that
+    return retval;
+  };
+
+  /**
+   * Fetches all attachments for a given SelectedItem and updates its linkAttribute and fileNameAttribute with as semicolon separated lists
+   * It also rebuilds the featureInfo HTML content to inlude attachments
+   * @param {any} item A SelectedItem to update. The Item must reside in the same layer as the attachmentclient is created from.
+   * @param {any} map The map
+   * @returns A promise when resolved returns the raw resonse from server
+   */
+  const populatePseudoAttributes = function populatePseudoAttributes(item, map) {
+    const feature = item.getFeature();
+    return getAttachments(feature).then(data => {
+      // Have to loop through config to make sure attrib is added even when no attachments in that group
+      groups.forEach(currAttrib => {
+        let val = '';
+        let texts = '';
+        if (data.has(currAttrib.name)) {
+          const group = data.get(currAttrib.name);
+          val = group.map(g => g.url).join(';');
+          texts = group.map(g => g.filename).join(';');
+        }
+        if (currAttrib.linkAttribute) {
+          feature.set(currAttrib.linkAttribute, val);
+        }
+        if (currAttrib.fileNameAttribute) {
+          feature.set(currAttrib.fileNameAttribute, texts);
+        }
+        // Have to rebuild the visual representation as new attribs have been added
+        // Ideally this should have been made before SelectedItem was created, but that changes so much
+        // in the code flow as the getAttachment is async-ish
+        const content = getAttributes(feature, layer, map);
+        item.setContent(content);
+      });
+      return data;
+    });
+    // No error handling, let caller deal with that
+  };
+
+  /**
+   * Posts a new attachment to the server
+   * @param {any} feature The feature the attachments belongs to
+   * @param {any} file The actual file object
+   * @param {any} group Name of the group that the attachment belongs to. Ingored for arcgis.
+   * @returns A promise when resolved returns the id of the newly created attachment
+   */
+  const addAttachment = function addAttachment(feature, file, group) {
+    const relativeUrl = `${layerId}/${getId(feature)}/addAttachment`;
+    const url = new URL(relativeUrl, urlbase);
+    const formData = new FormData();
+    // Name "attachment" is in arcgis spec. (and by pure coincident in origo spec.)
+    formData.append('attachment', file);
+    // Named attribute. Arcgis does not support it
+    if (format === 'origo') {
+      formData.append('group', group);
+    }
+    // ArcGis server defaults to html. Origo doesn't care
+    formData.append('f', 'json');
+
+    // Perform the actual call
+    const retval = fetch(url, {
+      method: 'POST',
+      body: formData
+    })
+      .then(res => res.json())
+      .then(res => res.addAttachmentResult.objectId);
+    // .catch(err => {
+    //  console.log(err);
+    // });
+    // No error handling. Let caller deal with that.
+    return retval;
+  };
+  /**
+   * Deletes an attachemnt from the server
+   * @param {any} feature The feature that the attachment belongs to
+   * @param {any} id Id of the attachment
+   * @returns A promise when resolved yields the raw response from the server
+   */
+  const deleteAttachment = function deleteAttachment(feature, id) {
+    const relativeUrl = `${layerId}/${getId(feature)}/deleteAttachments`;
+    const url = new URL(relativeUrl, urlbase);
+
+    // Perform the actual request
+    return fetch(url, {
+      method: 'POST',
+      body: new URLSearchParams({
+        attachmentIds: id,
+        // ArcGis server defaults to html. Origo doesn't care
+        f: 'json'
+      })
+    })
+      .then(res => res.json());
+    // .catch(err => {
+    //  console.log(err);
+    // });
+    // No error handling
+  };
+
+  // Return all operations on the repository
+  return {
+    getAttachments,
+    addAttachment,
+    populatePseudoAttributes,
+    deleteAttachment,
+    getGroups
+  };
+};
+
+export default attachmentclient;

--- a/src/utils/attachmentclient.js
+++ b/src/utils/attachmentclient.js
@@ -68,7 +68,8 @@ const attachmentclient = function attachmentclient(layer) {
    * @returns A promise when resolved yields an array of attachments infos
    */
   const getAttachments = function getAttachments(feature) {
-    const relativeUrl = `${layerId}/${getId(feature)}/attachments`;
+    // Parameter f to get repsonse in json from AGS. Origo format ignores parameter
+    const relativeUrl = `${layerId}/${getId(feature)}/attachments?f=json`;
     const url = new URL(relativeUrl, urlbase);
 
     // Do the actual call to server
@@ -99,9 +100,6 @@ const attachmentclient = function attachmentclient(layer) {
         }
         return allAttachments;
       });
-      // .catch(err => {
-      //  console.log(err);
-      // });
     // No error handling. Let caller deal with that
     return retval;
   };
@@ -169,9 +167,6 @@ const attachmentclient = function attachmentclient(layer) {
     })
       .then(res => res.json())
       .then(res => res.addAttachmentResult.objectId);
-    // .catch(err => {
-    //  console.log(err);
-    // });
     // No error handling. Let caller deal with that.
     return retval;
   };
@@ -195,10 +190,7 @@ const attachmentclient = function attachmentclient(layer) {
       })
     })
       .then(res => res.json());
-    // .catch(err => {
-    //  console.log(err);
-    // });
-    // No error handling
+    // No error handling let caller deal with that
   };
 
   // Return all operations on the repository

--- a/src/utils/groupby.js
+++ b/src/utils/groupby.js
@@ -1,0 +1,21 @@
+/**
+ * Groups an array of objects into groups based on a grouping function.
+ * @param {any[]} list An array of objects to group
+ * @param {any} keyGetter Function that creates a key to group by. Commonly an arrow function returning a field e.g. item => item.myField
+ * @returns {Map} A map with the result of keyGetter as key and an array of objects as value
+ */
+const groupBy = (list, keyGetter) => {
+  const map = new Map();
+  list.forEach((item) => {
+    const key = keyGetter(item);
+    const collection = map.get(key);
+    if (!collection) {
+      map.set(key, [item]);
+    } else {
+      collection.push(item);
+    }
+  });
+  return map;
+};
+
+export default groupBy;


### PR DESCRIPTION
Closes #1314 

Intoduces the concept of attachments. Attachments are files that are not a part of a feature, but are related to a feature.  The implementation only includes the client side part of the attachment handling. In order to actually use attachments an attachment server is needed. The attachment handling is pretty much like in ArcGis and the server interface is actually taken from ArcGis server specification.

This PR consists of several parts:
	1. Code that comprises an attachment server client repository class.
	2. Code to include insertion and deletions in the attributes editor
	3. Code to create temporary attributes from the attachments links
	4. A new attribute formatter "linktext"
	5. As a bonus, a utility function groupBy is added.

**Configuration**
Configuration is performed by adding an _attachments_ field to a layer.
```
"attachments" :{
	"url"
	"format" 
	"foreignKey" 
	"stripLayerNameFromId" 
	layerId
	groups [{
		name
		title
		linkAttribute
		fileNameAttribute
		allowedFiles
	}]
}
```

**Configuration explained**
_url_ : The base adress for the attachment server e.g. "http://localhost:1337Myserver"
_format_: "origo" or "arcgis". Defaults to origo
_foreignKey_: Name of the attribute in the parent feature that contains the private key. If omitted feature.getId() i used
_stripLayerNameFromId_: removes layer name from featureid. Defaults to true. Useful when using geoserver wfs services to get only database FID as private key. (Just splits on ".")
_layerId_: The name of the layer as perceived by the attachment server, Defaults to layer name if omitted.
_groups_: Array of groups of attachemnts. A group has its own title and each group is treated as a separate attribute. At least one group has to be specified. If format is "arcgis" exactly one group must be specified.
_name_: Name of the group as perceived by the attachment server. Ignored for format = "arcgis"
_title_: Title displayed in the editor. Ignored for format = "arcgis"
_linkAttribute_: Name of an attribute to create on a feature containing all links as a semicolon separated list. Optional.
_fileNameAttribute_: Name of an attribute to create on a feature containing all filename as a semicolon separated list. Order is same as linkAttribute list. Optional.
_allowedFiles_: comma separated list of valid file extensionas and mime types that are allowed to upload. Format is accordning to the accept attribute of <input type = "file">  https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file

**Usage**
**Edit attachments**
Once a layer is configured using the above configuration, attachments can be viewed, added and removed from a feature using the normal attributes edit form. Due to the "out-of-band" nature of attachments all operations occurs immediately and the feature must exist on the server before adding attachments. If using autoSave that is not a problem.

There are plenty room for improvements here. For example adding support for synchronizing the attachments operations with the save operation and allowing add attachments to newly created features, but that would require a pretty complex state handling so I skipped it. Also it would be possible to implement different strategies on how to handle feature refresh if the relation between attachments and features in the database is known. For instance if the attachment server actually updates the feature with a child relation, a refresh of the feature would be needed, or a field could be updated by the editor. But this implementation only supports a foreign key relation from the attachment. Technically, the attachments form does not have to reside in the edit form, or even require an edit session, but to reuse as much as possible I put it there. It could be a separate tool in the editor or a separate control.

**Display attachments in info window**
If the linkAttribute configuration is specified a temporary attribute is added to each feature when the feature info is displayed. This makes it possible to display attachments as normal attributes by configure an attribute that uses the temporary attribute. If the fileNameAttribute configuration is specified the link text can be set using the attribute option linktext.

Assuming the attributes configuration contains a group entry containing "linkAttribute": "extra" and "fileNameAttribute": "extra_links", the list of links can be displayed by configuring an attribute for it.
```
{
          "title": "Extra",
          "linktext": "extra_links",
          "url": "extra",
          "splitter": ";"
 }
```

If configured in this way, the feature info sends a request to the attachment server each time a feature is displayed. It works regardless of which infoWindow is used (ovelay, sidebar, infoWindow). It also possible to configure attachments to be displayed for WMS-services, although it is not possible to edit attachments as that is performed in edit mode.

If the attachment server updates a real attribute with the links, there is no need for configuring the creation of the temporary attributes. However, as the feature is not automatically refreshed when attachments change it is not a good idea to create an application that uses both editing and feature info

**The attachment server**
The server should implement the interface of the arcgis server rest api:
_List attachments_: https://developers.arcgis.com/rest/services-reference/enterprise/attachment-infos-feature-service-.htm
_Get attachment_: https://developers.arcgis.com/rest/services-reference/enterprise/attachment-feature-service-.htm (Documentation says both returns an attachemntInfo object and streams the file. As I have no arcgis server to test against, I assumed that what you get is actually just the file downloaded as its mimetype as that would be the most appropriate thing to do)
_Add attachment_: https://developers.arcgis.com/rest/services-reference/enterprise/add-attachment.htm 
_Delete attachment_: https://developers.arcgis.com/rest/services-reference/enterprise/delete-attachments.htm
Update is not used.
I have not tested against a arcgis server as I don't have one.

If mode is set to "origo" the server should support additional functionality:
1. The attachmentInfo object should contain another field called "group", containing the name of the group the attachment belongs to
2. When adding an attachment the server should support another post variable called "group" containing the name of the group the attachment will belong to.

Reference implementation
There is a zero configuration reference implementation for test purposes here: https://github.com/ornskoldsvikskommun/attachmentServer-reference


**Security considerations**
The interface does not specify och explicitly support any authentication or authorization mechanisms. Instead it relies on the principle of the browser handling user sessions if the attachment server is deployed to the same server (as visible to the client) as the application. By deploying the attachment server to the same server as the application will make the browser send session cookies and basic authentication headers from the application that can be used for authorization. Another option for intranets would be using windows integrated authentication in the attachment server. To separate public access and internal use, two separate instances of the attachment server using different configuration but accessing the same data can be used, or use a server that updates the feature with a pre-cooked attribute for the public application.
