### PR TITLE
fix: make layers with workspace:layer names work with stylePicker

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -386,7 +386,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
   };
 
   const getLayerStylePicker = function getLayerStylePicker(layer) {
-    return layerStylePicker[layer.get('name')] || [];
+    return layerStylePicker[layer.get('id')] || [];
   };
 
   const addLayerStylePicker = function addLayerStylePicker(layerProps) {


### PR DESCRIPTION
Aims to fix #1634 

A rather simple potential fix. Have tested:
- Sharing mapstate and hash
- Printing
- Combined with Show only visible layers
- WFS and WMS alt stylers