### PR TITLE
Format the datetime value

### DIFF
--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -83,6 +83,13 @@ const getContent = {
       if (attribute.suffix) {
         suffix = attribute.suffix;
       }
+      if (attribute.formatDatetime) {
+        if (!Number.isNaN(Date.parse(featureValue))) {
+          const locale = 'locale' in attribute.formatDatetime ? attribute.formatDatetime.locale : 'default';
+          const options = 'options' in attribute.formatDatetime ? attribute.formatDatetime.options : { dateStyle: 'full', timeStyle: 'long' };
+          val = new Intl.DateTimeFormat(locale, options).format(Date.parse(featureValue));
+        }
+      }
       if (attribute.url) {
         val = buildUrlContent(feature, attribute, attributes, map);
       }


### PR DESCRIPTION
Format the datetime value if it is a valid datetime otherwise leave as is.

Example of how the datetime can be formatted:

```
{
  "name":"dateLastPreparation",
  "title": "Senast preparerad: ",
  "formatDatetime": {"locale": "sv-SE", "options": { "dateStyle": "full", "timeStyle": "long" }}
}
```

```
{
  "name":"dateLastPreparation",
  "title": "Senast preparerad: ",
  "formatDatetime": {"locale": "en-US", "options": { "weekday": "long", "year": "numeric", "month": "long", "day": "numeric" }}
}

```

More formatting options can be found here: 
[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat)

Test config:
[https://kartatest.sundsvall.se/test/index.json](https://kartatest.sundsvall.se/test/index.json)

Closes #1421 