### PR TITLE
Changed to focus-visible

### DIFF
--- a/scss/_bookmark.scss
+++ b/scss/_bookmark.scss
@@ -1,27 +1,55 @@
-.o-bookmark-button:focus-visible {
+.o-bookmark-button:focus {
   background-color: $grey-lighter;
 }
 
-.o-bookmark-button.light:focus-visible {
+.o-bookmark-button.light:focus {
   background-color: $grey-lighter;
 }
 
-.o-bookmark-button.primary:focus-visible {
+.o-bookmark-button.primary:focus {
   background-color: $primary-color-dark;
 }
 
-.o-bookmark-button.danger:focus-visible {
+.o-bookmark-button.danger:focus {
   background-color: $danger-color-dark;
 }
 
-.o-bookmark-button.grey-light:focus-visible {
+.o-bookmark-button.grey-light:focus {
   background-color: $grey-light;
 }
 
-.o-bookmark-button.grey-lighter:focus-visible {
+.o-bookmark-button.grey-lighter:focus {
   background-color: $grey-lighter;
 }
 
-.o-bookmark-button.grey-lightest:focus-visible {
+.o-bookmark-button.grey-lightest:focus {
+  background-color: $grey-lightest;
+}
+
+.o-bookmark-button:focus:not(:focus-visible) {
+  background-color: $light-color;
+}
+
+.o-bookmark-button.light:focus:not(:focus-visible) {
+  background-color: $light-color;
+}
+
+.o-bookmark-button.primary:focus:not(:focus-visible) {
+  background-color: $primary-color;
+}
+
+.o-bookmark-button.danger:focus:not(:focus-visible) {
+  background-color: $danger-color;
+}
+
+.o-bookmark-button.grey-light:focus:not(:focus-visible) {
+  background-color: $grey-light;
+}
+
+.o-bookmark-button.grey-lighter:focus:not(:focus-visible) {
+  background-color: $grey-lighter;
+}
+
+.o-bookmark-button.grey-lightest:focus:not(:focus-visible) {
   background-color: $grey-lightest;
 }

--- a/scss/_bookmark.scss
+++ b/scss/_bookmark.scss
@@ -1,27 +1,27 @@
-.o-bookmark-button:focus {
+.o-bookmark-button:focus-visible {
   background-color: $grey-lighter;
 }
 
-.o-bookmark-button.light:focus {
+.o-bookmark-button.light:focus-visible {
   background-color: $grey-lighter;
 }
 
-.o-bookmark-button.primary:focus {
+.o-bookmark-button.primary:focus-visible {
   background-color: $primary-color-dark;
 }
 
-.o-bookmark-button.danger:focus {
+.o-bookmark-button.danger:focus-visible {
   background-color: $danger-color-dark;
 }
 
-.o-bookmark-button.grey-light:focus {
+.o-bookmark-button.grey-light:focus-visible {
   background-color: $grey-light;
 }
 
-.o-bookmark-button.grey-lighter:focus {
+.o-bookmark-button.grey-lighter:focus-visible {
   background-color: $grey-lighter;
 }
 
-.o-bookmark-button.grey-lightest:focus {
+.o-bookmark-button.grey-lightest:focus-visible {
   background-color: $grey-lightest;
 }

--- a/scss/_ol.scss
+++ b/scss/_ol.scss
@@ -4,9 +4,14 @@
   color: #bbb;
 }
 
-.ol-attribution li a:focus-visible {
+.ol-attribution li a:focus {
   color: #fff;
   text-decoration: underline;
+}
+
+.ol-attribution li a:focus:not(:focus-visible) {
+  color: #bbb;
+  text-decoration: none;
 }
 
 .ol-overlaycontainer-stopevent {

--- a/scss/_ol.scss
+++ b/scss/_ol.scss
@@ -4,7 +4,7 @@
   color: #bbb;
 }
 
-.ol-attribution li a:focus {
+.ol-attribution li a:focus-visible {
   color: #fff;
   text-decoration: underline;
 }

--- a/scss/_position.scss
+++ b/scss/_position.scss
@@ -25,9 +25,14 @@
   position: relative;
 }
 
-.o-position-button:focus-visible {
+.o-position-button:focus {
   background-color: #fff;
   color: #000;
+}
+
+.o-position-button:focus:not(:focus-visible) {
+  background-color: #000;
+  color: #fff;
 }
 
 .o-position-center-button {
@@ -44,12 +49,21 @@
   z-index: 100;
 }
 
-.o-position-center-button:focus-visible {
+.o-position-center-button:focus {
   background-color: rgba(255, 255, 255, 0.7);
   color: #fff;
 
   .o-icon-position {
     fill: #000;
+  }
+}
+
+.o-position-center-button:focus:not(:focus-visible) {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: #fff;
+
+  .o-icon-position {
+    fill: #fff;
   }
 }
 

--- a/scss/_position.scss
+++ b/scss/_position.scss
@@ -25,7 +25,7 @@
   position: relative;
 }
 
-.o-position-button:focus {
+.o-position-button:focus-visible {
   background-color: #fff;
   color: #000;
 }
@@ -44,7 +44,7 @@
   z-index: 100;
 }
 
-.o-position-center-button:focus {
+.o-position-center-button:focus-visible {
   background-color: rgba(255, 255, 255, 0.7);
   color: #fff;
 

--- a/scss/_viewer.scss
+++ b/scss/_viewer.scss
@@ -38,7 +38,7 @@
   text-decoration: underline;
 }
 
-.o-footer a:focus {
+.o-footer a:focus-visible {
   color: $white;
   text-decoration: underline;
 }

--- a/scss/_viewer.scss
+++ b/scss/_viewer.scss
@@ -38,9 +38,14 @@
   text-decoration: underline;
 }
 
-.o-footer a:focus-visible {
+.o-footer a:focus {
   color: $white;
   text-decoration: underline;
+}
+
+.o-footer a:focus:not(:focus-visible) {
+  color: $white;
+  text-decoration: none;
 }
 
 .o-footer .o-footer-middle {

--- a/scss/ui/_button.scss
+++ b/scss/ui/_button.scss
@@ -98,7 +98,11 @@ button {
       border: 2px solid $grey-light;
     }
 
-    &.active:focus-visible {
+    &.active:focus {
+      border: 2px solid $grey-light;
+    }
+
+    &.active:focus:not(:focus-visible) {
       border: 2px solid $grey-light;
     }
   }
@@ -107,7 +111,11 @@ button {
     border: 2px solid $grey-lighter;
   }
 
-  &.border:focus-visible {
+  &.border:focus {
+    border: 2px solid $grey-lighter;
+  }
+
+  &.border:focus:not(:focus-visible) {
     border: 2px solid $grey-lighter;
   }
 
@@ -120,7 +128,11 @@ button {
       border: 2px solid $primary-color-dark;
     }
 
-    &.primary:focus-visible {
+    &.primary:focus {
+      border: 2px solid $primary-color-dark;
+    }
+
+    &.primary:focus:not(:focus-visible) {
       border: 2px solid $primary-color-dark;
     }
 
@@ -174,44 +186,85 @@ button:hover,
   }
 }
 
-button:focus-visible,
-.button:focus-visible {
-  &.light:focus-visible {
+button:focus,
+.button:focus {
+  &.light:focus {
     background-color: $grey-light;
     border: 1px solid $black;
   }
 
-  &.primary:focus-visible {
+  &.primary:focus {
     background-color: $primary-color-dark;
     border: 1px solid $black;
   }
 
-  &.danger:focus-visible {
+  &.danger:focus {
     background-color: $danger-color-dark;
     border: 1px solid $black;
   }
 
-  &.grey-light:focus-visible {
+  &.grey-light:focus {
     background-color: $grey;
     border: 1px solid $black;
   }
 
-  &.grey-lighter:focus-visible {
+  &.grey-lighter:focus {
     background-color: $grey-light;
     border: 1px solid $black;
   }
 
-  &.grey-lightest:focus-visible {
+  &.grey-lightest:focus {
     background-color: $grey-lighter;
     border: 1px solid $black;
   }
 
-  &.icon-small:focus-visible {
+  &.icon-small:focus {
     border: 1px solid $black;
   }
 
-  &.icon-smaller:focus-visible {
+  &.icon-smaller:focus {
     border: 1px solid $black;
+  }
+}
+
+button:focus:not(:focus-visible),
+.button:focus:not(:focus-visible) {
+  &.light:focus:not(:focus-visible) {
+    background-color: $light-color;
+    border: 0;
+  }
+
+  &.primary:focus:not(:focus-visible) {
+    background-color: $primary-color;
+    border: 0;
+  }
+
+  &.danger:focus:not(:focus-visible) {
+    background-color: $danger-color;
+    border: 0;
+  }
+
+  &.grey-light:focus:not(:focus-visible) {
+    background-color: $grey-light;
+    border: 0;
+  }
+
+  &.grey-lighter:focus:not(:focus-visible) {
+    background-color: $grey-lighter;
+    border: 0;
+  }
+
+  &.grey-lightest:focus:not(:focus-visible) {
+    background-color: $grey-lightest;
+    border: 0;
+  }
+
+  &.icon-small:focus:not(:focus-visible) {
+    border: 0;
+  }
+
+  &.icon-smaller:focus:not(:focus-visible) {
+    border: 0;
   }
 }
 

--- a/scss/ui/_button.scss
+++ b/scss/ui/_button.scss
@@ -98,7 +98,7 @@ button {
       border: 2px solid $grey-light;
     }
 
-    &.active:focus {
+    &.active:focus-visible {
       border: 2px solid $grey-light;
     }
   }
@@ -107,7 +107,7 @@ button {
     border: 2px solid $grey-lighter;
   }
 
-  &.border:focus {
+  &.border:focus-visible {
     border: 2px solid $grey-lighter;
   }
 
@@ -120,7 +120,7 @@ button {
       border: 2px solid $primary-color-dark;
     }
 
-    &.primary:focus {
+    &.primary:focus-visible {
       border: 2px solid $primary-color-dark;
     }
 
@@ -174,43 +174,43 @@ button:hover,
   }
 }
 
-button:focus,
-.button:focus {
-  &.light:focus {
+button:focus-visible,
+.button:focus-visible {
+  &.light:focus-visible {
     background-color: $grey-light;
     border: 1px solid $black;
   }
 
-  &.primary:focus {
+  &.primary:focus-visible {
     background-color: $primary-color-dark;
     border: 1px solid $black;
   }
 
-  &.danger:focus {
+  &.danger:focus-visible {
     background-color: $danger-color-dark;
     border: 1px solid $black;
   }
 
-  &.grey-light:focus {
+  &.grey-light:focus-visible {
     background-color: $grey;
     border: 1px solid $black;
   }
 
-  &.grey-lighter:focus {
+  &.grey-lighter:focus-visible {
     background-color: $grey-light;
     border: 1px solid $black;
   }
 
-  &.grey-lightest:focus {
+  &.grey-lightest:focus-visible {
     background-color: $grey-lighter;
     border: 1px solid $black;
   }
 
-  &.icon-small:focus {
+  &.icon-small:focus-visible {
     border: 1px solid $black;
   }
 
-  &.icon-smaller:focus {
+  &.icon-smaller:focus-visible {
     border: 1px solid $black;
   }
 }

--- a/scss/ui/_dropdown.scss
+++ b/scss/ui/_dropdown.scss
@@ -27,7 +27,7 @@
   cursor: pointer;
 }
 
-.dropdown li:focus {
+.dropdown li:focus-visible {
   background-color: #eee;
   cursor: pointer;
 }

--- a/scss/ui/_dropdown.scss
+++ b/scss/ui/_dropdown.scss
@@ -27,7 +27,12 @@
   cursor: pointer;
 }
 
-.dropdown li:focus-visible {
+.dropdown li:focus {
   background-color: #eee;
+  cursor: pointer;
+}
+
+.dropdown li:focus:not(:focus-visible) {
+  background-color: #000;
   cursor: pointer;
 }

--- a/scss/ui/_input.scss
+++ b/scss/ui/_input.scss
@@ -93,9 +93,14 @@ input[type=range] {
   min-width: 0;
 }
 
-input[type=range]:focus-visible {
+input[type=range]:focus {
   outline: none;
   border: 1px solid $black;
+}
+
+input[type=range]:focus:not(:focus-visible) {
+  outline: none;
+  border: 0;
 }
 
 input[type=range]::-webkit-slider-runnable-track {

--- a/scss/ui/_input.scss
+++ b/scss/ui/_input.scss
@@ -93,7 +93,7 @@ input[type=range] {
   min-width: 0;
 }
 
-input[type=range]:focus {
+input[type=range]:focus-visible {
   outline: none;
   border: 1px solid $black;
 }


### PR DESCRIPTION
Fixes #1394 
Changed to focus-visible from focus to only display clear focus when using keyboard navigation and not on mouse clicks. 
One problem is that focus-visible is a new feature in web browser and only got adopted as of 2021. Thoose with old browser will not see clearly focused buttons when tabbing.