### PR TITLE
Search config option 1 with custom layer projection

### DIFF
--- a/src/getfeature.js
+++ b/src/getfeature.js
@@ -92,7 +92,7 @@ sourceType.WFS = function wfsSourceType(id, layer, serverUrl, extent) {
   const data = ['service=WFS',
     '&version=1.0.0',
     `&request=GetFeature&typeName=${layer.get('name')}`,
-    '&outputFormat=json',
+    '&outputFormat=application/json',
     queryFilter
   ].join('');
 

--- a/src/getfeature.js
+++ b/src/getfeature.js
@@ -96,5 +96,14 @@ sourceType.WFS = function wfsSourceType(id, layer, serverUrl, extent) {
     queryFilter
   ].join('');
 
-  return fetch(url + data, { type: 'GET', dataType: 'json' }).then(res => res.json()).then(json => format.readFeatures(json)).catch(error => console.error(error));
+  return fetch(url + data, { type: 'GET', dataType: 'json' })
+    .then(res => res.json())
+    .then(json => {
+      const sourceOpts = layer.getSource().getOptions();
+      if (sourceOpts.dataProjection !== sourceOpts.projectionCode) {
+        return format.readFeatures(json, { dataProjection: sourceOpts.dataProjection, featureProjection: sourceOpts.projectionCode });
+      }
+      return format.readFeatures(json);
+    })
+    .catch(error => console.error(error));
 };


### PR DESCRIPTION
Fixes #1534.

Lets the [getFeature](https://github.com/origo-map/origo/blob/master/src/getfeature.js) function return features in the map's projection also when the layer projection differs.

Also a step towards #1139 as getFeature called for QGIS Server layers will always need to handle differing projections (due to QGIS Server only serving GeoJSON in EPSG:4326).