### PR TITLE
fix: make sure all AGS layer ids compared in print-legend are numbers

### DIFF
--- a/src/controls/print/print-legend.js
+++ b/src/controls/print/print-legend.js
@@ -215,7 +215,7 @@ const LayerRow = function LayerRow(options) {
     if (!json) {
       return getTitleWithIcon(title, '');
     }
-    const legendLayer = json.layers.find((l) => l.layerId === id || l.layerName === id);
+    const legendLayer = json.layers.find((l) => +l.layerId === +id || l.layerName === id);
     if (!legendLayer) {
       return getTitleWithIcon(title, '');
     }


### PR DESCRIPTION
Aims to fix #1580 
