### PR TITLE
fix: add method for plugins to regenerate visible layers

### DIFF
--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -424,6 +424,7 @@ const Legend = function Legend(options = {}) {
     },
     getuseGroupIndication() { return useGroupIndication; },
     getOverlaysCollapse() { return overlaysCmp.overlaysCollapse; },
+    resetVisibleLayersView() { setVisibleLayersViewActive(true); },
     addButtonToTools(button) {
       const toolsEl = document.getElementById(toolsCmp.getId());
       toolsEl.classList.remove('hidden');

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -424,7 +424,7 @@ const Legend = function Legend(options = {}) {
     },
     getuseGroupIndication() { return useGroupIndication; },
     getOverlaysCollapse() { return overlaysCmp.overlaysCollapse; },
-    resetVisibleLayersView() { setVisibleLayersViewActive(true); },
+    setVisibleLayersViewActive,
     addButtonToTools(button) {
       const toolsEl = document.getElementById(toolsCmp.getId());
       toolsEl.classList.remove('hidden');


### PR DESCRIPTION
Aims to fix #1585 

It could be seen as potentially incomplete (setting setVisibleLayersViewActive(true) again as opposed to toggling as suggested in the issue. I've not encountered any ill effects in preliminary testing however. With this our Layermanager-csw can as part of its onAdd() do:
```javascript
      if(sharedLayers) {
        ReadAddedLayersFromMapState(sharedLayers, viewer);
        if (viewer.getControlByName('legend').getState().visibleLayersViewActive) {
          viewer.getControlByName('legend').resetVisibleLayersView();
        }
      }
```