### PR TITLE
Support for changing share map hash

### DIFF
--- a/origo.js
+++ b/origo.js
@@ -25,6 +25,7 @@ import { renderSvgIcon } from './src/utils/legendmaker';
 import SelectedItem from './src/models/SelectedItem';
 import 'elm-pep';
 import 'pepjs';
+import permalink from './src/permalink/permalink';
 
 const Origo = function Origo(configPath, options = {}) {
   /** Reference to the returned Component */
@@ -112,9 +113,13 @@ const Origo = function Origo(configPath, options = {}) {
       .catch(error => console.error(error));
   };
   // Add a listener to handle a new sharemap when using hash format.
-  window.addEventListener('hashchange', () => {
-    // "Reboot" the application by creating a new viewer instance using the original configuration and the new sharemap state
-    initViewer();
+  window.addEventListener('hashchange', (ev) => {
+    const newParams = permalink.parsePermalink(ev.newURL);
+
+    if (newParams.map) {
+      // "Reboot" the application by creating a new viewer instance using the original configuration and the new sharemap state
+      initViewer();
+    }
   });
 
   return ui.Component({

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -14,7 +14,6 @@ import Layer from './layer';
 import Main from './components/main';
 import Footer from './components/footer';
 import flattenGroups from './utils/flattengroups';
-import getAttributes from './getattributes';
 import getcenter from './geometry/getcenter';
 import isEmbedded from './utils/isembedded';
 


### PR DESCRIPTION
Resolves #1453.

This PR makes it possible to update the hash part of the url to change to another sharemap state.

The map is completely "rebooted" to fully reflect the new incoming map state. In order to do so without messing around too much in the viewer a completely new Viewer is created instead of trying to restore all state. As a new viewer is created, external code that uses the `'load'`-event should also reinitialise itself using the new viewer.