### PR TITLE
HTMLElement as modal content

### DIFF
--- a/src/ui/modal.js
+++ b/src/ui/modal.js
@@ -3,10 +3,25 @@ import Element from './element';
 import Button from './button';
 import { html } from './dom/dom';
 
+/**
+ * Creates a modal and displays it. The modal is created as a div tag that is attached to the DOM as a child of the options.target element.
+ * @param {any} options Object containing options for the modal. Valid options are:
+ *  title: Title of modal
+ *  content: The content to display. String containing html
+ *  contentElement: HTMLElement containing the content. If specified the 'content' param is ignored.
+ *  cls: Optional classes to append to the modal container div
+ *  static: true if modal must be explicitly closed
+ *  target: DOM element to wich modal div is appended as a child. Required. Most likely the viewer element.
+ *  closeIcon: name of icon to use as close button. Defaults to a cross.
+ *  style: html style attributes to add to modal div
+ *  newTabUrl: URL to create a link button to
+ *  @returns {any} A Component representing the modal.
+ */
 export default function Modal(options = {}) {
   const {
     title = '',
     content = '',
+    contentElement,
     cls = '',
     isStatic = options.static,
     target,
@@ -72,7 +87,7 @@ export default function Modal(options = {}) {
 
       contentEl = Element({
         cls: 'o-modal-content',
-        innerHTML: `${content}`
+        innerHTML: contentElement || `${content}`
       });
 
       this.addComponent(screenEl);

--- a/src/ui/modal.js
+++ b/src/ui/modal.js
@@ -11,7 +11,7 @@ import { html } from './dom/dom';
  *  contentElement: HTMLElement containing the content. If specified the 'content' param is ignored.
  *  cls: Optional classes to append to the modal container div
  *  static: true if modal must be explicitly closed
- *  target: DOM element to wich modal div is appended as a child. Required. Most likely the viewer element.
+ *  target: ID of DOM element to wich modal div is appended as a child. Required. Most likely the viewer element.
  *  closeIcon: name of icon to use as close button. Defaults to a cross.
  *  style: html style attributes to add to modal div
  *  newTabUrl: URL to create a link button to
@@ -87,7 +87,7 @@ export default function Modal(options = {}) {
 
       contentEl = Element({
         cls: 'o-modal-content',
-        innerHTML: contentElement || `${content}`
+        innerHTML: `${content}`
       });
 
       this.addComponent(screenEl);
@@ -96,6 +96,12 @@ export default function Modal(options = {}) {
 
       this.on('render', this.onRender);
       document.getElementById(target).appendChild(html(this.render()));
+      // Now the modal exists in DOM. Append the DOM content (if any).
+      if (contentElement) {
+        const contentDOMEl = document.getElementById(contentEl.getId());
+        contentDOMEl.innerHTML = '';
+        contentDOMEl.appendChild(contentElement);
+      }
       this.dispatch('render');
     },
     onRender() {


### PR DESCRIPTION
Closes #1406 

Added possibility to specify the contents of a Modal as a `HTMLElement` object in order to pre build the contents complete with eventhandlers and all.

This PR adds a `contentElement` parameter to Modal constructor options. The `contentElement`  should be a  `HTMLElement` containing the content. If present, it takes precedence over the `content` option.

Hard to test, as it is only an api change and not used anywhere, but can be tested by calling `Origo.ui.Modal()` from console and also by regression tests of existing modals.

As a note this feature could probably have been implemented by allowing either text or HTMLElement in the content option, but in order to keep absolute backwards compability it is implemented as a new option. There is a small risk that the implementation of performing a toString() operation on the content value serves some purpose with certain content if it in fact is not a string already.