### PR TITLE
feature: enable WMS-layers in stylepicker

### DIFF
--- a/src/controls/print/print-legend.js
+++ b/src/controls/print/print-legend.js
@@ -59,6 +59,10 @@ const LayerRow = function LayerRow(options) {
   const getWMSLegendUrl = (aLayer, format) => {
     const url = getOneUrl(aLayer);
     const layerName = aLayer.get('name');
+    const style = viewer.getStyle(aLayer.get('styleName'));
+    if (style && style[0] && style[0][0] && style[0][0].icon) {
+      return `${style[0][0].icon.src}&format=${format}`;
+    }
     return `${url}?SERVICE=WMS&layer=${layerName}&format=${format}&version=1.1.1&request=getLegendGraphic&scale=401&legend_options=dpi:300`;
   };
 

--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -56,6 +56,20 @@ function createWmsStyle(wmsOptions, source, viewer, defaultStyle = true) {
   return styleName;
 }
 
+function createWmsLayer(wmsOptions, source, viewer) {
+  const wmsOpts = wmsOptions;
+  const wmsSource = source;
+  if (wmsOpts.styleName === 'default') {
+    wmsOpts.styleName = createWmsStyle(wmsOptions, source, viewer);
+    wmsOpts.style = wmsOptions.styleName;
+  } else if (wmsOptions.altStyleIndex > -1) {
+    wmsOpts.defaultStyle = createWmsStyle(wmsOptions, source, viewer);
+    wmsOpts.styleName = createWmsStyle(wmsOptions, source, viewer, false);
+    wmsOpts.style = wmsOptions.styleName;
+    wmsSource.getParams().STYLES = wmsOptions.styleName;
+  }
+}
+
 const wms = function wms(layerOptions, viewer) {
   const wmsDefault = {
     featureinfoLayer: null
@@ -92,24 +106,12 @@ const wms = function wms(layerOptions, viewer) {
 
   if (renderMode === 'image') {
     const source = createImageSource(sourceOptions);
-    if (wmsOptions.styleName === 'default') {
-      wmsOptions.styleName = createWmsStyle(wmsOptions, source, viewer);
-      wmsOptions.style = wmsOptions.styleName;
-    }
+    createWmsLayer(wmsOptions, source, viewer);
     return image(wmsOptions, source);
   }
 
   const source = createTileSource(sourceOptions);
-
-  if (wmsOptions.styleName === 'default') {
-    wmsOptions.styleName = createWmsStyle(wmsOptions, source, viewer);
-    wmsOptions.style = wmsOptions.styleName;
-  } else if (wmsOptions.altStyleIndex > -1) {
-    wmsOptions.defaultStyle = createWmsStyle(wmsOptions, source, viewer);
-    wmsOptions.styleName = createWmsStyle(wmsOptions, source, viewer, false);
-    wmsOptions.style = wmsOptions.styleName;
-    source.getParams().STYLES = wmsOptions.styleName;
-  }
+  createWmsLayer(wmsOptions, source, viewer);
   return tile(wmsOptions, source);
 };
 


### PR DESCRIPTION
Proposes to fix #1583 

Allows users to declare alternate styles for WMS-layers in the stylepicker. It is possible to declare whether a style is has theme. A title for the default style is declared by setting the `default` flag. Chosen style will be saved when sharing the map. 

Example of how to format the settings in json:
![es-85](https://user-images.githubusercontent.com/92101462/203066615-8874e2d8-e870-4504-98b8-ba6c868ff847.png)

![es-85-legend](https://user-images.githubusercontent.com/92101462/203069407-47b1ef80-196c-4985-bc6e-ab0709ebc597.png)


Will also take style-url for WMS-layers declared in json document into consideration before the url from layer source in the print legend.