### PR TITLE
fix: fix geoserver wms theme layer print legend

### DIFF
--- a/src/controls/print/print-legend.js
+++ b/src/controls/print/print-legend.js
@@ -122,7 +122,7 @@ const LayerRow = function LayerRow(options) {
       let content = '';
 
       const style = viewer.getStyle(layer.get('styleName'));
-      if (style && style[0]) {
+      if (style && style[0] && (!style[0][0].extendedLegend)) {
         content = getStyleContent(title, style);
       } else if ((!layer.get('type')) || (layer.get('type').includes('AGS'))) {
         content = getTitleWithIcon(title, '');


### PR DESCRIPTION
Aims to fix #1488 

If a layer style definition has the extendedLegend-property (meaning true) the affected function will land at
```javascript
      } else {
        content = await getJSONContent(title);
```

which will for a Geoserver 2.16+ return rules for a pretty theme legend and for others, like an ArcGIS Server with WMS layers, return the title of the layer with no icon, even when printing an Image. #1484 