### PR TITLE
Auto hide layers and save button in editor

### DIFF
--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -174,6 +174,14 @@ function init(options, v) {
   viewer = v;
   editHandler(options, v);
   render();
+  // Hide layers choice button if only 1 layer i editable
+  if (editableLayers.length < 2) {
+    $editLayers.classList.add('o-hidden');
+  }
+  // Hide save button if configured with autoSave
+  if (options.autoSave) {
+    $editSave.classList.add('o-hidden');
+  }
   editorLayers(editableLayers, {
     activeLayer: currentLayer
   }, v);

--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -174,9 +174,9 @@ function init(options, v) {
   viewer = v;
   editHandler(options, v);
   render();
-  // Hide layers choice button if only 1 layer i editable
+  // Hide layers choice button if only 1 layer in editable
   if (editableLayers.length < 2) {
-    $editLayers.classList.add('o-hidden');
+    $editLayers.parentNode.classList.add('o-hidden');
   }
   // Hide save button if configured with autoSave
   if (options.autoSave) {


### PR DESCRIPTION
Hides layer selector button when only one layer is editable.
Hides save button when autosave option is true.
Closes #1494 