### PR TITLE
Fix blurry editor form

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -18,18 +18,12 @@
   border-radius: 6px;
   bottom: auto;
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
-  box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
   font-family: Arial,sans-serif;
   left: 50%;
   position: absolute;
   right: auto;
   top: 50%;
   transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
-  transform-style: preserve-3d;
-  transform-style: preserve-3d;
-  transform-style: preserve-3d;
   width: 300px;
   z-index: 1100;
 }


### PR DESCRIPTION
Fixes #1563, quick and dirty.

Can't see that `transform-style: preserve-3d` has been used for anything in particular in the past and I haven't noticed any negative side effect after removing it. But please, throw your weirdest modal configs at it and see if it breaks!