### PR TITLE
feature: make the central print component available externally

### DIFF
--- a/src/controls/print/index.js
+++ b/src/controls/print/index.js
@@ -63,9 +63,13 @@ const Print = function Print(options = {}) {
   let screenButton;
   let mapMenu;
   let menuItem;
+  let printComponent;
+
+  const getPrintComponent = () => printComponent;
 
   return Component({
     name: 'print',
+    getPrintComponent,
     onInit() {
       if ('visible' in northArrow) {
         showNorthArrow = northArrow.visible;
@@ -76,7 +80,7 @@ const Print = function Print(options = {}) {
     },
     onAdd(evt) {
       viewer = evt.target;
-      const printComponent = PrintComponent({
+      printComponent = PrintComponent({
         logo,
         northArrow,
         printLegend,


### PR DESCRIPTION
Aims to fix #1654 . Enables for instance `viewer.getControlByName('print').getPrintComponent().on('render', () => {` for something to happen when the print preview panel is opened. More things become possible.