### PR TITLE
Allow custom URL parameters in WFS sources

### DIFF
--- a/src/layer/wfssource.js
+++ b/src/layer/wfssource.js
@@ -102,7 +102,7 @@ class WfsSource extends VectorSource {
     }
 
     // Create the complete URL
-    let url = [`${serverUrl}?service=WFS`,
+    let url = [`${serverUrl}${serverUrl.indexOf('?') < 0 ? '?' : '&'}service=WFS`,
       `&version=1.1.0&request=GetFeature&typeName=${this._options.featureType}&outputFormat=application/json`,
       `&srsname=${this._options.dataProjection}`].join('');
     url += queryFilter;


### PR DESCRIPTION
Fixes #1470.

When constructing the WFS source URL, any parameters included will be kept and further parameters from Origo will be appended after an ampersand (&).

If a custom parameter would be in conflict with a parameter added by Origo, Origos parameter should override the custom parameter on account of being added last.