### PR TITLE
Make vector sources aware of custom layer extent

### DIFF
--- a/src/layer/geojson.js
+++ b/src/layer/geojson.js
@@ -12,6 +12,9 @@ function createSource(options) {
         const numFeatures = vectorSource.getFeatures().length;
         for (let i = 0; i < numFeatures; i += 1) {
           vectorSource.forEachFeature((feature) => {
+            if (!feature.getGeometry().intersectsExtent(options.customExtent)) {
+              vectorSource.removeFeature(feature);
+            }
             if (!feature.getId()) {
               if (feature.get(options.idField)) {
                 feature.setId(feature.get(options.idField));
@@ -39,6 +42,8 @@ const geojson = function geojson(layerOptions, viewer) {
   const geojsonOptions = Object.assign(geojsonDefault, layerOptions);
   const sourceOptions = {};
   sourceOptions.attribution = geojsonOptions.attribution;
+  sourceOptions.customExtent = geojsonOptions.extent;
+  geojsonOptions.extent = undefined;
   sourceOptions.projectionCode = viewer.getProjectionCode();
   sourceOptions.idField = layerOptions.idField || 'id';
   if (geojsonOptions.projection) {

--- a/src/layer/topojson.js
+++ b/src/layer/topojson.js
@@ -21,6 +21,8 @@ const topojson = function topojson(layerOptions, viewer) {
   const sourceOptions = {};
 
   sourceOptions.attribution = topojsonOptions.attribution;
+  sourceOptions.customExtent = topojsonOptions.extent;
+  topojsonOptions.extent = undefined;
   sourceOptions.projectionCode = viewer.getProjectionCode();
   sourceOptions.sourceName = layerOptions.source;
   if (isUrl(topojsonOptions.source)) {

--- a/src/layer/wfs.js
+++ b/src/layer/wfs.js
@@ -15,6 +15,8 @@ export default function wfs(layerOptions, viewer) {
   sourceOptions.geometryName = wfsOptions.geometryName;
   sourceOptions.filter = wfsOptions.filter;
   sourceOptions.attribution = wfsOptions.attribution;
+  sourceOptions.customExtent = wfsOptions.extent;
+  wfsOptions.extent = undefined;
   sourceOptions.resolutions = viewer.getResolutions();
   sourceOptions.projectionCode = viewer.getProjectionCode();
   if (wfsOptions.projection) {

--- a/src/layer/wfssource.js
+++ b/src/layer/wfssource.js
@@ -3,6 +3,7 @@
 import VectorSource from 'ol/source/Vector';
 import GeoJSONFormat from 'ol/format/GeoJSON';
 import * as LoadingStrategy from 'ol/loadingstrategy';
+import { getIntersection } from 'ol/extent';
 import { transformExtent } from 'ol/proj';
 import replacer from '../utils/replacer';
 
@@ -88,11 +89,12 @@ class WfsSource extends VectorSource {
       queryFilter = cqlfilter ? `&CQL_FILTER=${cqlfilter}` : '';
     } else {
       // Extent should be used. Depending if there also is a filter, the queryfilter looks different
+      const ext = getIntersection(this._options.customExtent, extent) || extent;
       let requestExtent;
       if (this._options.dataProjection !== this._options.projectionCode) {
-        requestExtent = transformExtent(extent, this._options.projectionCode, this._options.dataProjection);
+        requestExtent = transformExtent(ext, this._options.projectionCode, this._options.dataProjection);
       } else {
-        requestExtent = extent;
+        requestExtent = ext;
       }
       if (cqlfilter) {
         queryFilter = `&CQL_FILTER=${cqlfilter} AND BBOX(${this._options.geometryName},${requestExtent.join(',')},'${this._options.dataProjection}')`;


### PR DESCRIPTION
Fixes #1523.

Had to copy and reset `extent` parameter to ensure backwards compatibility and to make sure it doesn't affect layer rendering since `extent` is also a native vector layer parameter.