### PR TITLE
feature: wfs filtering

### DIFF
--- a/src/layer/wfssource.js
+++ b/src/layer/wfssource.js
@@ -64,6 +64,23 @@ class WfsSource extends VectorSource {
   }
 
   /**
+   * Set filter on layer
+   * @param {any} cql
+   */
+  setFilter(cql) {
+    this._options.filter = cql;
+    this.refresh();
+  }
+
+  /**
+   * Clear filter on layer
+   */
+  clearFilter() {
+    this._options.filter = '';
+    this.refresh();
+  }
+
+  /**
    * Helper to reuse code. Consider it to be private to this class
    * @param {any} extent
    * @param {any} cql if provided, extent is ignored


### PR DESCRIPTION
Fixes #1679
Adds setFilter and clearFilter methods to the wfs source Example:
origo.api().getLayer('my_layer').getSource().setFilter("namn in ('Museiparken')")