### PR TITLE
feature: editor api

### DIFF
--- a/src/controls/editor/drawtools.js
+++ b/src/controls/editor/drawtools.js
@@ -155,6 +155,22 @@ const drawToolsSelector = function drawToolsSelector(tools, defaultLayer, v) {
   }
 
   init();
+
+  return {
+    /**
+     * Call this to update available tools when layer has changed. No need to call if layer changed using GUI, as that is done by an event.
+     * @param {any} layerName
+     */
+    updateTools: (layerName) => {
+      currentLayer = layerName;
+      // If not visible we don't actually have to change the tools now
+      if (active) {
+        setActive(false);
+        setDrawTools(currentLayer);
+        setActive(true);
+      }
+    }
+  };
 };
 
 export default drawToolsSelector;

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -1333,7 +1333,6 @@ async function onAddChild(e) {
 function editAttributesDialogApi(featureId, layerName = null) {
   const layer = viewer.getLayer(layerName);
   const feature = layer.getSource().getFeatureById(featureId);
-  // TODO: Should we check anything? Layer editable, tool allowed?
   // Hijack the current layer for a while. If there's a modal visible it is closed (without saving) as editAttributes can not handle
   // multiple dialogs for the same layer so to be safe we always close. Technically the user can not
   // call this function when a modal is visible, as they can't click anywhere.
@@ -1362,15 +1361,11 @@ function editAttributesDialogApi(featureId, layerName = null) {
  * the feature has been saved and thus will have a permanent database Id. If not autosave it returns immediately (async of course) and
  * the id will be a temporary Guid that can be used until the feature is saved, then it will be replaced. Keeping a reference to the feature
  * itself will still work.
- * @param {any} layerName
+ * @param {any} layerName Name of layer to add a feature to
+ * @param {any} geometry A geomtry to add to the feature that will be created
  * @returns {Feature} the newly created feature
  */
 async function createFeatureApi(layerName, geometry = null) {
-  // TODO: Should we check anything?  editor active, something selected, attribute editor active, draw active, tool allowed?
-  //       If toolbar is not visible and not autosave, it will be pretty anonymous
-  // TODO: add parameter for geometry, or should that be added later manually?
-  //       If autosave, there is no later, as changes made outside editor will not end up in edit store (altough if it ends up there for some other reason
-  //       changes will be saved as editstore only keeps a reference to the feature itself, not the edits made)
   const editLayer = editLayers[layerName];
   if (!editLayer) {
     throw new Error('Ej redigerbart lager');
@@ -1393,15 +1388,12 @@ async function createFeatureApi(layerName, geometry = null) {
 
 async function deleteFeatureApi(featureId, layerName) {
   const feature = viewer.getLayer(layerName).getSource().getFeatureById(featureId);
-  // TODO: Should we check anything? Layer editable, tool allowed?
-  //       If toolbar is not visible and not autosave, it will be pretty anonymous
   const layer = viewer.getLayer(layerName);
   await deleteFeature(feature, layer);
 }
 
 function setActiveLayerApi(layerName) {
   const layer = editLayers[layerName];
-  // TODO: Move check to editor?
   if (!layer || layer.get('isTable')) {
     // Can't set tables as active in editor as the editor can't handle them. They are in list though, as they may
     // be edited through api

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -56,6 +56,9 @@ let breadcrumbs = [];
 let autoCreatedFeature = false;
 
 function isActive() {
+  // FIXME: this only happens at startup as they are set to null on closing. If checking for null/falsley/not truely it could work as isVisible with
+  // the exption that it can not determine if it is visble before interactions are set, i.e. it can't be used to determine if interactions should be set.
+  // Right now it does not matter as it is not used anywhere critical.
   if (modify === undefined || select === undefined) {
     return false;
   }
@@ -80,10 +83,10 @@ function setActive(editType) {
       select.setActive(false);
       break;
     default:
-      draw.setActive(false);
-      hasDraw = false;
+      if (draw) draw.setActive(false);
       if (modify) modify.setActive(true);
-      select.setActive(true);
+      if (select) select.setActive(true);
+      hasDraw = false;
       break;
   }
 }
@@ -526,11 +529,21 @@ function setInteractions(drawType) {
   }
 }
 
+function closeAllModals() {
+  // Close all modals first to get rid of tags in DOM
+  if (modal) modal.closeModal();
+  modal = null;
+  breadcrumbs.forEach(br => {
+    if (br.modal) br.modal.closeModal();
+  });
+  breadcrumbs = [];
+}
+
 function setEditLayer(layerName) {
   // It is not possible to actually change layer while having breadcrubs as all modals must be closed, which will
   // pop off all breadcrumbs.
   // But just in case something changes, reset the breadcrumbs when a new layer is edited.
-  breadcrumbs = [];
+  closeAllModals();
   currentLayer = layerName;
   setAllowedOperations();
   setInteractions();
@@ -689,8 +702,15 @@ function onModalClosed() {
     attributes = lastBread.attributes;
 
     // State is restored, now show parent modal instead and refresh as the title attribute might have changed
-    modal.show();
-    refreshRelatedTablesForm(lastBread.feature);
+    if (modal) {
+      modal.show();
+    }
+    if (lastBread.feature) {
+      refreshRelatedTablesForm(lastBread.feature);
+    }
+  } else {
+    // last modal to be closed. Set to null so we can check if there is an modal.
+    modal = null;
   }
 }
 
@@ -729,7 +749,9 @@ function onAttributesAbort(features) {
     abortBtnEl.addEventListener('click', (e) => {
       abortBtnEl.blur();
       features.forEach((feature) => {
-        deleteFeature(feature, editLayers[currentLayer]).then(() => select.getFeatures().clear());
+        deleteFeature(feature, viewer.getLayer(currentLayer)).then(() => {
+          if (select) select.getFeatures().clear();
+        });
       });
       modal.closeModal();
       // The modal does not fire close event when it is closed externally
@@ -1304,6 +1326,90 @@ async function onAddChild(e) {
 }
 
 /**
+ * Opens the attribute editor dialog for a feature. The dialog excutes asynchronously and never returns anything.
+ * @param {any} feature
+ * @param {any} layer
+ */
+function editAttributesDialogApi(featureId, layerName = null) {
+  const layer = viewer.getLayer(layerName);
+  const feature = layer.getSource().getFeatureById(featureId);
+  // TODO: Should we check anything? Layer editable, tool allowed?
+  // Hijack the current layer for a while. If there's a modal visible it is closed (without saving) as editAttributes can not handle
+  // multiple dialogs for the same layer so to be safe we always close. Technically the user can not
+  // call this function when a modal is visible, as they can't click anywhere.
+  // Restoring currentLayer is performed in onModalClosed(), as we can't await the modal.
+  // Close all modals and eat all breadcrumbs
+  closeAllModals();
+  // If editing in another layer, add a breadcrumb to restore layer when modal is closed.
+  if (layerName && layerName !== currentLayer) {
+    const newBreadcrumb = {
+      layerName: currentLayer,
+      title,
+      attributes
+    };
+    breadcrumbs.push(newBreadcrumb);
+    title = layer.get('title');
+    attributes = layer.get('attributes');
+    // Don't call setEditLayer, as that would change tools which requires that editor is active,
+    // and if it is a table it would probably crash on somehing geometry related.
+    currentLayer = layerName;
+  }
+  editAttributes(feature);
+}
+
+/**
+ * Creates a new feature and adds it to a layer. Default values are set. If autosave is set, it returns when
+ * the feature has been saved and thus will have a permanent database Id. If not autosave it returns immediately (async of course) and
+ * the id will be a temporary Guid that can be used until the feature is saved, then it will be replaced. Keeping a reference to the feature
+ * itself will still work.
+ * @param {any} layerName
+ * @returns {Feature} the newly created feature
+ */
+async function createFeatureApi(layerName, geometry = null) {
+  // TODO: Should we check anything?  editor active, something selected, attribute editor active, draw active, tool allowed?
+  //       If toolbar is not visible and not autosave, it will be pretty anonymous
+  // TODO: add parameter for geometry, or should that be added later manually?
+  //       If autosave, there is no later, as changes made outside editor will not end up in edit store (altough if it ends up there for some other reason
+  //       changes will be saved as editstore only keeps a reference to the feature itself, not the edits made)
+  const editLayer = editLayers[layerName];
+  if (!editLayer) {
+    throw new Error('Ej redigerbart lager');
+  }
+  const newfeature = new Feature();
+  if (geometry) {
+    if (geometry.getType() !== editLayer.get('geometryType')) {
+      throw new Error('Kan inte lägga till en geometri av den typen i det lagret');
+    }
+    newfeature.setGeometryName(editLayer.get('geometryName'));
+    newfeature.setGeometry(geometry);
+  }
+  await addFeatureToLayer(newfeature, layerName);
+  if (autoForm) {
+    autoCreatedFeature = true;
+    editAttributesDialogApi(newfeature.getId(), layerName);
+  }
+  return newfeature;
+}
+
+async function deleteFeatureApi(featureId, layerName) {
+  const feature = viewer.getLayer(layerName).getSource().getFeatureById(featureId);
+  // TODO: Should we check anything? Layer editable, tool allowed?
+  //       If toolbar is not visible and not autosave, it will be pretty anonymous
+  const layer = viewer.getLayer(layerName);
+  await deleteFeature(feature, layer);
+}
+
+function setActiveLayerApi(layerName) {
+  const layer = editLayers[layerName];
+  // TODO: Move check to editor?
+  if (!layer || layer.get('isTable')) {
+    // Can't set tables as active in editor as the editor can't handle them. They are in list though, as they may
+    // be edited through api
+    throw new Error(`Layer ${layerName} är inte redigerbart`);
+  }
+  setEditLayer(layerName);
+}
+/**
  * Eventhandler called from relatedTableForm when delete button is pressed
  * @param { any } e Event containing layers and features necessary
  */
@@ -1311,6 +1417,12 @@ function onDeleteChild(e) {
   deleteFeature(e.detail.feature, e.detail.layer).then(() => refreshRelatedTablesForm(e.detail.parentFeature));
 }
 
+/**
+ * Creates the handler. It is used as sort of a singelton, but in theory there could be many handlers.
+ * It communicates with the editor toolbar and forms using DOM events, which makes it messy to have more than one instance as they would use the same events.
+ * @param {any} options
+ * @param {any} v The viewer object
+ */
 export default function editHandler(options, v) {
   viewer = v;
   featureInfo = viewer.getControlByName('featureInfo');
@@ -1331,6 +1443,8 @@ export default function editHandler(options, v) {
   autoSave = options.autoSave;
   autoForm = options.autoForm;
   validateOnDraw = options.validateOnDraw;
+
+  // Listen to DOM events from menus and forms
   document.addEventListener('toggleEdit', onToggleEdit);
   document.addEventListener('changeEdit', onChangeEdit);
   document.addEventListener('editorShapes', onChangeShape);
@@ -1338,4 +1452,12 @@ export default function editHandler(options, v) {
   document.addEventListener(dispatcher.EDIT_CHILD_EVENT, onEditChild);
   document.addEventListener(dispatcher.ADD_CHILD_EVENT, onAddChild);
   document.addEventListener(dispatcher.DELETE_CHILD_EVENT, onDeleteChild);
+
+  return {
+    // These functions are called from Editor Component, possibly from its Api so change these calls with caution.
+    createFeature: createFeatureApi,
+    editAttributesDialog: editAttributesDialogApi,
+    deleteFeature: deleteFeatureApi,
+    setActiveLayer: setActiveLayerApi
+  };
 }

--- a/src/controls/editor/editorlayers.js
+++ b/src/controls/editor/editorlayers.js
@@ -5,6 +5,7 @@ import utils from '../../utils';
 const createElement = utils.createElement;
 
 let viewer;
+let dropdown;
 
 export default function editorLayers(editableLayers, v, optOptions = {}) {
   viewer = v;
@@ -35,7 +36,7 @@ export default function editorLayers(editableLayers, v, optOptions = {}) {
     });
     const { body: popoverHTML } = new DOMParser().parseFromString(popover, 'text/html');
     document.getElementById('o-editor-layers').insertAdjacentElement('afterend', popoverHTML);
-    dropDown(options.target, options.selectOptions, {
+    dropdown = dropDown(options.target, options.selectOptions, {
       dataAttribute: 'layer',
       active: options.activeLayer
     });
@@ -83,6 +84,17 @@ export default function editorLayers(editableLayers, v, optOptions = {}) {
     document.addEventListener('changeEdit', onChangeEdit);
   }
 
+  /**
+   * Updates layer selection list to reflect the current setting
+   * @param {any} layerName
+   */
+  function changeLayer(layerName) {
+    dropdown.select(layerName);
+  }
+
   render(renderOptions);
   addListener(target);
+  return {
+    changeLayer
+  };
 }

--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -1,6 +1,5 @@
 import editortemplate from './editortemplate';
 import dispatcher from './editdispatcher';
-import editHandler from './edithandler';
 import editorLayers from './editorlayers';
 import drawTools from './drawtools';
 
@@ -14,6 +13,7 @@ let $editDelete;
 let $editLayers;
 let $editSave;
 let viewer;
+let layerSelector;
 
 function render() {
   const { body: editortemplateHTML } = new DOMParser().parseFromString(editortemplate, 'text/html');
@@ -172,7 +172,6 @@ function init(options, v) {
   editableLayers = options.editableLayers;
   // Keep a reference to viewer. Used later.
   viewer = v;
-  editHandler(options, v);
   render();
   // Hide layers choice button if only 1 layer in editable
   if (editableLayers.length < 2) {
@@ -182,7 +181,7 @@ function init(options, v) {
   if (options.autoSave) {
     $editSave.classList.add('o-hidden');
   }
-  editorLayers(editableLayers, v, {
+  layerSelector = editorLayers(editableLayers, v, {
     activeLayer: currentLayer
   });
   drawTools(options.drawTools, currentLayer, v);
@@ -202,6 +201,14 @@ function init(options, v) {
 export default (function exportInit() {
   return {
     init,
-    toggleToolbar
+    toggleToolbar,
+    /**
+   * Updates layer selection list to reflect the current setting
+   * @param {any} layerName
+   */
+    changeActiveLayer: (layerName) => {
+      currentLayer = layerName;
+      layerSelector.changeLayer(layerName);
+    }
   };
 }());

--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -14,6 +14,7 @@ let $editLayers;
 let $editSave;
 let viewer;
 let layerSelector;
+let drawToolsSelector;
 
 function render() {
   const { body: editortemplateHTML } = new DOMParser().parseFromString(editortemplate, 'text/html');
@@ -152,6 +153,11 @@ function toggleSave(e) {
   }
 }
 
+function changeLayerInternal(layer) {
+  currentLayer = layer;
+  setAllowedTools();
+}
+
 /**
  * Called when toggleEdit event is raised
  * @param {any} e Custom event
@@ -161,8 +167,7 @@ function onToggleEdit(e) {
   // If the event contains a currentLayer, the currentLayer has either changed
   // or the editor toolbar is activated and should display the last edited layer or default if first time
   if (tool === 'edit' && e.detail.currentLayer) {
-    currentLayer = e.detail.currentLayer;
-    setAllowedTools();
+    changeLayerInternal(e.detail.currentLayer);
   }
   e.stopPropagation();
 }
@@ -184,7 +189,7 @@ function init(options, v) {
   layerSelector = editorLayers(editableLayers, v, {
     activeLayer: currentLayer
   });
-  drawTools(options.drawTools, currentLayer, v);
+  drawToolsSelector = drawTools(options.drawTools, currentLayer, v);
 
   document.addEventListener('enableInteraction', onEnableInteraction);
   document.addEventListener('changeEdit', onChangeEdit);
@@ -207,8 +212,9 @@ export default (function exportInit() {
    * @param {any} layerName
    */
     changeActiveLayer: (layerName) => {
-      currentLayer = layerName;
+      changeLayerInternal(layerName);
       layerSelector.changeLayer(layerName);
+      drawToolsSelector.updateTools(layerName);
     }
   };
 }());

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -56,6 +56,25 @@ export default function dropDown(target, items, options) {
     });
   }
 
+  /**
+   * Marks the provided value as selected. Does NOT fire the changeDropdown event as it is assumed that caller controls this control and
+   * already knows what to do.
+   * @param {any} value
+   */
+  function select(value) {
+    const optionslist = targetEl.getElementsByTagName('ul').item(0).getElementsByTagName('li');
+    const length = optionslist.length;
+    for (let ix = 0; ix < length; ix += 1) {
+      if (optionslist.item(ix).attributes[dataAttribute].value === value) {
+        toggleActive(optionslist.item(ix));
+      }
+    }
+  }
+
   render();
   addListener();
+
+  return {
+    select
+  };
 }


### PR DESCRIPTION
Closes #1615 and closes #1616. (Sorry had to implement them together)

Adds api functions to the Edit-component in order to make it possible to implement plug-in controls that can access the editor without having to make the user interact with the map or the editor toolbar.

# Implemented api-functions
All functions can be called without the editor actually being active (toolbar visible) and are accessed by getting a reference to the Edit-control: `viewer.getControlByName('editor');` and executing the methods on the component. All functions honor autoSave-setting.
## Change active layer
_changeActiveLayer:(layerName)_ : Changes the editor's active layer. The layer must be a layer that is not configured as a table, i.e. it should have a geometry and configured as editable as usual. The selected layer is indicated in the toolbar.

## Create new feature
_async function createFeature(layerName, geometry = null)_: Creates a new empty feature in the indicated layer. The layer does not have to be the same as the editor's active layer and the editor's active layer is NOT changed. The layer can be configured as `isTable`. If layer has geometry, a geometry should be passed as parameter. When the feature is created it is returned (in the promise). If autoSave is set, it will not return until it is saved. If autoForm is set the attribute editor will open after this function has returned.
## Delete feature
_async function deleteFeature(featureId, layerName)_: deletes a feature, honoring cascading delete setting for related tables. The layer does not have to be the same as the editor's active layer and the editor's active layer is NOT changed. The layer can be configured as `isTable`.  If autoSave is set it returns (in promise) when deleted from database.
## Open Attribute Editor
_function editFeatureAttributes(featureId, layerName)_: Opens the edit attributes dialog for the feature and returns immediately. The layer does not have to be the same as the editor's active layer and the editor's active layer is NOT changed. The layer can be configured as `isTable`. If autoSave is set the feature is saved when the dialog closes as usual.