### PR TITLE
Default values in editor

### DIFF
--- a/src/controls/editor/editform.js
+++ b/src/controls/editor/editform.js
@@ -146,7 +146,9 @@ const createForm = function createForm(obj) {
       el = `<div class="validate ${cls}"><label>${label}</label><br><input type="number" step="0.01" min="0" name="decimaltal" id="${id}" value="${val}"${readonly}${required}></div>`;
       break;
     case 'hidden':
-      el = `<input type="hidden ${cls}" id="${id}" value="${val}">`;
+      // Note that an input with type="hidden" is not the same as an input with class="o-hidden". Type hidden is to roundtrip values invisible to the user
+      // class o-hidden is to temporarily hide an input as logic in view says it should not be visible right now (batch edit or constraints).
+      el = `<input class="${cls}" type="hidden" id="${id}" value="${val}">`;
       break;
     default:
       break;


### PR DESCRIPTION
Closes #1495. 

Adds possibility to update feature variables from localStorage, sessionStorage or setting a timestamp. Configuration basically as in issue #1495, but `alwaysUpdate` is renamed to `updateOnEdit`  and added `useUTC` for timestamps to select between local time and UTC.

If type is timestamp it is possible to set a format depending on what the timestamp is for.
Time formats supported:
- `time` : hh:mm:ss. Used when database field is _time_ or _text_
- `date`: YYYY-MM-dd. Used when database field is _date_ or _text_
- `datetime`: "YYYY-MM-dd hh:mm:ss" Used when database field is text and you want a readable string.
- `timestamp`: Default. Can be parsed by most iso date time parsers. Used when database field is DateTime (or similar) or when using a _date_, _time_ or _datetime_ attribute type in editor.

As a bonus, the `hidden` attribute type is fixed.