### PR TITLE
feat: add feature styling

### DIFF
--- a/src/controls/draganddrop.js
+++ b/src/controls/draganddrop.js
@@ -8,6 +8,7 @@ import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 import Style from '../style';
 import { Component } from '../ui';
+import { getStylewindowStyle } from './editor/stylewindow';
 
 const DragAndDrop = function DragAndDrop(options = {}) {
   let dragAndDrop;
@@ -21,6 +22,7 @@ const DragAndDrop = function DragAndDrop(options = {}) {
       map = viewer.getMap();
       const groupName = options.groupName || 'egna-lager';
       const groupTitle = options.groupTitle || 'Egna lager';
+      const styleByAttribute = options.styleByAttribute || false;
       const featureStyles = options.featureStyles || {
         Point: [{
           circle: {
@@ -95,6 +97,12 @@ const DragAndDrop = function DragAndDrop(options = {}) {
         }
         vectorSource = new VectorSource({
           features: event.features
+        });
+        vectorSource.forEachFeature((feature) => {
+          if (feature.get('style') && styleByAttribute) {
+            const featureStyle = getStylewindowStyle(feature, feature.get('style'));
+            feature.setStyle(featureStyle);
+          }
         });
         if (!viewer.getGroup(groupName)) {
           viewer.addGroup({ title: groupTitle, name: groupName, expanded: true });

--- a/src/controls/editor/styletemplate.js
+++ b/src/controls/editor/styletemplate.js
@@ -1,0 +1,93 @@
+export default function styleTemplate(palette, swStyle) {
+  const colorArray = palette;
+  let fillHtml = '<div id="o-editor-style-fill" class="padding border-bottom"><div class="text-large text-align-center">Fyllning</div><div id="o-editor-style-fillColor"><ul>';
+  if (!colorArray.includes(swStyle.fillColor)) {
+    colorArray.push(swStyle.fillColor);
+  }
+  if (!colorArray.includes(swStyle.strokeColor)) {
+    colorArray.push(swStyle.strokeColor);
+  }
+  for (let i = 0; i < colorArray.length; i += 1) {
+    const checked = colorArray[i] === swStyle.fillColor ? ' checked=true' : '';
+    fillHtml += `<li>
+    <input type="radio" id="fillColorRadio${i}" name="fillColorRadio" value="${colorArray[i]}"${checked} />
+    <label for="fillColorRadio${i}"><span style="background:${colorArray[i]}"></span></label>
+    </li>`;
+  }
+
+  fillHtml += `</ul></div><div class="padding-smaller o-tooltip active">
+  <input id="o-editor-style-fillOpacitySlider" type="range" min="0.05" max="1" value="${swStyle.fillOpacity}" step="0.05">
+  <div class="text-align-center">
+    <span class="text-smaller float-left">5%</span>
+    <span class="text-smaller">Opacitet</span>
+    <span class="text-smaller float-right">100%</span>
+  </div>
+  </div></div>`;
+
+  let strokeHtml = '<div id="o-editor-style-stroke" class="padding border-bottom"><div class="text-large text-align-center">Kantlinje</div><div id="o-editor-style-strokeColor"><ul>';
+  for (let i = 0; i < colorArray.length; i += 1) {
+    const checked = colorArray[i] === swStyle.strokeColor ? ' checked=true' : '';
+    strokeHtml += `<li>
+    <input type="radio" id="strokeColorRadio${i}" name="strokeColorRadio" value="${colorArray[i]}"${checked} />
+    <label for="strokeColorRadio${i}"><span style="background:${colorArray[i]}"></span></label>
+    </li>`;
+  }
+
+  strokeHtml += `</ul></div><div class="padding-smaller o-tooltip active">
+  <input id="o-editor-style-strokeOpacitySlider" type="range" min="0.05" max="1" value="${swStyle.strokeOpacity}" step="0.05">
+  <div class="text-align-center">
+    <span class="text-smaller float-left">5%</span>
+    <span class="text-smaller">Opacitet</span>
+    <span class="text-smaller float-right">100%</span>
+  </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+  <input id="o-editor-style-strokeWidthSlider" type="range" min="1" max="10" value="${swStyle.strokeWidth}" step="1">
+  <div class="text-align-center">
+    <span class="text-smaller float-left">1px</span>
+    <span class="text-smaller">Linjebredd</span>
+    <span class="text-smaller float-right">10px</span>
+  </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+    <select id="o-editor-style-strokeType" class="small no-margin width-full">
+      <option value="line"${swStyle.strokeType === 'line' ? ' selected' : ''}>Heldragen linje</option>
+      <option value="dash"${swStyle.strokeType === 'dash' ? ' selected' : ''}>Streckad linje</option>
+      <option value="point"${swStyle.strokeType === 'point' ? ' selected' : ''}>Punktad linje</option>
+      <option value="dash-point"${swStyle.strokeType === 'dash-point' ? ' selected' : ''}>Streck-punkt-linje</option>
+    </select>
+  </div></div>`;
+
+  const pointHtml = `<div id="o-editor-style-point" class="padding border-bottom"><div class="text-large text-align-center">Punkt</div><div class="padding-smaller o-tooltip active">
+    <input id="o-editor-style-pointSizeSlider" type="range" min="1" max="50" value="${swStyle.pointSize}" step="1">
+    <div class="text-align-center">
+      <span class="text-smaller float-left">1px</span>
+      <span class="text-smaller">Punktstorlek</span>
+      <span class="text-smaller float-right">50px</span>
+    </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+    <select id="o-editor-style-pointType" class="small no-margin width-full">
+      <option value="circle"${swStyle.pointType === 'circle' ? ' selected' : ''}>Cirkel</option>
+      <option value="x"${swStyle.pointType === 'x' ? ' selected' : ''}>Kryss</option>
+      <option value="cross"${swStyle.pointType === 'cross' ? ' selected' : ''}>Kors</option>
+      <option value="star"${swStyle.pointType === 'star' ? ' selected' : ''}>Stjärna</option>
+      <option value="triangle"${swStyle.pointType === 'triangle' ? ' selected' : ''}>Triangel</option>
+      <option value="square"${swStyle.pointType === 'square' ? ' selected' : ''}>Kvadrat</option>
+    </select>
+  </div></div>`;
+
+  const textHtml = `<div id="o-editor-style-text" class="padding border-bottom"><div class="text-large text-align-center">Text</div><div class="padding-smaller o-tooltip active">
+    <input id="o-editor-style-textSizeSlider" type="range" min="8" max="128" value="${swStyle.textSize}" step="1">
+    <div class="text-align-center">
+      <span class="text-smaller float-left">8px</span>
+      <span class="text-smaller">Textstorlek</span>
+      <span class="text-smaller float-right">128px</span>
+    </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+    <input id="o-editor-style-textString" class="small no-margin width-full" type="text" value="${swStyle.textString}">
+  </div></div>`;
+
+  return textHtml + pointHtml + fillHtml + strokeHtml;
+}

--- a/src/controls/editor/stylewindow.js
+++ b/src/controls/editor/stylewindow.js
@@ -1,0 +1,556 @@
+import Circle from 'ol/style/Circle';
+import Fill from 'ol/style/Fill';
+import MultiPoint from 'ol/geom/MultiPoint';
+import Point from 'ol/geom/Point';
+import RegularShape from 'ol/style/RegularShape';
+import Stroke from 'ol/style/Stroke';
+import Style from 'ol/style/Style';
+import Text from 'ol/style/Text';
+import styleTemplate from './styletemplate';
+import { Button, Component, Element, dom } from '../../ui';
+import editHandler from './edithandler';
+
+const white = [255, 255, 255, 1];
+const blue = [0, 153, 255, 1];
+const blueSelect = [0, 153, 255, 0.1];
+const width = 3;
+
+const drawStyle = {
+  draw: [{
+    text: {
+      font: 'bold 13px "Helvetica Neue", Helvetica, Arial, sans-serif',
+      textBaseline: 'bottom',
+      textAlign: 'center',
+      offsetY: -4,
+      fill: {
+        color: [0, 153, 255, 1]
+      },
+      stroke: {
+        color: [255, 255, 255, 0.8],
+        width: 4
+      }
+    }
+  }, {
+    stroke: {
+      color: [0, 153, 255, 1],
+      width: 3
+    }
+  }, {
+    fill: {
+      color: [255, 255, 255, 0]
+    }
+  }, {
+    icon: {
+      anchor: [0.5, 32],
+      anchorXUnits: 'fraction',
+      anchorYUnits: 'pixels',
+      src: 'img/png/drop_blue.png'
+    }
+  }],
+  select: [{
+    stroke: {
+      color: white,
+      width: width + 2
+    }
+  }, {
+    stroke: {
+      color: blue,
+      width
+    },
+    fill: {
+      color: blueSelect
+    },
+    circle: {
+      radius: 3,
+      stroke: {
+        color: blue,
+        width: 0
+      },
+      fill: {
+        color: blue
+      }
+    }
+  }],
+  text: {
+    text: {
+      font: '20px "Helvetica Neue", Helvetica, Arial, sans-serif',
+      textBaseline: 'bottom',
+      textAlign: 'center',
+      fill: {
+        color: blue
+      },
+      stroke: {
+        color: [255, 255, 255, 0.8],
+        width: 4
+      }
+    }
+  }
+};
+
+const selectionStyle = new Style({
+  image: new Circle({
+    radius: 6,
+    fill: new Fill({
+      color: [200, 100, 100, 0.8]
+    })
+  }),
+  geometry(feature) {
+    let coords;
+    let pointGeometry;
+    const type = feature.getGeometry().getType();
+    if (type === 'Polygon') {
+      coords = feature.getGeometry().getCoordinates()[0];
+      pointGeometry = new MultiPoint(coords);
+    } else if (type === 'LineString') {
+      coords = feature.getGeometry().getCoordinates();
+      pointGeometry = new MultiPoint(coords);
+    } else if (type === 'Point') {
+      coords = feature.getGeometry().getCoordinates();
+      pointGeometry = new Point(coords);
+    }
+    return pointGeometry;
+  }
+});
+
+let annotationField;
+let swStyle = {};
+const swDefaults = {
+  fillColor: 'rgb(0,153,255)',
+  fillOpacity: 0.75,
+  strokeColor: 'rgb(0,153,255)',
+  strokeOpacity: 1,
+  strokeWidth: 2,
+  strokeType: 'line',
+  pointSize: 10,
+  pointType: 'circle',
+  textSize: 20,
+  textString: 'Text',
+  textFont: '"Helvetica Neue", Helvetica, Arial, sans-serif'
+};
+
+function rgbToArray(colorString, opacity = 1) {
+  const colorArray = colorString.replace(/[^\d,.]/g, '').split(',');
+  colorArray[3] = opacity;
+  return colorArray;
+}
+
+function rgbToRgba(colorString, opacity = 1) {
+  const colorArray = colorString.replace(/[^\d,.]/g, '').split(',');
+  return `rgba(${colorArray[0]}, ${colorArray[1]}, ${colorArray[2]}, ${opacity})`;
+}
+
+function createRegularShape(type, size, fill, stroke) {
+  let style;
+  switch (type) {
+    case 'square':
+      style = new Style({
+        image: new RegularShape({
+          fill,
+          stroke,
+          points: 4,
+          radius: size,
+          angle: Math.PI / 4
+        })
+      });
+      break;
+
+    case 'triangle':
+      style = new Style({
+        image: new RegularShape({
+          fill,
+          stroke,
+          points: 3,
+          radius: size,
+          rotation: 0,
+          angle: 0
+        })
+      });
+      break;
+
+    case 'star':
+      style = new Style({
+        image: new RegularShape({
+          fill,
+          stroke,
+          points: 5,
+          radius: size,
+          radius2: size / 2.5,
+          angle: 0
+        })
+      });
+      break;
+
+    case 'cross':
+      style = new Style({
+        image: new RegularShape({
+          fill,
+          stroke,
+          points: 4,
+          radius: size,
+          radius2: 0,
+          angle: 0
+        })
+      });
+      break;
+
+    case 'x':
+      style = new Style({
+        image: new RegularShape({
+          fill,
+          stroke,
+          points: 4,
+          radius: size,
+          radius2: 0,
+          angle: Math.PI / 4
+        })
+      });
+      break;
+
+    case 'circle':
+      style = new Style({
+        image: new Circle({
+          fill,
+          stroke,
+          radius: size
+        })
+      });
+      break;
+
+    default:
+      style = new Style({
+        image: new Circle({
+          fill,
+          stroke,
+          radius: size
+        })
+      });
+  }
+  return style;
+}
+
+function setFillColor(color) {
+  swStyle.fillColor = rgbToRgba(color, swStyle.fillOpacity);
+}
+
+function setStrokeColor(color) {
+  swStyle.strokeColor = rgbToRgba(color, swStyle.strokeOpacity);
+}
+
+function getStyleObject() {
+  return Object.assign({}, swStyle);
+}
+
+function restoreStylewindow() {
+  document.getElementById('o-editor-style-fill').classList.remove('hidden');
+  document.getElementById('o-editor-style-stroke').classList.remove('hidden');
+  document.getElementById('o-editor-style-point').classList.remove('hidden');
+  document.getElementById('o-editor-style-text').classList.remove('hidden');
+}
+
+function updateStylewindow(feature) {
+  let geometryType = feature.getGeometry().getType();
+  swStyle = Object.assign(swStyle, feature.get('style'));
+  if (feature.get(annotationField)) {
+    geometryType = 'TextPoint';
+  }
+  switch (geometryType) {
+    case 'LineString':
+    case 'MultiLineString':
+      document.getElementById('o-editor-style-fill').classList.add('hidden');
+      document.getElementById('o-editor-style-point').classList.add('hidden');
+      document.getElementById('o-editor-style-text').classList.add('hidden');
+      break;
+    case 'Polygon':
+    case 'MultiPolygon':
+      document.getElementById('o-editor-style-point').classList.add('hidden');
+      document.getElementById('o-editor-style-text').classList.add('hidden');
+      break;
+    case 'Point':
+    case 'MultiPoint':
+      document.getElementById('o-editor-style-text').classList.add('hidden');
+      break;
+    case 'TextPoint':
+      document.getElementById('o-editor-style-stroke').classList.add('hidden');
+      document.getElementById('o-editor-style-point').classList.add('hidden');
+      break;
+    default:
+      break;
+  }
+  document.getElementById('o-editor-style-pointSizeSlider').value = swStyle.pointSize;
+  document.getElementById('o-editor-style-pointType').value = swStyle.pointType;
+  document.getElementById('o-editor-style-textSizeSlider').value = swStyle.textSize;
+  document.getElementById('o-editor-style-textString').value = swStyle.textString;
+  swStyle.strokeColor = swStyle.strokeColor.replace(/ /g, '');
+  const strokeEl = document.getElementById('o-editor-style-strokeColor');
+  const strokeInputEl = strokeEl.querySelector(`input[value = "${swStyle.strokeColor}"]`);
+  if (strokeInputEl) {
+    strokeInputEl.checked = true;
+  } else {
+    const checkedEl = document.querySelector('input[name = "strokeColorRadio"]:checked');
+    if (checkedEl) {
+      checkedEl.checked = false;
+    }
+  }
+  document.getElementById('o-editor-style-strokeWidthSlider').value = swStyle.strokeWidth;
+  document.getElementById('o-editor-style-strokeOpacitySlider').value = swStyle.strokeOpacity;
+  document.getElementById('o-editor-style-strokeType').value = swStyle.strokeType;
+
+  const fillEl = document.getElementById('o-editor-style-fillColor');
+  swStyle.fillColor = swStyle.fillColor.replace(/ /g, '');
+  const fillInputEl = fillEl.querySelector(`input[value = "${swStyle.fillColor}"]`);
+  if (fillInputEl) {
+    fillInputEl.checked = true;
+  } else {
+    const checkedEl = document.querySelector('input[name = "fillColorRadio"]:checked');
+    if (checkedEl) {
+      checkedEl.checked = false;
+    }
+  }
+  document.getElementById('o-editor-style-fillOpacitySlider').value = swStyle.fillOpacity;
+}
+
+function getStylewindowStyle(feature, featureStyle) {
+  const styleObj = Object.assign(swStyle, featureStyle);
+
+  let geometryType = feature.getGeometry().getType();
+  if (feature.get(annotationField)) {
+    geometryType = 'TextPoint';
+  }
+  const style = [];
+  let lineDash;
+  if (styleObj.strokeType === 'dash') {
+    lineDash = [3 * styleObj.strokeWidth, 3 * styleObj.strokeWidth];
+  } else if (styleObj.strokeType === 'dash-point') {
+    lineDash = [3 * styleObj.strokeWidth, 3 * styleObj.strokeWidth, 0.1, 3 * styleObj.strokeWidth];
+  } else if (styleObj.strokeType === 'point') {
+    lineDash = [0.1, 3 * styleObj.strokeWidth];
+  } else {
+    lineDash = false;
+  }
+
+  const stroke = new Stroke({
+    color: styleObj.strokeColor,
+    width: styleObj.strokeWidth,
+    lineDash
+  });
+  const fill = new Fill({
+    color: styleObj.fillColor
+  });
+  const font = `${styleObj.textSize}px ${styleObj.textFont}`;
+  switch (geometryType) {
+    case 'LineString':
+    case 'MultiLineString':
+      style[0] = new Style({
+        stroke
+      });
+      break;
+    case 'Polygon':
+    case 'MultiPolygon':
+      style[0] = new Style({
+        fill,
+        stroke,
+        text: new Text({
+          text: styleObj.textString || 'Text',
+          font,
+          fill
+        })
+      });
+      break;
+    case 'Point':
+    case 'MultiPoint':
+      style[0] = createRegularShape(styleObj.pointType, styleObj.pointSize, fill, stroke);
+      break;
+    case 'TextPoint':
+      style[0] = new Style({
+        text: new Text({
+          text: styleObj.textString || 'Text',
+          font,
+          fill
+        })
+      });
+      feature.set(annotationField, styleObj.textString || 'Text');
+      break;
+    default:
+      style[0] = createRegularShape(styleObj.pointType, styleObj.pointSize, fill, stroke);
+      break;
+  }
+  return style;
+}
+
+function styleFeature(feature) {
+  if (feature) {
+    const style = feature.getStyle() || [];
+    style[0] = getStylewindowStyle(feature)[0];
+    feature.set('style', getStyleObject());
+    feature.setStyle(style);
+  } else {
+    editHandler.getSelection().forEach((selectedFeature) => {
+      const style = selectedFeature.getStyle();
+      style[0] = getStylewindowStyle(selectedFeature)[0];
+      selectedFeature.set('style', getStyleObject());
+      selectedFeature.setStyle(style);
+    });
+  }
+}
+
+function bindUIActions() {
+  let matches;
+  const fillColorEl = document.getElementById('o-editor-style-fillColor');
+  const strokeColorEl = document.getElementById('o-editor-style-strokeColor');
+
+  matches = fillColorEl.querySelectorAll('span');
+  for (let i = 0; i < matches.length; i += 1) {
+    matches[i].addEventListener('click', function e() {
+      setFillColor(this.style.backgroundColor);
+      styleFeature();
+    });
+  }
+
+  matches = strokeColorEl.querySelectorAll('span');
+  for (let i = 0; i < matches.length; i += 1) {
+    matches[i].addEventListener('click', function e() {
+      setStrokeColor(this.style.backgroundColor);
+      styleFeature();
+    });
+  }
+
+  document.getElementById('o-editor-style-fillOpacitySlider').addEventListener('input', function e() {
+    swStyle.fillOpacity = this.value;
+    setFillColor(swStyle.fillColor);
+    styleFeature();
+  });
+
+  document.getElementById('o-editor-style-strokeOpacitySlider').addEventListener('input', function e() {
+    swStyle.strokeOpacity = this.value;
+    setStrokeColor(swStyle.strokeColor);
+    styleFeature();
+  });
+
+  document.getElementById('o-editor-style-strokeWidthSlider').addEventListener('input', function e() {
+    swStyle.strokeWidth = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-editor-style-strokeType').addEventListener('change', function e() {
+    swStyle.strokeType = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-editor-style-pointType').addEventListener('change', function e() {
+    swStyle.pointType = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-editor-style-pointSizeSlider').addEventListener('input', function e() {
+    swStyle.pointSize = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-editor-style-textString').addEventListener('input', function e() {
+    swStyle.textString = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-editor-style-textSizeSlider').addEventListener('input', function e() {
+    swStyle.textSize = this.value;
+    styleFeature();
+  });
+}
+
+function Stylewindow(optOptions = {}) {
+  const {
+    title = 'Anpassa stil',
+    cls = 'control overflow-hidden hidden',
+    target,
+    closeIcon = '#ic_close_24px',
+    style = '',
+    palette = ['rgb(166,206,227)', 'rgb(31,120,180)', 'rgb(178,223,138)', 'rgb(51,160,44)', 'rgb(251,154,153)', 'rgb(227,26,28)', 'rgb(253,191,111)']
+  } = optOptions;
+
+  annotationField = optOptions.annotation || 'annonation';
+  swStyle = Object.assign(swDefaults, optOptions.swDefaults);
+
+  let stylewindowEl;
+  let titleEl;
+  let headerEl;
+  let contentEl;
+  let closeButton;
+
+  palette.forEach((item, index) => {
+    const colorArr = rgbToArray(palette[index]);
+    palette[index] = `rgb(${colorArr[0]},${colorArr[1]},${colorArr[2]})`;
+  });
+
+  const closeWindow = function closeWindow() {
+    stylewindowEl.classList.toggle('hidden');
+  };
+
+  return Component({
+    closeWindow,
+    onInit() {
+      const headerCmps = [];
+
+      titleEl = Element({
+        cls: 'flex row justify-start margin-y-small margin-left text-weight-bold',
+        style: 'width: 100%;',
+        innerHTML: `${title}`
+      });
+      headerCmps.push(titleEl);
+
+      closeButton = Button({
+        cls: 'small round margin-top-small margin-right-small margin-bottom-auto margin-right icon-smaller grey-lightest no-shrink',
+        icon: closeIcon,
+        validStates: ['initial', 'hidden'],
+        click() {
+          closeWindow();
+        }
+      });
+      headerCmps.push(closeButton);
+
+      headerEl = Element({
+        cls: 'flex justify-end grey-lightest',
+        components: headerCmps
+      });
+
+      contentEl = Element({
+        cls: 'o-editor-stylewindow-content overflow-auto',
+        innerHTML: `${styleTemplate(palette, swStyle)}`
+      });
+
+      this.addComponent(headerEl);
+      this.addComponent(contentEl);
+
+      this.on('render', this.onRender);
+      document.getElementById(target).appendChild(dom.html(this.render()));
+      this.dispatch('render');
+      bindUIActions();
+    },
+    onRender() {
+      stylewindowEl = document.getElementById('o-editor-stylewindow');
+    },
+    render() {
+      let addStyle;
+      if (style !== '') {
+        addStyle = `style="${style}"`;
+      } else {
+        addStyle = '';
+      }
+      return `<div id="o-editor-stylewindow" class="${cls} flex">
+                  <div class="absolute flex column no-margin width-full height-full" ${addStyle}>
+                    ${headerEl.render()}
+                    ${contentEl.render()}
+                  </div>
+                </div>`;
+    }
+  });
+}
+
+export {
+  drawStyle,
+  selectionStyle,
+  Stylewindow,
+  restoreStylewindow,
+  updateStylewindow,
+  getStylewindowStyle,
+  styleFeature
+};

--- a/src/layer/geojson.js
+++ b/src/layer/geojson.js
@@ -2,6 +2,7 @@ import VectorSource from 'ol/source/Vector';
 import GeoJSON from 'ol/format/GeoJSON';
 import vector from './vector';
 import isurl from '../utils/isurl';
+import { getStylewindowStyle } from '../controls/editor/stylewindow';
 
 function createSource(options) {
   const vectorSource = new VectorSource({
@@ -22,6 +23,10 @@ function createSource(options) {
                 feature.setId(1000000 + i);
               }
             }
+            if (feature.get('style') && options.styleByAttribute) {
+              const featureStyle = getStylewindowStyle(feature, feature.get('style'));
+              feature.setStyle(featureStyle);
+            }
             i += 1;
           });
         }
@@ -37,7 +42,8 @@ function createSource(options) {
 
 const geojson = function geojson(layerOptions, viewer) {
   const geojsonDefault = {
-    layerType: 'vector'
+    layerType: 'vector',
+    styleByAttribute: false
   };
   const geojsonOptions = Object.assign(geojsonDefault, layerOptions);
   const sourceOptions = {};
@@ -46,6 +52,7 @@ const geojson = function geojson(layerOptions, viewer) {
   geojsonOptions.extent = undefined;
   sourceOptions.projectionCode = viewer.getProjectionCode();
   sourceOptions.idField = layerOptions.idField || 'id';
+  sourceOptions.styleByAttribute = geojsonOptions.styleByAttribute;
   if (geojsonOptions.projection) {
     sourceOptions.dataProjection = geojsonOptions.projection;
   } else if (sourceOptions.projection) {


### PR DESCRIPTION
Fixes #1676
Adds the possibility to set the drag and drop control as well as a geojson source to style features based on the "style" attribute of the feature rather than the layer style. Configured as `"styleByAttribute":true` as options for the drag and drop control or property of a geojson-layer. Set to false by default. This functionlity is most useful with export/import/sharing functionality.

Example usage:
```
    {
      "name": "draganddrop",
      "options": {
        "styleByAttribute":true
      }
    }
```
OR
```
    {
      "name": "origo-mask",
      "opacity": 0.25,
      "title": "origo-mask",
      "group": "none",
      "queryable": false,
      "source": "data/origo-mask-3857.geojson",
      "style": "mask",
      "type": "GEOJSON",
      "visible": true,
      "styleByAttribute": true
    }
```
Origo mask geojson with style object:
```
............."features": [
{ "type": "Feature", "properties": {"style":{"fillColor":"rgba(255,120,20,0.8)","fillOpacity":0.8,"strokeColor":"rgba(255, 0, 0, 1)","strokeOpacity":1,"strokeWidth":"6","strokeType":"dash"}}, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -19679343, -19747663 ],....................
```
And it will override the layer setting:
![image](https://user-images.githubusercontent.com/6848075/217542374-bc104364-c82d-4ab5-b32a-8df3091207d1.png)
