### PR TITLE
Extended legend inline

### DIFF
--- a/scss/ui/_flex.scss
+++ b/scss/ui/_flex.scss
@@ -6,87 +6,96 @@ $flex-grow: 1;
 $flex-grow-all: 2;
 
 .flex {
-  // flex container
-  display: flex;
+    // flex container
+    display: flex;
 
-  &.row {
-    flex-direction: row;
-  }
+    &.row {
+        flex-direction: row;
+    }
 
-  &.row-reverse {
-    flex-direction: row-reverse;
-  }
+    &.row-reverse {
+        flex-direction: row-reverse;
+    }
 
-  &.column {
-    flex-direction: column;
-  }   
+    &.column {
+        flex-direction: column;
+    }
 
-  &.column-reverse {
-    flex-direction: column-reverse;
-  }
-  
-  // flex items
-  .shrink {
-    flex-shrink: $flex-shrink;
-  }
+    &.column-reverse {
+        flex-direction: column-reverse;
+    }
+    
+    // flex items
+    .shrink {
+        flex-shrink: $flex-shrink;
+    }
 
-  .grow {
-    flex-grow: $flex-grow;
-  }   
+    .grow {
+        flex-grow: $flex-grow;
+    }
 
-  .no-shrink {
-    flex-shrink: $flex-no-shrink;
-  }
+    .no-shrink {
+        flex-shrink: $flex-no-shrink;
+    }
 
-  .no-grow {
-    flex-grow: $flex-no-grow;
-  }
+    .no-grow {
+        flex-grow: $flex-no-grow;
+    }
 
-  .grow-all {
-    flex-grow: $flex-grow-all;
-  }
+    .grow-all {
+        flex-grow: $flex-grow-all;
+    }
 
-  .no-wrap {
-    flex-wrap: nowrap;
-  }
+    .no-wrap {
+        flex-wrap: nowrap;
+    }
 
-  .justify-start {
-    justify-content: flex-start;
-  }
+    .wrap {
+        flex-wrap: wrap;
+    }
+    /* Use this on an empty div to simulate a br in flex. requires that container has flex-wrap: wrap*/
+    .flex-line-break {
+        flex-basis: 100%;
+        height: 0;
+    }
 
-  .justify-end {
-    justify-content: flex-end;
-  }
+    .justify-start {
+        justify-content: flex-start;
+    }
 
-  .justify-center {
-    justify-content: center;
-  }
+    .justify-end {
+        justify-content: flex-end;
+    }
 
-  .justify-space-between {
-    justify-content: space-between;
-  }
+    .justify-center {
+        justify-content: center;
+    }
 
-  .justify-space-evenly {
-    justify-content: space-evenly;
-  }   
+    .justify-space-between {
+        justify-content: space-between;
+    }
 
-  .align-start {
-    align-items: flex-start;
-  }
+    .justify-space-evenly {
+        justify-content: space-evenly;
+    }
 
-  .align-end {
-    align-items: flex-end;
-  }
+    .align-start {
+        align-items: flex-start;
+    }
 
-  .align-center {
-    align-items: center;
-  }
+    .align-end {
+        align-items: flex-end;
+    }
 
-  .align-baseline {
-    align-items: baseline;
-  }
+    .align-center {
+        align-items: center;
+    }
 
-  .align-stretch {
-    align-items: stretch;
-  }     
+    .align-baseline {
+        align-items: baseline;
+    }
+
+    .align-stretch {
+        align-items: stretch;
+    }
 }

--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -1,5 +1,5 @@
-import { Component, Button, dom } from '../../ui';
-import { HeaderIcon } from '../../utils/legendmaker';
+import { Component, Button, dom, Collapse } from '../../ui';
+import { HeaderIcon, Legend } from '../../utils/legendmaker';
 import PopupMenu from '../../ui/popupmenu';
 
 const OverlayLayer = function OverlayLayer(options) {
@@ -22,12 +22,13 @@ const OverlayLayer = function OverlayLayer(options) {
 
   const hasStylePicker = viewer.getLayerStylePicker(layer).length > 0;
   const layerIconCls = `round compact icon-small relative no-shrink light ${hasStylePicker ? 'style-picker' : ''}`;
-  const cls = `${clsSettings} flex row align-center padding-left padding-right-smaller item`.trim();
+  const cls = `${clsSettings} flex row align-center padding-left padding-right-smaller item wrap`.trim();
   const title = layer.get('title') || 'Titel saknas';
   const name = layer.get('name');
   const secure = layer.get('secure');
   let moreInfoButton;
   let popupMenu;
+  let hasExtendedLegend = false;
 
   const checkIcon = '#ic_check_circle_24px';
   let uncheckIcon = '#ic_radio_button_unchecked_24px';
@@ -42,6 +43,7 @@ const OverlayLayer = function OverlayLayer(options) {
   if (!headerIcon) {
     headerIcon = icon;
     headerIconClass = iconCls;
+    hasExtendedLegend = true;
   }
 
   const eventOverlayProps = new CustomEvent('overlayproperties', {
@@ -69,11 +71,32 @@ const OverlayLayer = function OverlayLayer(options) {
     return !visible;
   };
 
+  // Create a legend for the layer and wrap it in a Collapse.
+  // Always do this even if there is no extended legend, as user may change symbol later and then its nice to have a placeholder.
+  const extendedLegendContent = Component({
+    render() {
+      // Need to wrap legend as Collapse requires an id on the content
+      return `<div id="${this.getId()}" class="padding-left">${hasExtendedLegend ? Legend(style) : ''}</div>`;
+    },
+    setContent(content) {
+      const contentEl = document.getElementById(this.getId());
+      contentEl.innerHTML = content;
+    },
+    toggle() {
+      // Throw an event and let it bubble up to Collapse
+      const contentEl = document.getElementById(this.getId());
+      const collapseEvent = 'collapse:toggle';
+      const customEvt = new CustomEvent(collapseEvent, { bubbles: true });
+      contentEl.dispatchEvent(customEvt);
+    }
+  });
+  const extendedLegendCmp = Collapse({ collapseX: false, contentComponent: extendedLegendContent, expanded: layer.get('expanded') });
+
   const layerIcon = Button({
     cls: `${headerIconClass} ${layerIconCls}`,
     click() {
-      if (!secure) {
-        toggleVisible(layer.getVisible());
+      if (hasExtendedLegend) {
+        extendedLegendContent.toggle();
       }
     },
     style: {
@@ -86,20 +109,6 @@ const OverlayLayer = function OverlayLayer(options) {
   });
 
   buttons.push(layerIcon);
-
-  const label = Component({
-    onRender() {
-      const labelEl = document.getElementById(this.getId());
-      labelEl.addEventListener('click', (e) => {
-        layerIcon.dispatch('click');
-        e.preventDefault();
-      });
-    },
-    render() {
-      const labelCls = 'text-smaller padding-x-small grow pointer no-select overflow-hidden';
-      return `<div id="${this.getId()}" class="${labelCls}">${title}</div>`;
-    }
-  });
 
   const toggleButton = Button({
     cls: 'round small icon-smaller no-shrink',
@@ -118,6 +127,21 @@ const OverlayLayer = function OverlayLayer(options) {
   });
 
   buttons.push(toggleButton);
+
+  const label = Component({
+    onRender() {
+      const labelEl = document.getElementById(this.getId());
+      labelEl.addEventListener('click', (e) => {
+        toggleButton.dispatch('click');
+        e.preventDefault();
+      });
+    },
+    render() {
+      const labelCls = 'text-smaller padding-x-small grow pointer no-select overflow-hidden';
+      return `<div id="${this.getId()}" class="${labelCls}">${title}</div>`;
+    }
+  });
+
 
   const layerInfoMenuItem = Component({
     onRender() {
@@ -268,6 +292,13 @@ const OverlayLayer = function OverlayLayer(options) {
     const newStyle = viewer.getStyle(layer.get('styleName'));
     const layerIconCmp = document.getElementById(layerIcon.getId());
     let newIcon = HeaderIcon(newStyle, opacity);
+    if (!newIcon) {
+      hasExtendedLegend = true;
+      extendedLegendContent.setContent(Legend(newStyle));
+    } else {
+      hasExtendedLegend = false;
+      extendedLegendContent.setContent('');
+    }
     headerIconClass = !newIcon ? iconCls : headerIconCls;
     newIcon = !newIcon ? icon : newIcon;
     layerIconCmp.className = `${headerIconClass} ${layerIconCls}`;
@@ -293,6 +324,7 @@ const OverlayLayer = function OverlayLayer(options) {
       }
       this.addComponents(buttons);
       this.addComponent(label);
+      this.addComponent(extendedLegendCmp);
       this.dispatch('render');
 
       if (layer.getMaxResolution() !== Infinity || layer.getMinResolution() !== 0) {
@@ -317,7 +349,10 @@ const OverlayLayer = function OverlayLayer(options) {
       });
     },
     render() {
-      return `<li id="${this.getId()}" class="${cls}">${ButtonsHtml}</li>`;
+      let extendedLegendHtml = '';
+      // Inject the extended legend in the same li element to avoid problems with callers that assumes that each layer is one li, but add a linebreak
+      extendedLegendHtml = `<div class="flex-line-break"></div>${extendedLegendCmp.render()}`;
+      return `<li id="${this.getId()}" class="${cls}">${ButtonsHtml}${extendedLegendHtml}</li>`;
     }
   });
 };

--- a/src/ui/collapse.js
+++ b/src/ui/collapse.js
@@ -100,12 +100,12 @@ export default function Collapse(options = {}) {
     data,
     expand,
     onInit() {
-      if ((headerComponent || footerComponent) && contentComponent) {
+      if (contentComponent) {
         if (headerComponent) { this.addComponent(headerComponent); }
         if (footerComponent) { this.addComponent(footerComponent); }
         this.addComponent(contentComponent);
       } else {
-        throw new Error('Header or content component is missing in collapse');
+        throw new Error('Content component is missing in collapse');
       }
     },
     onRender() {


### PR DESCRIPTION
Closes #1528 

Extended legends (e.g composite WMS-layers and thematic vector layers) are displayed below the layer name in legend. Default they are collapsed and are displayed by clicking the extended/no symbol icon.

Layers that do not have an extended legend are affected in that way that clicking the symbol now does exactly nothing instead of toggling visibility.

Layers that does not have any symbol at all will display a _legend missing_ text when the list symbol is clicked, which is the same as in layer info.

To start with the extended legend visible add `'expanded ': true` to the layer configuration.

It supports changing symbology using the stylePicker.

__Known issues__
If a thematic symbology has a `'header': true` setting, the thematic symbology will not be available inline. The main reason is that it would not be clear to the user that the symbol in the legend is clickable to see the rest of the symbols. To make it clear, the extended legend would need its own drop down button or be inside the three-dot-menu, which defies the simplicity of displaying them inline.

It may be hard to test with legend groups, as the eventhandling for collapsing and expanding groups is broken until #1551 is resolved.

