### PR TITLE
feat: enable automatic style creation for wms layers' getLegendGraphic

### DIFF
--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -37,6 +37,20 @@ function createImageSource(options) {
   }));
 }
 
+function createDefaultStyle(wmsOptions, source, viewer) {
+  const maxResolution = viewer.getResolutions()[viewer.getResolutions().length - 1];
+  const styleName = `${wmsOptions.name}_WMSDefault`;
+  const getLegendString = source.getLegendUrl(maxResolution, wmsOptions.legendParams);
+  const style = [[{
+    icon: {
+      src: `${getLegendString}`
+    },
+    extendedLegend: wmsOptions.hasThemeLegend || false
+  }]];
+  viewer.addStyle(styleName, style);
+  return styleName;
+}
+
 const wms = function wms(layerOptions, viewer) {
   const wmsDefault = {
     featureinfoLayer: null
@@ -54,7 +68,6 @@ const wms = function wms(layerOptions, viewer) {
   sourceOptions.projection = viewer.getProjection();
   sourceOptions.id = wmsOptions.id;
   sourceOptions.format = wmsOptions.format ? wmsOptions.format : sourceOptions.format;
-
   const styleSettings = viewer.getStyle(wmsOptions.styleName);
   const wmsStyleObject = styleSettings ? styleSettings[0].find(s => s.wmsStyle) : undefined;
   sourceOptions.style = wmsStyleObject ? wmsStyleObject.wmsStyle : '';
@@ -73,9 +86,19 @@ const wms = function wms(layerOptions, viewer) {
   }
 
   if (renderMode === 'image') {
+    const source = createImageSource(sourceOptions);
+    if (wmsOptions.styleName === 'default') {
+      wmsOptions.styleName = createDefaultStyle(wmsOptions, source, viewer);
+    }
     return image(wmsOptions, createImageSource(sourceOptions));
   }
-  return tile(wmsOptions, createTileSource(sourceOptions));
+
+  const source = createTileSource(sourceOptions);
+
+  if (wmsOptions.styleName === 'default') {
+    wmsOptions.styleName = createDefaultStyle(wmsOptions, source, viewer);
+  }
+  return tile(wmsOptions, source);
 };
 
 export default wms;

--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -90,7 +90,7 @@ const wms = function wms(layerOptions, viewer) {
     if (wmsOptions.styleName === 'default') {
       wmsOptions.styleName = createDefaultStyle(wmsOptions, source, viewer);
     }
-    return image(wmsOptions, createImageSource(sourceOptions));
+    return image(wmsOptions, source);
   }
 
   const source = createTileSource(sourceOptions);

--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -89,6 +89,7 @@ const wms = function wms(layerOptions, viewer) {
     const source = createImageSource(sourceOptions);
     if (wmsOptions.styleName === 'default') {
       wmsOptions.styleName = createDefaultStyle(wmsOptions, source, viewer);
+      wmsOptions.style = wmsOptions.styleName;
     }
     return image(wmsOptions, source);
   }
@@ -97,6 +98,7 @@ const wms = function wms(layerOptions, viewer) {
 
   if (wmsOptions.styleName === 'default') {
     wmsOptions.styleName = createDefaultStyle(wmsOptions, source, viewer);
+    wmsOptions.style = wmsOptions.styleName;
   }
   return tile(wmsOptions, source);
 };


### PR DESCRIPTION
Proposes to fix #1560 . Introduces two properties of a WMS layer:
```json
      "hasThemeLegend": true,
      "legendParams" : {
        "scale" : 5000,
        "legend_options" : "dpi:300"
      }
```
Where `hasThemeLegend` is necessary for "auto" style creation for WMS layers with a theme legend (to extendedLegend) and
`legendParams` is more or less what @steff-o suggested in the related issue. 

Both properties are ignored if a `style` property also exists for the given WMS layer.

The default "scale" for the getLegendGraphic call (there needs to be a scale for scale dependant styles) is the largest scale of the configured map (because typically theme layers have more visible classes at a larger scale than at a smaller scale if scale dependant) however that value is overriden if `scale` is given as a `legendParam`.

The possibility exists to make `hasThemeLegend` part of the `legendParams` object but it's slightly easier to merely define the `hasThemeLegend` property rather than it as part of an object if no special legendParams as per getLegendGraphic() are to be employed.