### PR TITLE
Allow multiple instances of a control

### DIFF
--- a/src/loadresources.js
+++ b/src/loadresources.js
@@ -125,10 +125,10 @@ const loadResources = async function loadResources(mapOptions, config) {
             }
 
             map.options = Object.assign(config, data);
-            map.options.controls = config.defaultControls || [];
+            map.options.controls = config.defaultControls.slice() || [];
             if (data.controls) {
               data.controls.forEach((control) => {
-                const matchingControlIndex = map.options.controls.findIndex(
+                const matchingControlIndex = config.defaultControls.findIndex(
                   (defaultControl) => (defaultControl.name === control.name)
                 );
                 if (matchingControlIndex !== -1) {


### PR DESCRIPTION
Fixes #1400 in a very simple way. For example, it makes it possible to add multiple About or Link controls with different settings in the config. It also makes it possible to add multiple instances of _any_ control that is not implemented as a default control in origo.js, which might be considered as a negative side effect.

A different approach could be to modify the Link and About controls (and possibly others) to accept multiple links/abouts. However, making such an implementation backwards compatible would probably be a bit messy since old style single links would have to be handled one way, and new style multiple links a different way.