### PR TITLE
Fix lint errors

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,7 +8,11 @@ Origo uses OpenLayers as the map component. Development in Origo shall support v
 When developing, progressive enhancement is an encouraged strategy. That means that it is allowed to adopt new technology that may not be widely supported today but enhances the user experience in modern web browsers under the condition that the functionality is not critical.
 
 ## JavaScript
-Origo follows the [Airbnb's JavaScript Style Guide](https://github.com/airbnb/javascript) for EcmaScript 6.
+Origo follows the [Airbnb's JavaScript Style Guide](https://github.com/airbnb/javascript) for EcmaScript 6. There are npm scripts that can be used
+to verify that the code complies with the rules: `npm run lint`to check the code, `npm run lint-run` to run the _webpack dev server_ with lint enabled and
+`npm run lint-build` to lint and build. As the lint rules are also enforced when creating a pull request, there must be no errors in the code. If an error can not be avoided 
+it must be ignored by adding a _eslint_ ignore comment: `// eslint-disable-next-line <name-of-error>`. There should also be a comment that
+clearly states why it is ignored instead of fixed.
 
 We wish to promote modular development, and in order to do this we have chosen [webpack](https://github.com/webpack/webpack) as the bundler.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "origo.js",
   "scripts": {
     "start": "npm run prebuild-sass | run-p watch-js watch-sass",
-    "lint": "eslint -c .eslintrc.json src/**/*.js --fix",
+    "lint": "eslint -c .eslintrc.json origo.js src/**/*.js --fix",
     "lint-run": "npm run prebuild-sass | webpack-dev-server --config ./tasks/webpack.lint.dev.js --mode development",
     "lint-build": "webpack --config ./tasks/webpack.lint.prod.js && npm run build-sass | npm run copy-plugins | npm run copy",
     "watch-js": "webpack-dev-server --config ./tasks/webpack.dev.js --mode development",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "origo.js",
   "scripts": {
     "start": "npm run prebuild-sass | run-p watch-js watch-sass",
-    "lint": "eslint -c .eslintrc.json src/* --fix",
+    "lint": "eslint -c .eslintrc.json src/**/*.js --fix",
     "lint-run": "npm run prebuild-sass | webpack-dev-server --config ./tasks/webpack.lint.dev.js --mode development",
     "lint-build": "webpack --config ./tasks/webpack.lint.prod.js && npm run build-sass | npm run copy-plugins | npm run copy",
     "watch-js": "webpack-dev-server --config ./tasks/webpack.dev.js --mode development",

--- a/src/controls/editor/editorlayers.js
+++ b/src/controls/editor/editorlayers.js
@@ -6,7 +6,7 @@ const createElement = utils.createElement;
 
 let viewer;
 
-export default function editorLayers(editableLayers, optOptions = {}, v) {
+export default function editorLayers(editableLayers, v, optOptions = {}) {
   viewer = v;
   function selectionModel(layerNames) {
     const selectOptions = layerNames.map((layerName) => {

--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -182,9 +182,9 @@ function init(options, v) {
   if (options.autoSave) {
     $editSave.classList.add('o-hidden');
   }
-  editorLayers(editableLayers, {
+  editorLayers(editableLayers, v, {
     activeLayer: currentLayer
-  }, v);
+  });
   drawTools(options.drawTools, currentLayer, v);
 
   document.addEventListener('enableInteraction', onEnableInteraction);

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -7,7 +7,7 @@ import GroupList from './grouplist';
  * type is grouplayer, it will be treated as a subgroup
  * with tick all and untick check boxes.
  */
-const Group = function Group(options = {}, viewer) {
+const Group = function Group(viewer, options = {}) {
   const {
     icon = '#ic_chevron_right_24px',
     cls = '',

--- a/src/controls/legend/overlays.js
+++ b/src/controls/legend/overlays.js
@@ -36,7 +36,7 @@ const Overlays = function Overlays(options) {
 
   const groupCmps = viewer.getGroups().reduce((acc, group) => {
     if (nonGroupNames.includes(group.name)) return acc;
-    return acc.concat(Group(group, viewer));
+    return acc.concat(Group(viewer, group));
   }, []);
 
   groupCmps.forEach((groupCmp) => {
@@ -182,7 +182,7 @@ const Overlays = function Overlays(options) {
   };
 
   const addGroup = function addGroup(groupOptions) {
-    const groupCmp = Group(groupOptions, viewer);
+    const groupCmp = Group(viewer, groupOptions);
     groupCmps.push(groupCmp);
     if (groupCmp.type === 'grouplayer') {
       const parent = groupCmps.find((cmp) => cmp.name === groupCmp.parent);

--- a/src/controls/print/print-settings.js
+++ b/src/controls/print/print-settings.js
@@ -178,10 +178,10 @@ const PrintSettings = function PrintSettings(options = {}) {
         width: sizes.custom ? sizes.custom[1] : sizeCustomMinWidth,
         state: size === 'custom' ? 'active' : 'initial'
       });
-      setScaleControl = SetScaleControl({
+      setScaleControl = SetScaleControl(map, {
         scales,
         initialScale: scaleInitial
-      }, map);
+      });
 
       contentComponent = Component({
         onRender() { this.dispatch('render'); },

--- a/src/controls/print/set-scale-control.js
+++ b/src/controls/print/set-scale-control.js
@@ -1,7 +1,7 @@
 import { Dropdown, Component } from '../../ui';
 import mapUtils from '../../maputils';
 
-export default function SetScaleControl(options = {}, map) {
+export default function SetScaleControl(map, options = {}) {
   const {
     scales = [],
     initialScale

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -251,4 +251,7 @@ function getAttributes(feature, layer, map) {
   return content;
 }
 
-export { getAttributes as default, getContent };
+// export { getAttributes as default, getContent };
+
+export default getAttributes;
+export { getContent };

--- a/src/utils/isurl.js
+++ b/src/utils/isurl.js
@@ -1,4 +1,4 @@
 export default function isUrl(s) {
-  const regexp = new RegExp('^(?:[a-z]+:)?//', 'i');
+  const regexp = /^(?:[a-z]+:)?\/\//i;
   return regexp.test(s);
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -14,7 +14,6 @@ import Layer from './layer';
 import Main from './components/main';
 import Footer from './components/footer';
 import flattenGroups from './utils/flattengroups';
-import getAttributes from './getattributes';
 import getcenter from './geometry/getcenter';
 import isEmbedded from './utils/isembedded';
 


### PR DESCRIPTION
Fixes #1451 by obeying som rules. Also fixed that all files are linted independent of which npm script is run. (Sort of, `npm run lint` will lint all files in the src tree except those ignored in _.eslintignore_, the other scripts will lint what is actually bundled honoring _.eslintignore_ )

I also added some stuff to the documentation on how to lint.

