### PR TITLE
fix: make print attempt to grip the correct styleSheet for rescaling …

### DIFF
--- a/src/controls/print/print-resize.js
+++ b/src/controls/print/print-resize.js
@@ -48,14 +48,18 @@ export default function PrintResize(options = {}) {
   };
 
   const getCssRule = function getCssRule(selector) {
-    const origoStyleSheet = viewer.getOrigoCSS();
-    const rules = origoStyleSheet.cssRules;
-    for (let i = 0; i < rules.length; i += 1) {
-      if (rules[i].selectorText === selector) {
-        return rules[i];
-      }
+    let soughtRule;
+    try {
+      Array.from(document.styleSheets).some((sheet) => Array.from(sheet.cssRules).some((cssRule) => {
+        if (cssRule.selectorText === selector) {
+          soughtRule = cssRule;
+          return true;
+        } return false;
+      }));
+    } catch (error) {
+      console.warn(error);
     }
-    return undefined;
+    return soughtRule;
   };
 
   const getVisibleLayers = function getVisibleLayers() {

--- a/src/controls/print/print-resize.js
+++ b/src/controls/print/print-resize.js
@@ -48,7 +48,8 @@ export default function PrintResize(options = {}) {
   };
 
   const getCssRule = function getCssRule(selector) {
-    const rules = document.styleSheets[0].cssRules;
+    const origoStyleSheet = Array.from(document.styleSheets).find(sheet => sheet.href && sheet.href.includes('css/style.css'));
+    const rules = origoStyleSheet.cssRules;
     for (let i = 0; i < rules.length; i += 1) {
       if (rules[i].selectorText === selector) {
         return rules[i];

--- a/src/controls/print/print-resize.js
+++ b/src/controls/print/print-resize.js
@@ -48,7 +48,7 @@ export default function PrintResize(options = {}) {
   };
 
   const getCssRule = function getCssRule(selector) {
-    const origoStyleSheet = Array.from(document.styleSheets).find(sheet => sheet.href && sheet.href.includes('css/style.css'));
+    const origoStyleSheet = viewer.getOrigoCSS();
     const rules = origoStyleSheet.cssRules;
     for (let i = 0; i < rules.length; i += 1) {
       if (rules[i].selectorText === selector) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -61,6 +61,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
   const center = urlParams.center || centerOption;
   const zoom = urlParams.zoom || zoomOption;
   const groups = flattenGroups(groupOptions);
+  let origoCSS = {};
 
   const getCapabilitiesLayers = () => {
     const capabilitiesPromises = [];
@@ -289,6 +290,8 @@ const Viewer = function Viewer(targetOption, options = {}) {
   const getEmbedded = function getEmbedded() {
     return isEmbedded(this.getTarget());
   };
+
+  const getOrigoCSS = () => origoCSS;
 
   const mergeSecuredLayer = (layerlist, capabilitiesLayers) => {
     if (capabilitiesLayers && Object.keys(capabilitiesLayers).length > 0) {
@@ -553,6 +556,11 @@ const Viewer = function Viewer(targetOption, options = {}) {
           this.addComponent(featureinfo);
 
           this.addControls();
+          origoCSS = Array.from(document.styleSheets).find(sheet => (
+            Array.from(sheet.cssRules).find(rule => (
+              rule.cssText.startsWith('.o-ui')
+            ))
+          ));
           this.dispatch('loaded');
         });
     },
@@ -614,6 +622,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
     getUrl,
     getUrlParams,
     getViewerOptions,
+    getOrigoCSS,
     removeGroup,
     removeOverlays,
     setStyle,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -61,7 +61,6 @@ const Viewer = function Viewer(targetOption, options = {}) {
   const center = urlParams.center || centerOption;
   const zoom = urlParams.zoom || zoomOption;
   const groups = flattenGroups(groupOptions);
-  let origoCSS = {};
 
   const getCapabilitiesLayers = () => {
     const capabilitiesPromises = [];
@@ -290,8 +289,6 @@ const Viewer = function Viewer(targetOption, options = {}) {
   const getEmbedded = function getEmbedded() {
     return isEmbedded(this.getTarget());
   };
-
-  const getOrigoCSS = () => origoCSS;
 
   const mergeSecuredLayer = (layerlist, capabilitiesLayers) => {
     if (capabilitiesLayers && Object.keys(capabilitiesLayers).length > 0) {
@@ -556,11 +553,6 @@ const Viewer = function Viewer(targetOption, options = {}) {
           this.addComponent(featureinfo);
 
           this.addControls();
-          origoCSS = Array.from(document.styleSheets).find(sheet => (
-            Array.from(sheet.cssRules).find(rule => (
-              rule.cssText.startsWith('.o-ui')
-            ))
-          ));
           this.dispatch('loaded');
         });
     },
@@ -622,7 +614,6 @@ const Viewer = function Viewer(targetOption, options = {}) {
     getUrl,
     getUrlParams,
     getViewerOptions,
-    getOrigoCSS,
     removeGroup,
     removeOverlays,
     setStyle,


### PR DESCRIPTION
…purposes. Attempts to fix #1483  . It is uncertain precisely which plugin caused the issue reporter's issue, perhaps the "Help" plugin they employ, it does however seem possible that it works in the same fashion as our version of the layermanager, i.e includes additional styleSheets.