### PR TITLE
Fix to support id parameter on wfs layers in sharemap

### DIFF
--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -253,9 +253,11 @@ const PrintComponent = function PrintComponent(options = {}) {
     const widthInMm = orientation === 'portrait' ? sizes[size][1] : sizes[size][0];
     widthImage = orientation === 'portrait' ? Math.round((sizes[size][1] * resolution) / 25.4) : Math.round((sizes[size][0] * resolution) / 25.4);
     heightImage = orientation === 'portrait' ? Math.round((sizes[size][0] * resolution) / 25.4) : Math.round((sizes[size][1] * resolution) / 25.4);
-    const scaleResolution = scale / getPointResolution(map.getView().getProjection(),
+    const scaleResolution = scale / getPointResolution(
+      map.getView().getProjection(),
       resolution / 25.4,
-      map.getView().getCenter());
+      map.getView().getCenter()
+    );
     printMapComponent.dispatch('change:setDPI', { resolution });
     pageElement.style.width = `${widthImage}px`;
     pageElement.style.height = `${heightImage}px`;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -474,27 +474,38 @@ const Viewer = function Viewer(targetOption, options = {}) {
           });
 
           if (urlParams.feature) {
-            let featureId = urlParams.feature;
+            const featureId = urlParams.feature;
             const layerName = featureId.split('.')[0];
             const layer = getLayer(layerName);
-
-            if (layer && layer.get('type') !== 'GROUP') {
-              const clusterSource = layer.getSource().source;
-              const id = featureId.split('.')[1];
+            const layerType = layer.get('type');
+            if (layer && layerType !== 'GROUP') {
               // FIXME: postrender event is only emitted if any features from a layer is actually drawn, which means there is no feature in the default extent,
               // it will not be triggered until map is panned or zoomed where a feature exists.
               layer.once('postrender', () => {
+                const clusterSource = layer.getSource().source;
+                // Assume that id is just the second part of the argumment and adjust it for special cases later.
+                let id = featureId.split('.')[1];
                 let feature;
+
+                if (layerType === 'WFS') {
+                  // WFS uses the layername as a part of the featureId. Problem is that it what the server think is the name that matters.
+                  // First we assume that the layername is actually correct, then take the special cases
+                  let idLayerPart = layerName;
+                  const layerId = layer.get('id');
+                  if (layerId) {
+                    // if layer explicitly has set the id it takes precedense over name
+                    // layer name already have popped the namespace part, but id is untouched.
+                    idLayerPart = layerId.split(':').pop();
+                  } else if (layerName.includes('__')) {
+                    // If using the __-notation to use same layer several times, we must only use the actual layer name
+                    idLayerPart = layerName.split('__')[0];
+                  }
+                  // Build the correct WFS id
+                  id = `${idLayerPart}.${id}`;
+                }
                 // FIXME: ensure that feature is loaded. If using bbox and feature is outside default extent it will not be found.
                 // Workaround is to have a default extent covering the entire map with the layer in visible range or use strategy all
-                if (layer.get('type') === 'WFS' && clusterSource) {
-                  feature = clusterSource.getFeatureById(featureId);
-                } else if (layer.get('type') === 'WFS') {
-                  if (featureId.includes('__')) {
-                    featureId = featureId.replace(featureId.substring(featureId.lastIndexOf('__'), featureId.lastIndexOf('.')), '');
-                  }
-                  feature = layer.getSource().getFeatureById(featureId);
-                } else if (clusterSource) {
+                if (clusterSource) {
                   feature = clusterSource.getFeatureById(id);
                 } else {
                   feature = layer.getSource().getFeatureById(id);


### PR DESCRIPTION
Fixes #1446 

Uses the value from the id-option (if present) on wfs layers to construct the featureId when opening a shared map. The id option takes precedence over layer name as that's how the layer is created, 
