### PR TITLE
fix: really disable print buttons while print preview map is loading

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -16,6 +16,11 @@ $print-scale-line-font-size: $font-size-smallest;
   overflow: hidden;
 }
 
+// for print buttons while print preview map is loading
+.print-button-disable {
+  pointer-events: none;
+}
+
 // scale-line
 .print-scale-line {
   background: $print-control-bg-color;

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -16,11 +16,6 @@ $print-scale-line-font-size: $font-size-smallest;
   overflow: hidden;
 }
 
-// for print buttons while print preview map is loading
-.print-button-disable {
-  pointer-events: none;
-}
-
 // scale-line
 .print-scale-line {
   background: $print-control-bg-color;

--- a/src/controls/print/print-toolbar.js
+++ b/src/controls/print/print-toolbar.js
@@ -18,10 +18,10 @@ const PrintToolbar = function PrintToolbar() {
       pdfButton.on('click', this.dispatchPrint.bind(this));
     },
     dispatchExport() {
-      this.dispatch('PNG');
+      if (pngButton.getState() !== 'disabled') this.dispatch('PNG');
     },
     dispatchPrint() {
-      this.dispatch('PDF');
+      if (pdfButton.getState() !== 'disabled') this.dispatch('PDF');
     },
     onRender() {
       this.dispatch('render');
@@ -39,14 +39,10 @@ const PrintToolbar = function PrintToolbar() {
     setDisabled(disabled) {
       if (disabled) {
         pngButton.setState('disabled');
-        document.getElementById(pngButton.getId()).classList.add('print-button-disable');
         pdfButton.setState('disabled');
-        document.getElementById(pdfButton.getId()).classList.add('print-button-disable');
       } else {
         pngButton.setState('initial');
-        document.getElementById(pngButton.getId()).classList.remove('print-button-disable');
         pdfButton.setState('initial');
-        document.getElementById(pdfButton.getId()).classList.remove('print-button-disable');
       }
     }
   });

--- a/src/controls/print/print-toolbar.js
+++ b/src/controls/print/print-toolbar.js
@@ -37,8 +37,17 @@ const PrintToolbar = function PrintToolbar() {
       </div>`;
     },
     setDisabled(disabled) {
-      pngButton.setState(disabled ? 'disabled' : 'initial');
-      pdfButton.setState(disabled ? 'disabled' : 'initial');
+      if (disabled) {
+        pngButton.setState('disabled');
+        document.getElementById(pngButton.getId()).classList.add('print-button-disable');
+        pdfButton.setState('disabled');
+        document.getElementById(pdfButton.getId()).classList.add('print-button-disable');
+      } else {
+        pngButton.setState('initial');
+        document.getElementById(pngButton.getId()).classList.remove('print-button-disable');
+        pdfButton.setState('initial');
+        document.getElementById(pdfButton.getId()).classList.remove('print-button-disable');
+      }
     }
   });
 };


### PR DESCRIPTION
Aims to fix #1661 
(and prevent unnecessary event listening when the print panel isn't active)