### PR TITLE
Adds export option for layers

### DIFF
--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -1,6 +1,7 @@
 import { Component, Button, dom } from '../../ui';
 import { HeaderIcon } from '../../utils/legendmaker';
 import PopupMenu from '../../ui/popupmenu';
+import exportToFile from '../../utils/exporttofile';
 
 const OverlayLayer = function OverlayLayer(options) {
   const {
@@ -156,6 +157,42 @@ const OverlayLayer = function OverlayLayer(options) {
       }
     });
     popupMenuItems.push(zoomToExtentMenuItem);
+  }
+
+  if (layer.get('exportable')) {
+    const exportFormat = layer.get('exportFormat');
+    let exportFormatArray = [];
+    if (exportFormat && typeof exportFormat === 'string') {
+      exportFormatArray.push(exportFormat);
+    } else if (exportFormat && Array.isArray(exportFormat)) {
+      exportFormatArray = exportFormat;
+    }
+    const formats = exportFormatArray.filter(format => format === 'geojson' || format === 'gpx' || format === 'kml');
+    if (formats.length === 0) { formats.push('geojson'); }
+    formats.forEach((format) => {
+      const exportLayerMenuItem = Component({
+        onRender() {
+          const labelEl = document.getElementById(this.getId());
+          labelEl.addEventListener('click', (e) => {
+            const features = layer.getSource().getFeatures();
+            exportToFile(features, format, {
+              featureProjection: viewer.getProjection().getCode(),
+              filename: title || 'export'
+            });
+            e.preventDefault();
+          });
+        },
+        render() {
+          let exportLabel;
+          if (exportFormatArray.length > 1) {
+            exportLabel = `Spara lager (.${format})`;
+          } else { exportLabel = 'Spara lager'; }
+          const labelCls = 'text-smaller padding-x-small grow pointer no-select overflow-hidden';
+          return `<li id="${this.getId()}" class="${labelCls}">${exportLabel}</li>`;
+        }
+      });
+      popupMenuItems.push(exportLayerMenuItem);
+    });
   }
 
   if (layer.get('removable')) {

--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -167,7 +167,7 @@ const OverlayLayer = function OverlayLayer(options) {
     } else if (exportFormat && Array.isArray(exportFormat)) {
       exportFormatArray = exportFormat;
     }
-    const formats = exportFormatArray.filter(format => format === 'geojson' || format === 'gpx' || format === 'kml');
+    const formats = exportFormatArray.map(format => format.toLowerCase()).filter(format => format === 'geojson' || format === 'gpx' || format === 'kml');
     if (formats.length === 0) { formats.push('geojson'); }
     formats.forEach((format) => {
       const exportLayerMenuItem = Component({

--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -160,7 +160,7 @@ const OverlayLayer = function OverlayLayer(options) {
   }
 
   if (layer.get('exportable')) {
-    const exportFormat = layer.get('exportFormat');
+    const exportFormat = layer.get('exportFormat') || layer.get('exportformat');
     let exportFormatArray = [];
     if (exportFormat && typeof exportFormat === 'string') {
       exportFormatArray.push(exportFormat);


### PR DESCRIPTION
Fixes #1559 

Should be used with caution and works only for vector layers. It exports the features that has been requested from the server, thus works best with geojson-layers or wfs with strategy:all but is primarily intended for draw layers.

Configured like this:
   
>  {
      "name": "origo-cities",
      "title": "Origokommuner",
      "group": "root",
      "source": "data/origo-cities-3857.geojson",
      "style": "origo-logo",
      "type": "GEOJSON",
      "attributes": [
        {
          "name": "name"
        }
      ],
      "visible": true,
      "exportable": true,
      "exportFormat": "geojson" // ["geojson", "kml"]
    }

exportFormat can be a string (geojson, gpx or kml) or an array of formats. Defaults to geojson in case om omitted or invalid.