### PR TITLE
fix: allow styles subject to CORS to work with print - save image

### DIFF
--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -52,6 +52,7 @@ const mm2Pt = function convertMm2Pt(mm) {
 
 export const html2canvas = function html2canvas(el) {
   return convertHtml2canvas(el, {
+    useCORS: true,
     allowTaint: true,
     backgroundColor: null,
     logging: false,


### PR DESCRIPTION
Fixes #1484 so that Save image in print works for WMS layers with a style that references an URL elsewhere (subject to CORS); instead of a crash in the console (mine looks like
> Uncaught (in promise) DOMException: The operation is insecure.
)

styles not subject to CORS are (of course) not affected

If a remote style resides on a server not configured or not properly configured for CORS the Save image should now not crash but rather leave an empty space where the icon would be in the saved image legend

credits to @johnnyblasta who came up with the fix
