### PR TITLE
Only header draggable in infowindow expandable list.

### DIFF
--- a/src/infowindow_expandableList.js
+++ b/src/infowindow_expandableList.js
@@ -135,10 +135,12 @@ function render(viewerId) {
   mainContainer = document.createElement('div');
   setInfowindowStyle();
   mainContainer.classList.add('sidebarcontainer', 'expandable_list');
-  mainContainer.id = 'sidebarcontainer-draggable';
+  mainContainer.id = 'sidebarcontainer';
   urvalContainer = document.createElement('div');
   urvalContainer.classList.add('urvalcontainer');
+
   const urvalTextNodeContainer = document.createElement('div');
+  urvalTextNodeContainer.id = 'sidebarcontainer-draggable';
   urvalTextNodeContainer.classList.add('urval-textnode-container');
   const urvalTextNode = document.createTextNode(infowindowOptions.title || 'Träffar');
   urvalTextNodeContainer.appendChild(urvalTextNode);


### PR DESCRIPTION
Fixes #1628 by making only the header draggable in infowindow when using expandable list.

Before: Entire window was draggable

Now: Only header is draggable, just like when using "old" infowindow.