### PR TITLE
Fix group and subgroup expansion

### DIFF
--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -18,7 +18,7 @@ import { downloadPNG, downloadPDF, printToScalePDF } from '../../utils/download'
 import { afterRender, beforeRender } from './download-callback';
 import maputils from '../../maputils';
 import PrintResize from './print-resize';
-import { withLoading } from "../../loading";
+import { withLoading } from '../../loading';
 /** Backup of original OL function */
 const original = PluggableMap.prototype.getEventPixel;
 
@@ -334,7 +334,7 @@ const PrintComponent = function PrintComponent(options = {}) {
   const printToolbar = PrintToolbar();
   map.getAllLayers().forEach((l) => {
     // if we begin loading any data we want to disable the print buttons...
-    l.getSource().on(["tileloadstart", "imageloadstart"], () => printToolbar.setDisabled(true));
+    l.getSource().on(['tileloadstart', 'imageloadstart'], () => printToolbar.setDisabled(true));
   });
   // ...they then get re-enabled when the map has finished rendering
   map.on('rendercomplete', () => printToolbar.setDisabled(false));
@@ -540,19 +540,17 @@ const PrintComponent = function PrintComponent(options = {}) {
       }
       widthImage = orientation === 'portrait' ? Math.round((sizes[size][1] * resolution) / 25.4) : Math.round((sizes[size][0] * resolution) / 25.4);
       heightImage = orientation === 'portrait' ? Math.round((sizes[size][0] * resolution) / 25.4) : Math.round((sizes[size][1] * resolution) / 25.4);
-      await withLoading(() =>
-        printToScalePDF({
-          el: pageElement,
-          filename,
-          height,
-          orientation: pdfOrientation,
-          size,
-          width,
-          printScale,
-          widthImage,
-          heightImage
-        })
-      );
+      await withLoading(() => printToScalePDF({
+        el: pageElement,
+        filename,
+        height,
+        orientation: pdfOrientation,
+        size,
+        width,
+        printScale,
+        widthImage,
+        heightImage
+      }));
     },
     async onRender() {
       // Monkey patch OL

--- a/src/controls/print/print-toolbar.js
+++ b/src/controls/print/print-toolbar.js
@@ -13,6 +13,7 @@ const PrintToolbar = function PrintToolbar() {
 
   return Component({
     onInit() {
+      this.addComponents([pngButton, pdfButton]);
       pngButton.on('click', this.dispatchExport.bind(this));
       pdfButton.on('click', this.dispatchPrint.bind(this));
     },
@@ -26,13 +27,13 @@ const PrintToolbar = function PrintToolbar() {
       this.dispatch('render');
     },
     render() {
-      return this.html`
+      return `
       <div
         class="flex box fixed bottom-center button-group divider-horizontal box-shadow rounded-large bg-inverted z-index-ontop-high no-print"
         style="height: 2rem;"
       >
-        ${pngButton}
-        ${pdfButton}
+        ${pngButton.render()}
+        ${pdfButton.render()}
       </div>`;
     },
     setDisabled(disabled) {

--- a/src/loading.js
+++ b/src/loading.js
@@ -2,14 +2,14 @@
  * Show the global loading indicator
  */
 export function showLoading() {
-  document.getElementById("loading").classList.remove("hide");
+  document.getElementById('loading').classList.remove('hide');
 }
 
 /**
  * Hide the global loading indicator
  */
 export function hideLoading() {
-  document.getElementById("loading").classList.add("hide");
+  document.getElementById('loading').classList.add('hide');
 }
 
 /**

--- a/src/ui/component.js
+++ b/src/ui/component.js
@@ -1,105 +1,73 @@
 import Cuid from 'cuid';
+import Eventer from './utils/eventer';
 import isComponent from './utils/iscomponent';
-import Eventer from "./utils/eventer";
 
-class Base {
-  constructor(options) {
-    this.id = Cuid();
-    this.components = [];
+const Base = function Base() {
+  const id = Cuid();
+  let components = [];
 
-    // TODO: replace by inheriting from EventTarget
-    this._eventer = new Eventer();
-    this.on = this._eventer.on;
-    this.un = this._eventer.un;
-    this.dispatch = this._eventer.dispatch;
-
-    for (const [k, v] of Object.entries(options)) {
-      if (k === "onRender") {
-        // the onRender event is a special case; it will be run upon the `render` event from the parent component
-        this.on('add', (evt = {}) => {
-          if (evt.target && isComponent(evt.target)) {
-            const addListener = v.bind(this);
-            evt.target.on('render', addListener);
-            this.on('clear', () => {
-              evt.target.un('render', addListener);
-            });
-          }
-        });
-      } else if (k.length >= 5 && k.startsWith("on") && k[2].toUpperCase() === k[2]) {
-        const type = k.slice(2).toLowerCase();
-        this.on(type, v);
+  return {
+    addComponent(child) {
+      const evt = { target: this };
+      if (components.includes(child)) {
+        return child;
+      }
+      components.push(child);
+      child.dispatch('add', evt);
+      return child;
+    },
+    addComponents(children) {
+      children.forEach((child) => {
+        this.addComponent(child);
+      });
+    },
+    clearComponents() {
+      components.forEach((component) => {
+        component.dispatch('clear', { target: this });
+      });
+      components = [];
+    },
+    getComponents: () => components,
+    getId: () => id,
+    removeComponent(component) {
+      const index = components.indexOf(component);
+      if (index > -1) {
+        components.splice(index, 1);
+        component.dispatch('clear', { target: this });
       }
     }
-    Object.assign(this, options);
-  }
+  };
+};
 
-  addComponent(child) {
-    if (this.components.includes(child)) {
-      return child;
-    }
-    this.components.push(child);
-    child.dispatch('add', { target: this });
-    return child;
-  }
-  addComponents(children) {
-    children.forEach((child) => {
-      this.addComponent(child);
-    });
-  }
-  removeComponent(component) {
-    const index = this.components.indexOf(component);
-    if (index > -1) {
-      this.components.splice(index, 1);
-      component.dispatch('clear', { target: this });
-    }
-  }
-  clearComponents() {
-    this.components.forEach((component) => {
-      component.dispatch('clear', { target: this });
-    });
-    this.components = [];
-  }
-
-  getComponents() { return this.components; }
-  getId() { return this.id; }
-
-  /**
-   * This method can be used inside of component `render` functions for tagged template literals.
-   *
-   * It will call the render methods of interpolated child components, and also ensure that they are added as children
-   * to the rendered component. It will also inject the id of this component to the top level tag.
-   *
-   * @param {string[]} strings
-   * @param {(Base|any)[]} values
-   * @returns {string}
-   */
-  html(strings, ...values) {
-    const processValue = (v) => {
-      if (isComponent(v)) {
-        this.addComponent(v);
-        return v.render();
-      } else {
-        // convert to string as would usually be done in a template literal
-        return `${v}`;
+const Component = function Component(options) {
+  const addAddListener = function addAddListener(component) {
+    const onAdd = function onAdd(evt = {}) {
+      if (evt.target) {
+        if (isComponent(evt.target)) {
+          const addListener = component.onRender.bind(component);
+          evt.target.on('render', addListener);
+          component.on('clear', () => {
+            evt.target.un('render', addListener);
+          });
+        }
       }
     };
+    component.on('add', onAdd);
+  };
 
-    const interpolated = strings.reduce(
-        (accum, str, idx) => accum + str + (idx < values.length ? processValue(values[idx]) : ''),
-        '');
-
-    const firstRight = interpolated.indexOf('>');
-    if (interpolated.slice(0, firstRight).includes(' id="')) {
-      // top level tag already contains id, don't attempt to inject
-      return interpolated;
+  const createComponent = function createComponent(component) {
+    if (component.onInit) {
+      component.on('init', component.onInit);
     }
-    // inject id just before end of start tag
-    return interpolated.slice(0, firstRight-1) + ` id="${this.id}"` + interpolated.slice(firstRight);
-  }
-}
+    if (component.onAdd) {
+      component.on('add', component.onAdd);
+    } else if (component.onRender) {
+      addAddListener(component);
+    }
+    component.dispatch('init');
+    return Object.create(component);
+  };
+  return createComponent(Object.assign({}, Eventer(), Base(), options));
+};
 
-export default function Component(options) {
-  const component = new Base(options);
-  component.dispatch('init');
-  return component;
-}
+export default Component;


### PR DESCRIPTION
This PR reverts the component refactor from #1529, fixing group and subgroup expansion.

~The refactor of the base component in #1529 slightly changed how events where attached, which made it possible for onRender to be called more than once which in turn attached event handlers more than once, resulting in bugs like in #1551.~

~This PR fixes that by somewhat formalizing (and reducing) the handling of especially the "render" event. There is also commented out code to get a warning on similar issues (currently present in the print component, though without any user visible issues that I could find).~

Closes: #1551