### PR TITLE
Open current suggestions on focus in Search control

### DIFF
--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -203,6 +203,9 @@ const Search = function Search(options = {}) {
     });
     document.getElementsByClassName('o-search-field')[0].addEventListener('focus', () => {
       document.getElementById(`${wrapperElement.getId()}`).classList.add('active');
+      if (awesomplete.suggestions && awesomplete.suggestions.length > 0) {
+        awesomplete.open();
+      }
       window.dispatchEvent(new CustomEvent('resize'));
     });
   }


### PR DESCRIPTION
Fixes #1141.

Piggybacks on the listener on the `focus` event to show any suggestions stored from a completed search.