### PR TITLE
Allows additional URL parameters in the Search control and a custom search string parameter name

### DIFF
--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -42,7 +42,8 @@ const Search = function Search(options = {}) {
 
   const {
     geometryAttribute,
-    url
+    url,
+    customQueryParameter
   } = options;
 
   let searchDb = {};
@@ -330,7 +331,7 @@ const Search = function Search(options = {}) {
     };
 
     function makeRequest(reqHandler, obj) {
-      let queryUrl = `${url}${url.indexOf('?') !== -1 ? '&' : '?'}q=${encodeURI(obj.value)}`;
+      let queryUrl = `${url}${url.indexOf('?') !== -1 ? '&' : '?'}${customQueryParameter || 'q'}=${encodeURI(obj.value)}`;
       if (includeSearchableLayers) {
         queryUrl += `&l=${viewer.getSearchableLayers(searchableDefault)}`;
       }

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -330,7 +330,7 @@ const Search = function Search(options = {}) {
     };
 
     function makeRequest(reqHandler, obj) {
-      let queryUrl = `${url}?q=${encodeURI(obj.value)}`;
+      let queryUrl = `${url}${url.indexOf('?') !== -1 ? '&' : '?'}q=${encodeURI(obj.value)}`;
       if (includeSearchableLayers) {
         queryUrl += `&l=${viewer.getSearchableLayers(searchableDefault)}`;
       }

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -43,7 +43,7 @@ const Search = function Search(options = {}) {
   const {
     geometryAttribute,
     url,
-    customQueryParameter
+    queryParameterName = 'q'
   } = options;
 
   let searchDb = {};
@@ -331,7 +331,7 @@ const Search = function Search(options = {}) {
     };
 
     function makeRequest(reqHandler, obj) {
-      let queryUrl = `${url}${url.indexOf('?') !== -1 ? '&' : '?'}${customQueryParameter || 'q'}=${encodeURI(obj.value)}`;
+      let queryUrl = `${url}${url.indexOf('?') !== -1 ? '&' : '?'}${queryParameterName}=${encodeURI(obj.value)}`;
       if (includeSearchableLayers) {
         queryUrl += `&l=${viewer.getSearchableLayers(searchableDefault)}`;
       }


### PR DESCRIPTION
Fixes #1418.

Checks if the `url` already has a parameter question mark (and possibly additional parameters) before adding a new one.

Now, URLs such as `http://localhost:3001/origoserver/search?limit=10` will work.

Also adds a new config option for the Search control: `queryParameterName` that defaults to `q` and can be used to change the name of the query parameter if connecting to some other external service.