### PR TITLE
Comments in configuration

### DIFF
--- a/src/utils/stripjsoncomments.js
+++ b/src/utils/stripjsoncomments.js
@@ -32,7 +32,7 @@ function stripJSONComments(jsonstring) {
       json[ix + 1] = ' ';
       ix += 2;
       // Accept pretty much any row ending combo. We don't care and don't destroy
-      while (json[ix] !== '\n' && json[ix] !== '\r' && ix < lastindex) {
+      while (json[ix] !== '\n' && json[ix] !== '\r' && ix <= lastindex) {
         json[ix] = ' ';
         ix += 1;
       }
@@ -41,7 +41,7 @@ function stripJSONComments(jsonstring) {
       json[ix] = ' ';
       json[ix + 1] = ' ';
       ix += 2;
-      while (json[ix] !== '*' && json[ix + 1] !== '/' && ix < lastindex) {
+      while (!(json[ix] === '*' && json[ix + 1] === '/') && ix <= lastindex) {
         // Keep eol markers so we can produce a good error message when JSON.parse fails.
         if (json[ix] !== '\n' && json[ix] !== '\r') {
           json[ix] = ' ';

--- a/src/utils/stripjsoncomments.js
+++ b/src/utils/stripjsoncomments.js
@@ -1,0 +1,62 @@
+/**
+ * Removes comments from JSON files. Comments are replaced with blanks to keep same size
+ * and row numbering for easier debugging of parse errors.
+ *
+ * Both c-style one line comments and multi line comments are supported. Nested multiline is not supported.
+ * @param {any} jsonstring A string contining JSON
+ * @returns {string} A new JSON without comments
+ */
+function stripJSONComments(jsonstring) {
+  // Stupid javascript have immutable strings. Make a char array to work with.
+  const json = jsonstring.split('');
+  let ix = 0;
+  const lastindex = json.length - 1;
+
+  // Main loop. Beware, ix is advanced at several places.
+  while (ix < lastindex) {
+    // Found string literal, advance util end of literal to avoid having main loop keeping state
+    if (json[ix] === '"') {
+      ix += 1;
+      while (json[ix] !== '"' && ix < lastindex) {
+        if (json[ix] === '\\') {
+          // Eat away one extra. Technically an eascpe sequence can be longer than one character, but we are only interested in not stopping on
+          // an escaped double quote and afraid of an escaped backslash that would fool an unescaped double quote.
+          ix += 1;
+        }
+        ix += 1;
+      }
+    } else if (json[ix] === '/' && json[ix + 1] === '/') {
+      // Now we know that we�re not inside a string literal, start looking for comments
+    // If it is one line comment, advance until end of line
+      json[ix] = ' ';
+      json[ix + 1] = ' ';
+      ix += 2;
+      // Accept pretty much any row ending combo. We don't care and don't destroy
+      while (json[ix] !== '\n' && json[ix] !== '\r' && ix < lastindex) {
+        json[ix] = ' ';
+        ix += 1;
+      }
+    } else if (json[ix] === '/' && json[ix + 1] === '*') {
+    // If it is a multiline comment advance until end marker
+      json[ix] = ' ';
+      json[ix + 1] = ' ';
+      ix += 2;
+      while (json[ix] !== '*' && json[ix + 1] !== '/' && ix < lastindex) {
+        // Keep eol markers so we can produce a good error message when JSON.parse fails.
+        if (json[ix] !== '\n' && json[ix] !== '\r') {
+          json[ix] = ' ';
+        }
+        ix += 1;
+      }
+      json[ix] = ' ';
+      json[ix + 1] = ' ';
+      ix += 1;
+    }
+    // Advance to next character in main loop
+    ix += 1;
+  }
+  // Make a string out of it again
+  return json.join('');
+}
+
+export default stripJSONComments;


### PR DESCRIPTION
Closes #1380 

Support for c-style one line comments: `// This is a comment` and multi line comments: `/* This is also a comment */`. It does NOT support nested multiline comments and does not fix any syntactical errors that may occur due to parts being commented out. All characters, except new lines, in comments are replaced with spaces in order to keep same size and line numbering.

Also added better json parsing error message which throws an error containing the row number and an excerpt of the configuration at the location of the error instead of just file position.