### PR TITLE
fix: make print preview not crash when drag and dropped layer present…

### DIFF
--- a/src/controls/print/print-legend.js
+++ b/src/controls/print/print-legend.js
@@ -124,7 +124,9 @@ const LayerRow = function LayerRow(options) {
       const style = viewer.getStyle(layer.get('styleName'));
       if (style && style[0]) {
         content = getStyleContent(title, style);
-      } else if (!layer.get('type').includes('AGS')) {
+      } else if ((!layer.get('type')) || (layer.get('type').includes('AGS'))) {
+        content = getTitleWithIcon(title, '');
+      } else {
         content = await getJSONContent(title);
       }
       return `

--- a/src/controls/print/print-resize.js
+++ b/src/controls/print/print-resize.js
@@ -424,7 +424,7 @@ export default function PrintResize(options = {}) {
         // Remove styles instead?
         const styles = feature.getStyle();
         const scale = 1;
-        if (styles) {
+        if (Array.isArray(styles)) {
           styles.forEach(style => {
             const image = style.getImage();
             if (image) {


### PR DESCRIPTION
…; show theirs and other missing titles in legend. Proposes to fix #1466 

I tried to make more layers make it into the legend list, to not make seemingly arbitrary layers not show up even with a title.
(Further along more styles should show up of course incl default ones)

Tested with .gpx and .kml layers added as well as ags_feature and wfs and wms layers with and without styles, entered printed exited did the same and changed the resolution.