### PR TITLE
Wms stylepicker legendparams

### DIFF
--- a/src/controls/legend/overlayproperties.js
+++ b/src/controls/legend/overlayproperties.js
@@ -90,7 +90,7 @@ const OverlayProperties = function OverlayProperties(options = {}) {
       layerSource.refresh();
       layer.set('styleName', styleToSet);
       let maxResolution;
-      if (!(altStyle.legendParams) || !(Object.keys(altStyle.legendParams).find(k => k.toUpperCase() === 'SCALE'))) {
+      if (!(altStyle.legendParams) || !(Object.keys(altStyle.legendParams).find(key => key.toUpperCase() === 'SCALE'))) {
         maxResolution = viewer.getResolutions()[viewer.getResolutions().length - 1];
       }
 

--- a/src/controls/legend/overlayproperties.js
+++ b/src/controls/legend/overlayproperties.js
@@ -89,8 +89,15 @@ const OverlayProperties = function OverlayProperties(options = {}) {
       }
       layerSource.refresh();
       layer.set('styleName', styleToSet);
-      const maxResolution = viewer.getResolutions()[viewer.getResolutions().length - 1];
-      const getLegendString = layerSource.getLegendUrl(maxResolution, { STYLE: styleToSet });
+      let maxResolution;
+      if (!(altStyle.legendParams) || !(Object.keys(altStyle.legendParams).find(k => k.toUpperCase() === 'SCALE'))) {
+        maxResolution = viewer.getResolutions()[viewer.getResolutions().length - 1];
+      }
+
+      const getLegendString = layerSource.getLegendUrl(maxResolution, {
+        STYLE: styleToSet,
+        ...altStyle.legendParams
+      });
       const newWmsStyle = [[{
         icon: {
           src: `${getLegendString}`

--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -38,9 +38,24 @@ function createImageSource(options) {
 }
 
 function createWmsStyle(wmsOptions, source, viewer, defaultStyle = true) {
-  const maxResolution = viewer.getResolutions()[viewer.getResolutions().length - 1];
+  let altStyleLegendParams;
+  let maxResolution = viewer.getResolutions()[viewer.getResolutions().length - 1];
+
+  if (!(defaultStyle) && (wmsOptions.stylePicker)) {
+    const altStyle = wmsOptions.stylePicker.find(style => style.style === wmsOptions.styleName);
+    if (altStyle.legendParams) {
+      altStyleLegendParams = altStyle.legendParams;
+      if (Object.keys(altStyle.legendParams).find(key => key.toUpperCase() === 'SCALE')) {
+        maxResolution = null;
+      }
+    }
+  }
+
   const styleName = defaultStyle ? `${wmsOptions.name}_WMSDefault` : wmsOptions.styleName;
-  const getLegendString = defaultStyle ? source.getLegendUrl(maxResolution, wmsOptions.legendParams) : source.getLegendUrl(maxResolution, { STYLE: styleName });
+  const getLegendString = defaultStyle ? source.getLegendUrl(maxResolution, wmsOptions.legendParams) : source.getLegendUrl(maxResolution, {
+    STYLE: styleName,
+    ...altStyleLegendParams
+  });
   let hasThemeLegend = wmsOptions.hasThemeLegend || false;
   if (!defaultStyle) {
     hasThemeLegend = wmsOptions.stylePicker[wmsOptions.altStyleIndex].hasThemeLegend || false;


### PR DESCRIPTION
Aims to fix #1657 ie it adds the `legendParams` object property to the stylePicker for WMS-layers, so that alternative styles for a WMS layer can have such options for their legendGraphic as well as WMS-layers without a stylePicker and the default style of a WMS layer with a stylePicker.

Have run some basic tests on changing the style to a stylePicker style with legendParams, sharing, printing.