### PR TITLE
Export selection to local file

### DIFF
--- a/src/infowindow.js
+++ b/src/infowindow.js
@@ -1,4 +1,5 @@
 import { simpleExportHandler, layerSpecificExportHandler } from './infowindow_exporthandler';
+import exportToFile from './utils/exporttofile';
 
 let parentElement;
 let mainContainer;
@@ -293,10 +294,30 @@ function createSubexportComponent(selectionGroup) {
       });
       subexportContainer.appendChild(exportBtn);
     } else {
+      // TOOD: Is this logging really necessary?
       console.warn(`Export is not allowed for selection group: ${selectionGroup}`);
     }
-  } else {
-    console.warn(`Neither Specific Export is specified for selection group: ${selectionGroup} nor Simple Export is allowed!`);
+  } else if (exportOptions.clientExport) {
+    const conf = exportOptions.clientExport;
+    const exportAllowed = !conf.layers || conf.layers.find((l) => l === selectionGroup);
+    if (exportAllowed) {
+      const exportBtn = createExportButton(conf.buttonText || 'Exportera');
+      const btn = exportBtn.querySelector('button');
+      btn.addEventListener('click', () => {
+        exportBtn.loadStart();
+        const selectedItems = selectionManager.getSelectedItemsForASelectionGroup(selectionGroup);
+        const features = selectedItems.map(i => i.getFeature());
+        exportToFile(features, conf.format, {
+          featureProjection: viewer.getProjection().getCode(),
+          filename: selectionGroup
+        });
+        exportBtn.loadStop();
+      });
+      subexportContainer.appendChild(exportBtn);
+    } else {
+      // TOOD: Is this logging really necessary?
+      console.warn(`Neither Specific Export is specified for selection group: ${selectionGroup} nor Simple Export is allowed!`);
+    }
   }
 
   return subexportContainer;

--- a/src/infowindow.js
+++ b/src/infowindow.js
@@ -222,10 +222,6 @@ function createSubexportComponent(selectionGroup) {
   const subexportContainer = document.createElement('div');
   subexportContainer.classList.add('export-buttons-container');
 
-  if (activeLayer.get('type') === 'GROUP') {
-    console.warn('The selected layer is a LayerGroup, be careful!');
-  }
-
   if (exportOptions.layerSpecificExport) {
     layerSpecificExportOptions = exportOptions.layerSpecificExport.find((i) => i.layer === selectionGroup);
   }
@@ -293,9 +289,6 @@ function createSubexportComponent(selectionGroup) {
         });
       });
       subexportContainer.appendChild(exportBtn);
-    } else {
-      // TOOD: Is this logging really necessary?
-      console.warn(`Export is not allowed for selection group: ${selectionGroup}`);
     }
   } else if (exportOptions.clientExport) {
     const conf = exportOptions.clientExport;
@@ -314,9 +307,6 @@ function createSubexportComponent(selectionGroup) {
         exportBtn.loadStop();
       });
       subexportContainer.appendChild(exportBtn);
-    } else {
-      // TOOD: Is this logging really necessary?
-      console.warn(`Neither Specific Export is specified for selection group: ${selectionGroup} nor Simple Export is allowed!`);
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,3 +117,4 @@ export default {
 };
 
 export { default as slugify } from './utils/slugify';
+export { default as exportToFile } from './utils/exporttofile';

--- a/src/utils/exporttofile.js
+++ b/src/utils/exporttofile.js
@@ -1,0 +1,73 @@
+import GPXFormat from 'ol/format/GPX';
+import GeoJSONFormat from 'ol/format/GeoJSON';
+import KMLFormat from 'ol/format/KML';
+// TODO: move to maputils?
+
+/**
+ * Exports the given features to a file that is downloaded to the client.
+ * @param {any} features
+ * @param {'gpx' | 'geojson' | 'kml'} format Filetype.
+ * @param {Object} opts Object with options
+ * @param {any} opts.featureProjection The coordinatesystem that the features have on form 'EPSG:4326'.
+ * @param {any} [opts.filename] Suggested filename without extension. Defaults to 'origoexport'
+ * @returns {boolean} false if export failed
+ */
+const exportToFile = function exportToFile(features, format, opts = {}) {
+  const {
+    featureProjection,
+    filename = 'origoexport'
+  } = opts;
+  // None of the currently implemented formats supports custom CRS (well GeoJson can, but is not standard)
+  // If a format that supports custom CRS, dataProjection should be promoted to an optional parameter.
+  const dataProjection = 'EPSG:4326';
+  let formatter;
+
+  switch (format) {
+    case 'geojson':
+      formatter = new GeoJSONFormat();
+      break;
+    case 'gpx':
+      formatter = new GPXFormat();
+      break;
+    case 'kml':
+      formatter = new KMLFormat();
+      break;
+    // More formats could be added if desired, but some are not implemented as OL does not implement a writer, amd some because they are obscure.
+    // False as there will be no export
+    default: return false;
+  }
+  const formatterOptions = {
+    rightHanded: true,
+    dataProjection,
+    featureProjection
+  };
+
+  // Convert features to the specified format using the provided parameters
+  const bytes = formatter.writeFeatures(features, formatterOptions);
+
+  // Create the "file"
+  // always use octet/stream to force download if download-attrib is not supported on anchor tag
+  const data = new Blob([bytes], { type: 'octet/stream' });
+  const url = window.URL.createObjectURL(data);
+
+  // Let's play dirty. It is not possible to save a file progamaticallay (yet, it is in the making in saveAs),
+  // so we create a link that we click programatically
+  const el = document.createElement('a');
+  el.download = `${filename}.${format}`;
+  el.href = url;
+
+  el.addEventListener('click', () => {
+    // Schedule our own clean up to be performed when download has been performed, otherwise file is lost
+    // As download is performed in the same thread, we don't have to wait for anything special, just yield the thread.
+    setTimeout(() => {
+      // Must revoke object, otherwise there will be a memory leak.
+      window.URL.revokeObjectURL(url);
+    }, 0);
+  });
+  el.click();
+
+  // We did everyting we could check OK. If the user actually proceedes to save the file is beyond our knowledge
+  return true;
+};
+
+export default exportToFile;


### PR DESCRIPTION
Closes #1429

Adds an _export to file_ button to _infoWindow_.

Also exposes a utility function in the `Origo.Utils` "namespace" to export arbitrary features. Usage is documented in code.

Config by adding something like this to the `infoWindowoptions.export` configuration. It has the lowest precedence of the three kinds of export.

```
 "clientExport": {
          "buttonText" : "Exportera fil",
          "layers": [ "SketchMultiPoint", "To2018_Swe99TMWhatever" ],
          "format": "geojson"
        }
```

`format` is the file extension of the file format to export. Currently supported is `'geojson'`, `'gpx'` and `'kml'` . In theory more formats are supported by openlayers, but I picked the subset that can be drag and dropped and has the writeFeatures function implemented.

`layers` specifies the SelectionGroup name for those layers that are allowed to export from. If omitted, all layers are allowed.

In theory the configuration could have been incorporated in the simpleExport and layerSpecificExport using only a `format` option instead of url, but for simplicity and future proofing I made it a new kind of export.

__Known issues__
GPX only exports lines and multi lines. Not my fault, that's the way openlayers does it.

Exported GeoJson files does not contain coordinate system information. This is according to specification, but could be perceived as a flaw as it is common to include a `crs` property.

Exported features contains a property `"state" : "selected"` if they are highlighted. This is the result of how selectionManager handles selected features (which seems a bit dangerous, as 'state' is not unlikely to appear as a field in the data).