### PR TITLE
Adds option to add prefix/suffix to attribute value

### DIFF
--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -69,11 +69,19 @@ const getContent = {
   name(feature, attribute, attributes, map) {
     let val = '';
     let title = '';
+    let prefix = '';
+    let suffix = '';
     const featureValue = feature.get(attribute.name) === 0 ? feature.get(attribute.name).toString() : feature.get(attribute.name);
     if (featureValue) {
       val = featureValue;
       if (attribute.title) {
         title = `<b>${attribute.title}</b>`;
+      }
+      if (attribute.prefix) {
+        prefix = attribute.prefix;
+      }
+      if (attribute.suffix) {
+        suffix = attribute.suffix;
       }
       if (attribute.url) {
         val = buildUrlContent(feature, attribute, attributes, map);
@@ -83,7 +91,7 @@ const getContent = {
     if (typeof (attribute.cls) !== 'undefined') {
       newElement.classList.add(attribute.cls);
     }
-    newElement.innerHTML = `${title}${val}`;
+    newElement.innerHTML = `${title}${prefix}${val}${suffix}`;
     return newElement;
   },
   url(feature, attribute, attributes, map) {


### PR DESCRIPTION
Closes #1414 

Example config:
```
"attributes": [
  {
  	  "name":"length",
          "title": "Length: ",
          "prefix": "about ",
          "suffix": " km"
  }
]
```