### PR TITLE
fix: crash when printing on iOS

### DIFF
--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -84,6 +84,8 @@ const PrintComponent = function PrintComponent(options = {}) {
   const originalResolutions = viewer.getResolutions().map(item => item);
   const originalGrids = new Map();
   const deviceOnIos = isOnIos();
+
+  // eslint-disable-next-line no-underscore-dangle
   const olPixelRatio = map.pixelRatio_;
 
   if (!Array.isArray(scales) || scales.length === 0) {


### PR DESCRIPTION
Fixes #1665 
Lowered the pixelratio when printing if on iOS device. Also added touch.action: none for the print container since pinch zooming in the print preview also could make the print function crash.