### PR TITLE
Fix for search incorrect zoom

### DIFF
--- a/src/controls/editor/attachmentsform.js
+++ b/src/controls/editor/attachmentsform.js
@@ -60,7 +60,7 @@ const attachmentsform = function attachmentsform(layer, feature, el) {
       }
       const rowEl = createElement('div', '', { cls: 'flex row padding-x padding-y-smaller row-reverse' });
       const labelEl = createElement('label', '<span data-tooltip="Lägg till"></span>', { style: 'cursor: pointer;', cls: 'hover o-tooltip' });
-      const addButtonEl = createElement('button', '<span class="icon"><svg class="o-icon-24"><use xlink:href="#ic_add_24px"></use></svg></span>', { cls: 'compact', 'aria-label': 'Lägg till', style:'pointer-events:none;' });
+      const addButtonEl = createElement('button', '<span class="icon"><svg class="o-icon-24"><use xlink:href="#ic_add_24px"></use></svg></span>', { cls: 'compact', 'aria-label': 'Lägg till', style: 'pointer-events:none;' });
       // Do some silly css stuff to hide the actual file input as it is very ugly and use the label instead
       const inputEl = createElement('input', '', { type: 'file', accept: `${acceptstring}`, style: 'opacity: 0; width: 1px; height:1px; padding: 0; border:0;' });
       labelEl.appendChild(inputEl);

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -70,7 +70,7 @@ const Search = function Search(options = {}) {
     obj.title = objTitle;
     obj.content = content;
     clear();
-    featureInfo.render([obj], 'overlay', getCenter(features[0].getGeometry()), {ignorePan : true});
+    featureInfo.render([obj], 'overlay', getCenter(features[0].getGeometry()), { ignorePan: true });
     viewer.zoomToExtent(features[0].getGeometry(), maxZoomLevel);
   }
 

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -70,7 +70,7 @@ const Search = function Search(options = {}) {
     obj.title = objTitle;
     obj.content = content;
     clear();
-    featureInfo.render([obj], 'overlay', getCenter(features[0].getGeometry()));
+    featureInfo.render([obj], 'overlay', getCenter(features[0].getGeometry()), {ignorePan : true});
     viewer.zoomToExtent(features[0].getGeometry(), maxZoomLevel);
   }
 

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -318,16 +318,16 @@ const Featureinfo = function Featureinfo(options = {}) {
         });
         const popupEl = popup.getEl();
         const popupHeight = document.querySelector('.o-popup').offsetHeight + 10;
-          popupEl.style.height = `${popupHeight}px`;
-          let overlayOptions = { element: popupEl, positioning: 'bottom-center' };
-          if (!ignorePan) {
-            overlayOptions.autoPan = {
-              margin: 55,
-              animation: {
-                duration: 500
-              }
+        popupEl.style.height = `${popupHeight}px`;
+        const overlayOptions = { element: popupEl, positioning: 'bottom-center' };
+        if (!ignorePan) {
+          overlayOptions.autoPan = {
+            margin: 55,
+            animation: {
+              duration: 500
             }
-          }
+          };
+        }
         overlay = new Overlay(overlayOptions);
         map.addOverlay(overlay);
         overlay.setPosition(coord);

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -262,8 +262,9 @@ const Featureinfo = function Featureinfo(options = {}) {
    * @param {any} identifyItems
    * @param {any} target
    * @param {any} coordinate
+   * @param {bool} ignorePan true if overlay should not be panned into view
    */
-  const doRender = function doRender(identifyItems, target, coordinate) {
+  const doRender = function doRender(identifyItems, target, coordinate, ignorePan) {
     const map = viewer.getMap();
     items = identifyItems;
     clear();
@@ -317,17 +318,17 @@ const Featureinfo = function Featureinfo(options = {}) {
         });
         const popupEl = popup.getEl();
         const popupHeight = document.querySelector('.o-popup').offsetHeight + 10;
-        popupEl.style.height = `${popupHeight}px`;
-        overlay = new Overlay({
-          element: popupEl,
-          autoPan: {
-            margin: 55,
-            animation: {
-              duration: 500
+          popupEl.style.height = `${popupHeight}px`;
+          let overlayOptions = { element: popupEl, positioning: 'bottom-center' };
+          if (!ignorePan) {
+            overlayOptions.autoPan = {
+              margin: 55,
+              animation: {
+                duration: 500
+              }
             }
-          },
-          positioning: 'bottom-center'
-        });
+          }
+        overlay = new Overlay(overlayOptions);
         map.addOverlay(overlay);
         overlay.setPosition(coord);
         break;
@@ -390,8 +391,9 @@ const Featureinfo = function Featureinfo(options = {}) {
    * @param {any} identifyItems Array of SelectedItems
    * @param {any} target Name of infoWindow type
    * @param {any} coordinate Coordinate where to show pop up.
+   * @param {any} opts Additional options. Supported options are : ignorePan, disable auto pan to popup overlay.
    */
-  const render = function render(identifyItems, target, coordinate) {
+  const render = function render(identifyItems, target, coordinate, opts = {}) {
     // Append attachments (if any) to the SelectedItems
     const requests = [];
     identifyItems.forEach(currItem => {
@@ -411,18 +413,19 @@ const Featureinfo = function Featureinfo(options = {}) {
     // Wait for all requests. If there are no attachments it just calls .then() without waiting.
     Promise.all(requests)
       .then(() => {
-        doRender(identifyItems, target, coordinate);
+        doRender(identifyItems, target, coordinate, opts.ignorePan);
       })
       .catch(() => {
         alert('Kunde inte hämta bilagor. Fält från bilagor kommer att vara tomma.');
         // Show without attachments
-        doRender(identifyItems, target, coordinate);
+        doRender(identifyItems, target, coordinate, opts.ignorePan);
       });
   };
   /**
   * Shows the featureinfo popup/sidebar/infowindow for the provided features. Only vector layers are supported.
   * @param {any} fidsbylayer An object containing layer names as keys with a list of feature ids for each layer
   * @param {any} opts An object containing options. Supported options are : coordinate, the coordinate where popup will be shown. If omitted first feature is used.
+  *                                                                         ignorePan, do not autopan if type is overlay. Pan should be supressed if view is changed manually to avoid contradicting animations.
   * @returns nothing
   */
   const showInfo = function showInfo(fidsbylayer, opts = {}) {
@@ -438,7 +441,7 @@ const Featureinfo = function Featureinfo(options = {}) {
         newItems.push(newItem);
       });
     });
-    render(newItems, identifyTarget, opts.coordinate || maputils.getCenter(newItems[0].getFeature().getGeometry()));
+    render(newItems, identifyTarget, opts.coordinate || maputils.getCenter(newItems[0].getFeature().getGeometry()), opts);
   };
 
   const onClick = function onClick(evt) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -482,9 +482,12 @@ const Viewer = function Viewer(targetOption, options = {}) {
             if (layer && type !== 'GROUP') {
               const clusterSource = layer.getSource().source;
               const id = featureId.split('.')[1];
+              // FIXME: postrender event is only emitted if any features from a layer is actually drawn, which means there is no feature in the default extent,
+              // it will not be triggered until map is panned or zoomed where a feature exists.
               layer.once('postrender', () => {
                 let feature;
-
+                // FIXME: ensure that feature is loaded. If using bbox and feature is outside default extent it will not be found.
+                // Workaround is to have a default extent covering the entire map with the layer in visible range or use strategy all 
                 if (type === 'WFS' && clusterSource) {
                   feature = clusterSource.getFeatureById(featureId);
                 } else if (type === 'WFS') {
@@ -505,8 +508,10 @@ const Viewer = function Viewer(targetOption, options = {}) {
                   obj.content = getAttributes(feature, layer);
                   obj.layer = layer;
                   const centerGeometry = getcenter(feature.getGeometry());
+                  // FIXME: showOverlay option is undocumented and behaviour is probably not the desired. 
                   const infowindowType = featureinfoOptions.showOverlay === false ? 'sidebar' : 'overlay';
-                  featureinfo.render([obj], infowindowType, centerGeometry);
+                  // Don't auto pan as we're zooming in anyway on the next row. 
+                  featureinfo.render([obj], infowindowType, centerGeometry, { ignorePan : true});
                   map.getView().fit(feature.getGeometry(), {
                     maxZoom: getResolutions().length - 2,
                     padding: [15, 15, 40, 15],

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -487,7 +487,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
               layer.once('postrender', () => {
                 let feature;
                 // FIXME: ensure that feature is loaded. If using bbox and feature is outside default extent it will not be found.
-                // Workaround is to have a default extent covering the entire map with the layer in visible range or use strategy all 
+                // Workaround is to have a default extent covering the entire map with the layer in visible range or use strategy all
                 if (type === 'WFS' && clusterSource) {
                   feature = clusterSource.getFeatureById(featureId);
                 } else if (type === 'WFS') {
@@ -508,10 +508,10 @@ const Viewer = function Viewer(targetOption, options = {}) {
                   obj.content = getAttributes(feature, layer);
                   obj.layer = layer;
                   const centerGeometry = getcenter(feature.getGeometry());
-                  // FIXME: showOverlay option is undocumented and behaviour is probably not the desired. 
+                  // FIXME: showOverlay option is undocumented and behaviour is probably not the desired.
                   const infowindowType = featureinfoOptions.showOverlay === false ? 'sidebar' : 'overlay';
-                  // Don't auto pan as we're zooming in anyway on the next row. 
-                  featureinfo.render([obj], infowindowType, centerGeometry, { ignorePan : true});
+                  // Don't auto pan as we're zooming in anyway on the next row.
+                  featureinfo.render([obj], infowindowType, centerGeometry, { ignorePan: true });
                   map.getView().fit(feature.getGeometry(), {
                     maxZoom: getResolutions().length - 2,
                     padding: [15, 15, 40, 15],


### PR DESCRIPTION
Fixes #1405 by disabling the pan to overlay before search zooms to the search result feature, as the pan will be overrun anyway.

Added an option to disable panning when displaying popup as the panning animation was created using relative coordinates which became incorrect when immediately zooming to another extent. Also changed all known places where render() is called to support or make use of the option too keep old behavior.
