### PR TITLE
Editor checkbox value

### DIFF
--- a/src/controls/editor/editform.js
+++ b/src/controls/editor/editform.js
@@ -20,7 +20,6 @@ const createForm = function createForm(obj) {
   const required = obj.required ? ' required' : '';
   const name = obj.name ? obj.name : '';
   let el;
-  let checked;
   let firstOption;
   const maxLengthText = maxLength ? `, max ${obj.maxLength} tecken` : '';
   switch (type) {
@@ -31,8 +30,9 @@ const createForm = function createForm(obj) {
       el = `<div class="validate ${cls}"><label>${label}<br><textarea name="textarea${maxLengthText}" id="${id}" rows="3" ${maxLength}${readonly}${required}>${val}</textarea></label></div>`;
       break;
     case 'checkbox':
-      checked = val ? ' checked' : '';
-      el = `<div class="o-form-checkbox ${cls}"><label for="${id}">${label}<input type="checkbox" id="${id}" value="${val}"${checked}${disabled}></label></div>`;
+      const isChecked = obj.config && obj.config.uncheckedValue ? obj.config.uncheckedValue !== val : val;
+      const checked = isChecked ? ' checked' : '';
+      el = `<div class="o-form-checkbox ${cls}"><label for="${id}"><input type="checkbox" id="${id}" value="${val}"${checked}${disabled}/>${label}</label></div>`;
       break;
     case 'dropdown':
       if (val) {

--- a/src/controls/editor/editform.js
+++ b/src/controls/editor/editform.js
@@ -21,6 +21,7 @@ const createForm = function createForm(obj) {
   const name = obj.name ? obj.name : '';
   let el;
   let firstOption;
+  let checked;
   const maxLengthText = maxLength ? `, max ${obj.maxLength} tecken` : '';
   switch (type) {
     case 'text':
@@ -30,8 +31,7 @@ const createForm = function createForm(obj) {
       el = `<div class="validate ${cls}"><label>${label}<br><textarea name="textarea${maxLengthText}" id="${id}" rows="3" ${maxLength}${readonly}${required}>${val}</textarea></label></div>`;
       break;
     case 'checkbox':
-      const isChecked = obj.config && obj.config.uncheckedValue ? obj.config.uncheckedValue !== val : val;
-      const checked = isChecked ? ' checked' : '';
+      checked = (obj.config && obj.config.uncheckedValue ? obj.config.uncheckedValue !== val : val) ? ' checked' : '';
       el = `<div class="o-form-checkbox ${cls}"><label for="${id}"><input type="checkbox" id="${id}" value="${val}"${checked}${disabled}/>${label}</label></div>`;
       break;
     case 'dropdown':

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -768,8 +768,8 @@ function onAttributesSave(features, attrs) {
       if (!document.querySelector(containerClass) || document.querySelector(containerClass).classList.contains('o-hidden') === false) {
         // Check if checkbox. If checkbox read state.
         if (inputType === 'checkbox') {
-          const checkedValue = attribute.config && attribute.config.checkedValue || 1;
-          const uncheckedValue = attribute.config && attribute.config.uncheckedValue || 0;
+          const checkedValue = (attribute.config && attribute.config.checkedValue) || 1;
+          const uncheckedValue = (attribute.config && attribute.config.uncheckedValue) || 0;
           editEl[attribute.name] = document.getElementById(attribute.elId).checked ? checkedValue : uncheckedValue;
         } else { // Read value from input text, textarea or select
           editEl[attribute.name] = inputValue;

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -768,7 +768,9 @@ function onAttributesSave(features, attrs) {
       if (!document.querySelector(containerClass) || document.querySelector(containerClass).classList.contains('o-hidden') === false) {
         // Check if checkbox. If checkbox read state.
         if (inputType === 'checkbox') {
-          editEl[attribute.name] = document.getElementById(attribute.elId).checked ? 1 : 0;
+          const checkedValue = attribute.config && attribute.config.checkedValue || 1;
+          const uncheckedValue = attribute.config && attribute.config.uncheckedValue || 0;
+          editEl[attribute.name] = document.getElementById(attribute.elId).checked ? checkedValue : uncheckedValue;
         } else { // Read value from input text, textarea or select
           editEl[attribute.name] = inputValue;
         }

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -116,7 +116,7 @@ function getFeaturesByIds(type, layer, ids) {
 /**
  * Helper that calculates the default value for one attribute
  * @param {any} attribConf The list entry from "attributes"-configuration that default value should be calculated for
- * @returns The default value for provided attribute
+ * @returns The default value for provided attribute or undefined if no default value
  */
 function getDefaultValueForAttribute(attribConf) {
   const defaultsConfig = attribConf.defaultValue;
@@ -150,8 +150,12 @@ function getDefaultValueForAttribute(attribConf) {
           return isoDate.slice(0, 19);
       }
     }
+  } else if (attribConf.type === 'checkbox' && attribConf.config && attribConf.config.uncheckedValue) {
+    // Checkboxes defaults to unchecked value if no default value is specified. If no uncheckedValue is specified it
+    // will default to unchecked by some magic javascript falsly comparison later.
+    return attribConf.config.uncheckedValue;
   }
-  // Consistent return
+  // This attribute has no default value
   return undefined;
 }
 
@@ -161,10 +165,13 @@ function getDefaultValueForAttribute(attribConf) {
  * @returns {object} An object with attributes names as properties and the default value as value.
  */
 function getDefaultValues(attrs) {
-  return attrs.filter(attribute => attribute.name && attribute.defaultValue)
+  return attrs.filter(attribute => attribute.name)
     .reduce((prev, curr) => {
       const previous = prev;
-      previous[curr.name] = getDefaultValueForAttribute(curr);
+      const defaultValue = getDefaultValueForAttribute(curr);
+      if (defaultValue !== undefined) {
+        previous[curr.name] = defaultValue;
+      }
       return previous;
     }, {});
 }


### PR DESCRIPTION
Closes #1519 and fixes #1520.

Adds the possibility to add which values a checkbox should use for checked and unchecked. As a bonus the checkbox is moved to the left of the label.

checkedValue defaults to 1 (backwards compatible)
uncheckedValue defaults to 0 (backwards compatible)

It is possible to only specify one of checkedValue and uncheckedValue and make it work, but I wouldn't recommend it as for backwards compatibility the logic interprets any truthy value as checked unless uncheckedValue is specified, but on save a specific value is set.

```json
  {
          "name": "fritext",
          "title": "Check me out",
          "type": "checkbox",
          "config": {
            "uncheckedValue": "okryzz",
            "checkedValue": "kryzza lugnt"
          }
  }
```