### PR TITLE
Only emit event for SelectedItem

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -109,8 +109,12 @@ const Featureinfo = function Featureinfo(options = {}) {
  * Dispatches an "official" api event.
  * @param {SelectedItem} item The currently selected item
  */
-  const dispatchNewSelection = function dispachtNewSelection(item) {
-    component.dispatch('changeselection', item);
+  const dispatchNewSelection = function dispatchNewSelection(item) {
+    // Make sure it actually is a SelectedItem. At least Search can call render() without creating proper selectedItems when
+    // search result is remote.
+    if (item instanceof SelectedItem) {
+      component.dispatch('changeselection', item);
+    }
   };
 
   const dispatchToggleFeatureEvent = function dispatchToggleFeatureEvent(currentItem) {


### PR DESCRIPTION
Fixes #1363 

The  `changeselection` event is only emitted when the
item actually is a SelectedItem.