### PR TITLE
Monkey patch OL to correct position of mouse events in print preview

### DIFF
--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -5,6 +5,7 @@ import TileImage from 'ol/source/TileImage';
 import TileWMSSource from 'ol/source/TileWMS';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import { Group } from 'ol/layer';
+import PluggableMap from 'ol/PluggableMap';
 import {
   Button, Component, cuid, dom
 } from '../../ui';
@@ -16,6 +17,34 @@ import PrintToolbar from './print-toolbar';
 import { downloadPNG, downloadPDF, printToScalePDF } from '../../utils/download';
 import { afterRender, beforeRender } from './download-callback';
 import maputils from '../../maputils';
+/** Backup of original OL function */
+const original = PluggableMap.prototype.getEventPixel;
+
+/**
+ * Recalculates the event position to account for transform: scale in the container as OL does not do that.
+ * Used to monkey patch OL.
+ * @param {any} event
+ */
+const getEventPixelScale = function monkeyPatch(event) {
+  // This is internal in OL, nust allow
+  // eslint-disable-next-line no-underscore-dangle
+  const viewportPosition = this.viewport_.getBoundingClientRect();
+  let size = [viewportPosition.width, viewportPosition.height];
+  const view = this.getView();
+  if (view) {
+    // This is internal in OL, nust allow
+    // eslint-disable-next-line no-underscore-dangle
+    size = view.getViewportSize_();
+  }
+  const eventPosition = 'changedTouches' in event ? event.changedTouches[0] : event;
+
+  return [
+    ((eventPosition.clientX - viewportPosition.left) * size[0])
+    / viewportPosition.width,
+    ((eventPosition.clientY - viewportPosition.top) * size[1])
+    / viewportPosition.height
+  ];
+};
 
 const PrintComponent = function PrintComponent(options = {}) {
   const {
@@ -393,6 +422,10 @@ const PrintComponent = function PrintComponent(options = {}) {
       printMapComponent.dispatch('change:toggleNorthArrow', { showNorthArrow });
     },
     close() {
+      // Restore monkey patch
+      // WORKAROUND: Remove when OL supports transform: scale
+      // See https://github.com/openlayers/openlayers/issues/13283
+      PluggableMap.prototype.getEventPixel = original;
       // Restore scales
       if (!supressResolutionsRecalculation) {
         const viewerResolutions = viewer.getResolutions();
@@ -479,6 +512,10 @@ const PrintComponent = function PrintComponent(options = {}) {
       });
     },
     onRender() {
+      // Monkey patch OL
+      // WORKAROUND: Remove when OL supports transform: scale
+      // See https://github.com/openlayers/openlayers/issues/13283
+      PluggableMap.prototype.getEventPixel = getEventPixelScale;
       printScale = 0;
       today = new Date(Date.now());
       viewerMapTarget = map.getTarget();


### PR DESCRIPTION
Fixes #1422

__Beware__: this is a monkey patch that overrides an internal OL function and may very well break when OL is updated.

In order to minimise side effects, the monkey patch is only active when print preview is active.

Not all events are fixed with this PR as they internally in OL uses another way of calculating the position of the event. Pinch zoom and pan are among those interaction that is not fixed.