### PR TITLE
Added transformCoordinate to maputils

### DIFF
--- a/src/maputils.js
+++ b/src/maputils.js
@@ -1,4 +1,5 @@
 import Projection from 'ol/proj/Projection';
+import { transform } from 'ol/proj';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
@@ -190,6 +191,9 @@ const maputils = {
     viewer.getMap().addOverlay(overlay);
     overlay.setPosition(coordinates);
     return layer;
+  },
+  transformCoordinate: function transformCoordinate(coordinate, source, destination) {
+    return transform(coordinate, source, destination);
   }
 };
 


### PR DESCRIPTION
Fixes #1449 
Used like this:
_transformCoordinate(coordinate, source, destination)_

origo.api().getMapUtils().transformCoordinate([13.5,59.38],'EPSG:4326','EPSG:3857')

Can be used to set center in another coordinate system:
origo.api().getMap().getView().setCenter(origo.api().getMapUtils().transformCoordinate([13.5,59.38],'EPSG:4326','EPSG:3857'));

(Coordinate systems must be defined in the config unless using EPSG:3857 or EPSG:4326)