### PR TITLE
Fix for #1476 and #1482 (correct styling upon exiting print view)

### DIFF
--- a/src/controls/print/print-resize.js
+++ b/src/controls/print/print-resize.js
@@ -412,39 +412,9 @@ export default function PrintResize(options = {}) {
     }
   };
 
-  // "Resets" layer by changing scale to 1 or removing DPI parameter
+  // "Resets" layer by removing DPI parameter
   const resetLayerScale = function resetLayerScale(layer) {
     const source = layer.getSource();
-
-    if (isVector(layer)) {
-      const features = source.getFeatures();
-      if (features && features.length) {
-        const feature = features[0];
-
-        // Remove styles instead?
-        const styles = feature.getStyle();
-        const scale = 1;
-        if (Array.isArray(styles)) {
-          styles.forEach(style => {
-            const image = style.getImage();
-            if (image) {
-              image.setScale(scale);
-            }
-
-            const stroke = style.getStroke();
-            if (stroke) {
-              const strokeWidth = stroke.getWidth();
-              stroke.setWidth(strokeWidth * (150 / resolution));
-            }
-
-            const text = style.getText();
-            if (text) {
-              text.setScale(scale);
-            }
-          });
-        }
-      }
-    }
 
     if (isImage(layer) && isValidSource(source)) {
       const params = source.getParams();
@@ -592,6 +562,8 @@ export default function PrintResize(options = {}) {
       isActive = true;
     },
     resetLayers() {
+      resolution = 150;
+      updateLayers();
       resetLayers();
       resetWfsThemeLayers();
       isActive = false;

--- a/src/controls/print/print-resize.js
+++ b/src/controls/print/print-resize.js
@@ -391,9 +391,7 @@ export default function PrintResize(options = {}) {
               text.setScale(textScale);
             }
           });
-          source.getFeatures().forEach(feature => {
-            feature.setStyle(newStyle);
-          });
+          layer.setStyle(newStyle);
         }
       }
     }


### PR DESCRIPTION
This PR contains fixes #1476 and fixes #1482.

It properly "resets" scaling by using the existing `setLayerScale` function using the "original" DPI value (currently hardcoded to 150 as in other parts of the code).

Selection style is corrected by setting the layer style rather than the style of individual features (fix written by @sweco-sefaed).