### PR TITLE
Print export progress, button disabling and slight Component refactor

### DIFF
--- a/scss/origo.scss
+++ b/scss/origo.scss
@@ -61,3 +61,32 @@ body {
   overflow: hidden;
   position: relative;
 }
+
+#loading {
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 9999999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-color: rgba(0, 0, 0, 0.7);
+
+  &.hide {
+    display: none;
+  }
+
+  // based on code from https://codepen.io/mandelid/pen/kNBYLJ
+  .loading-spinner {
+    display: inline-block;
+    width: 75px;
+    height: 75px;
+    border: 5px solid rgba(255,255,255,.3);
+    border-radius: 50%;
+    border-top-color: #fff;
+    animation: spin 1s ease-in-out infinite;
+  }
+}

--- a/scss/ui/helpers/_animations.scss
+++ b/scss/ui/helpers/_animations.scss
@@ -24,3 +24,7 @@
     opacity: 0;
   }
 }
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -330,7 +330,15 @@ const PrintComponent = function PrintComponent(options = {}) {
     viewerResolutions: originalResolutions
   });
   const printInteractionToggle = PrintInteractionToggle({ map, target, mapInteractionsActive, pageSettings: viewer.getViewerOptions().pageSettings });
+
   const printToolbar = PrintToolbar();
+  map.getAllLayers().forEach((l) => {
+    // if we begin loading any data we want to disable the print buttons...
+    l.getSource().on(["tileloadstart", "imageloadstart"], () => printToolbar.setDisabled(true));
+  });
+  // ...they then get re-enabled when the map has finished rendering
+  map.on('rendercomplete', () => printToolbar.setDisabled(false));
+
   return Component({
     name: 'printComponent',
     onInit() {

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -18,6 +18,7 @@ import { downloadPNG, downloadPDF, printToScalePDF } from '../../utils/download'
 import { afterRender, beforeRender } from './download-callback';
 import maputils from '../../maputils';
 import PrintResize from './print-resize';
+import { withLoading } from "../../loading";
 /** Backup of original OL function */
 const original = PluggableMap.prototype.getEventPixel;
 
@@ -487,12 +488,12 @@ const PrintComponent = function PrintComponent(options = {}) {
       printElement.remove();
     },
     async downloadPNG() {
-      await downloadPNG({
+      await withLoading(() => downloadPNG({
         afterRender: afterRender(map),
         beforeRender: beforeRender(map),
         filename: `${filename}.png`,
         el: pageElement
-      });
+      }));
     },
     async downloadPDF() {
       let height;
@@ -507,7 +508,7 @@ const PrintComponent = function PrintComponent(options = {}) {
         width = sizes[size][0];
         pdfOrientation = orientation;
       }
-      await downloadPDF({
+      await withLoading(() => downloadPDF({
         afterRender: afterRender(map),
         beforeRender: beforeRender(map),
         el: pageElement,
@@ -516,7 +517,7 @@ const PrintComponent = function PrintComponent(options = {}) {
         orientation: pdfOrientation,
         size,
         width
-      });
+      }));
     },
     async printToScalePDF() {
       let height;
@@ -531,17 +532,19 @@ const PrintComponent = function PrintComponent(options = {}) {
       }
       widthImage = orientation === 'portrait' ? Math.round((sizes[size][1] * resolution) / 25.4) : Math.round((sizes[size][0] * resolution) / 25.4);
       heightImage = orientation === 'portrait' ? Math.round((sizes[size][0] * resolution) / 25.4) : Math.round((sizes[size][1] * resolution) / 25.4);
-      await printToScalePDF({
-        el: pageElement,
-        filename,
-        height,
-        orientation: pdfOrientation,
-        size,
-        width,
-        printScale,
-        widthImage,
-        heightImage
-      });
+      await withLoading(() =>
+        printToScalePDF({
+          el: pageElement,
+          filename,
+          height,
+          orientation: pdfOrientation,
+          size,
+          width,
+          printScale,
+          widthImage,
+          heightImage
+        })
+      );
     },
     async onRender() {
       // Monkey patch OL

--- a/src/controls/print/print-toolbar.js
+++ b/src/controls/print/print-toolbar.js
@@ -35,6 +35,10 @@ const PrintToolbar = function PrintToolbar() {
         ${pngButton.render()}
         ${pdfButton.render()}
       </div>`;
+    },
+    setDisabled(disabled) {
+      pngButton.setState(disabled ? 'disabled' : 'initial');
+      pdfButton.setState(disabled ? 'disabled' : 'initial');
     }
   });
 };

--- a/src/controls/print/print-toolbar.js
+++ b/src/controls/print/print-toolbar.js
@@ -13,7 +13,6 @@ const PrintToolbar = function PrintToolbar() {
 
   return Component({
     onInit() {
-      this.addComponents([pngButton, pdfButton]);
       pngButton.on('click', this.dispatchExport.bind(this));
       pdfButton.on('click', this.dispatchPrint.bind(this));
     },
@@ -27,13 +26,13 @@ const PrintToolbar = function PrintToolbar() {
       this.dispatch('render');
     },
     render() {
-      return `
+      return this.html`
       <div
         class="flex box fixed bottom-center button-group divider-horizontal box-shadow rounded-large bg-inverted z-index-ontop-high no-print"
         style="height: 2rem;"
       >
-        ${pngButton.render()}
-        ${pdfButton.render()}
+        ${pngButton}
+        ${pdfButton}
       </div>`;
     },
     setDisabled(disabled) {

--- a/src/loading.js
+++ b/src/loading.js
@@ -1,0 +1,27 @@
+/**
+ * Show the global loading indicator
+ */
+export function showLoading() {
+  document.getElementById("loading").classList.remove("hide");
+}
+
+/**
+ * Hide the global loading indicator
+ */
+export function hideLoading() {
+  document.getElementById("loading").classList.add("hide");
+}
+
+/**
+ * Show the loading indicator while the promise runs
+ *
+ * @param {() => Promise<void>} cb
+ */
+export async function withLoading(cb) {
+  showLoading();
+  try {
+    await cb();
+  } finally {
+    hideLoading();
+  }
+}

--- a/src/ui/component.js
+++ b/src/ui/component.js
@@ -1,73 +1,105 @@
 import Cuid from 'cuid';
-import Eventer from './utils/eventer';
 import isComponent from './utils/iscomponent';
+import Eventer from "./utils/eventer";
 
-const Base = function Base() {
-  const id = Cuid();
-  let components = [];
+class Base {
+  constructor(options) {
+    this.id = Cuid();
+    this.components = [];
 
-  return {
-    addComponent(child) {
-      const evt = { target: this };
-      if (components.includes(child)) {
-        return child;
-      }
-      components.push(child);
-      child.dispatch('add', evt);
-      return child;
-    },
-    addComponents(children) {
-      children.forEach((child) => {
-        this.addComponent(child);
-      });
-    },
-    clearComponents() {
-      components.forEach((component) => {
-        component.dispatch('clear', { target: this });
-      });
-      components = [];
-    },
-    getComponents: () => components,
-    getId: () => id,
-    removeComponent(component) {
-      const index = components.indexOf(component);
-      if (index > -1) {
-        components.splice(index, 1);
-        component.dispatch('clear', { target: this });
+    // TODO: replace by inheriting from EventTarget
+    this._eventer = new Eventer();
+    this.on = this._eventer.on;
+    this.un = this._eventer.un;
+    this.dispatch = this._eventer.dispatch;
+
+    for (const [k, v] of Object.entries(options)) {
+      if (k === "onRender") {
+        // the onRender event is a special case; it will be run upon the `render` event from the parent component
+        this.on('add', (evt = {}) => {
+          if (evt.target && isComponent(evt.target)) {
+            const addListener = v.bind(this);
+            evt.target.on('render', addListener);
+            this.on('clear', () => {
+              evt.target.un('render', addListener);
+            });
+          }
+        });
+      } else if (k.length >= 5 && k.startsWith("on") && k[2].toUpperCase() === k[2]) {
+        const type = k.slice(2).toLowerCase();
+        this.on(type, v);
       }
     }
-  };
-};
+    Object.assign(this, options);
+  }
 
-const Component = function Component(options) {
-  const addAddListener = function addAddListener(component) {
-    const onAdd = function onAdd(evt = {}) {
-      if (evt.target) {
-        if (isComponent(evt.target)) {
-          const addListener = component.onRender.bind(component);
-          evt.target.on('render', addListener);
-          component.on('clear', () => {
-            evt.target.un('render', addListener);
-          });
-        }
+  addComponent(child) {
+    if (this.components.includes(child)) {
+      return child;
+    }
+    this.components.push(child);
+    child.dispatch('add', { target: this });
+    return child;
+  }
+  addComponents(children) {
+    children.forEach((child) => {
+      this.addComponent(child);
+    });
+  }
+  removeComponent(component) {
+    const index = this.components.indexOf(component);
+    if (index > -1) {
+      this.components.splice(index, 1);
+      component.dispatch('clear', { target: this });
+    }
+  }
+  clearComponents() {
+    this.components.forEach((component) => {
+      component.dispatch('clear', { target: this });
+    });
+    this.components = [];
+  }
+
+  getComponents() { return this.components; }
+  getId() { return this.id; }
+
+  /**
+   * This method can be used inside of component `render` functions for tagged template literals.
+   *
+   * It will call the render methods of interpolated child components, and also ensure that they are added as children
+   * to the rendered component. It will also inject the id of this component to the top level tag.
+   *
+   * @param {string[]} strings
+   * @param {(Base|any)[]} values
+   * @returns {string}
+   */
+  html(strings, ...values) {
+    const processValue = (v) => {
+      if (isComponent(v)) {
+        this.addComponent(v);
+        return v.render();
+      } else {
+        // convert to string as would usually be done in a template literal
+        return `${v}`;
       }
     };
-    component.on('add', onAdd);
-  };
 
-  const createComponent = function createComponent(component) {
-    if (component.onInit) {
-      component.on('init', component.onInit);
-    }
-    if (component.onAdd) {
-      component.on('add', component.onAdd);
-    } else if (component.onRender) {
-      addAddListener(component);
-    }
-    component.dispatch('init');
-    return Object.create(component);
-  };
-  return createComponent(Object.assign({}, Eventer(), Base(), options));
-};
+    const interpolated = strings.reduce(
+        (accum, str, idx) => accum + str + (idx < values.length ? processValue(values[idx]) : ''),
+        '');
 
-export default Component;
+    const firstRight = interpolated.indexOf('>');
+    if (interpolated.slice(0, firstRight).includes(' id="')) {
+      // top level tag already contains id, don't attempt to inject
+      return interpolated;
+    }
+    // inject id just before end of start tag
+    return interpolated.slice(0, firstRight-1) + ` id="${this.id}"` + interpolated.slice(firstRight);
+  }
+}
+
+export default function Component(options) {
+  const component = new Base(options);
+  component.dispatch('init');
+  return component;
+}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -24,10 +24,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
   let selectionmanager;
 
   let {
-    projection
-  } = options;
-
-  const {
+    projection,
     breakPoints,
     breakPointsPrefix,
     clsOptions = '',
@@ -561,6 +558,10 @@ const Viewer = function Viewer(targetOption, options = {}) {
                               ${main.render()}
                               ${footer.render()}
                             </div>
+                          </div>
+                              
+                          <div id="loading" class="hide">
+                            <div class="loading-spinner"></div>
                           </div>`;
       const el = document.querySelector(target);
       el.innerHTML = htmlString;


### PR DESCRIPTION
* Show a loading spinner while exporting to PDF (fixes #1359)
* Disable print export buttons while the map is updating (prevents accidental incomplete exports due to pending tiles)
* Refactor the base `Component` to make use of ES6 class syntax as well as introduce a convenience `html` tagged template literal for use in `render()` methods

The third point is introduced in a way so that it does not affect its interface. If wanted it can be extracted into a separate PR.