### PR TITLE
feature: featureinfo templates with alias and API functionality

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -13,7 +13,7 @@ import getFeatureInfo from './getfeatureinfo';
 import replacer from './utils/replacer';
 import SelectedItem from './models/SelectedItem';
 import attachmentclient from './utils/attachmentclient';
-import getAttributes, { getContent } from './getattributes';
+import getAttributes, { getContent, featureinfotemplates } from './getattributes';
 import relatedtables from './utils/relatedtables';
 
 const styleTypes = StyleTypes();
@@ -694,7 +694,8 @@ const Featureinfo = function Featureinfo(options = {}) {
     },
     render,
     showInfo,
-    showFeatureInfo
+    showFeatureInfo,
+    featureinfotemplates
   });
 };
 

--- a/src/featureinfotemplates.js
+++ b/src/featureinfotemplates.js
@@ -3,7 +3,20 @@ import defaultTemplate from './templates/featureinfotemplate';
 const templates = {};
 templates.default = defaultTemplate;
 
-function featureinfotemplates(template, attributes) {
-  return templates[template](attributes);
+function renameKeys(obj, newKeys) {
+  const keyValues = Object.keys(obj).map(key => {
+    const newKey = newKeys[key] || key;
+    return { [newKey]: obj[key] };
+  });
+  return Object.assign({}, ...keyValues);
+}
+
+function featureinfotemplates(template, featureAttributes, attributeAlias) {
+  const attributes = featureAttributes;
+  if (attributes.url) {
+    attributes.url = `<a href="${attributes.url}" target="_blank">${attributes.url}</a>`;
+  }
+  const renamedObj = renameKeys(attributes, attributeAlias);
+  return templates[template](renamedObj);
 }
 export default featureinfotemplates;

--- a/src/featureinfotemplates.js
+++ b/src/featureinfotemplates.js
@@ -1,7 +1,13 @@
 import defaultTemplate from './templates/featureinfotemplate';
+import templateHelpers from './utils/templatehelpers';
 
 const templates = {};
 templates.default = defaultTemplate;
+
+function addFeatureinfotemplate(name, fn) {
+  templates[name] = fn;
+  return true;
+}
 
 function renameKeys(obj, newKeys) {
   const keyValues = Object.keys(obj).map(key => {
@@ -11,7 +17,7 @@ function renameKeys(obj, newKeys) {
   return Object.assign({}, ...keyValues);
 }
 
-function featureinfotemplates(template, featureAttributes, attributeAlias) {
+function getFromTemplate(template, featureAttributes, attributeAlias) {
   const attributes = featureAttributes;
   if (attributes.url) {
     attributes.url = `<a href="${attributes.url}" target="_blank">${attributes.url}</a>`;
@@ -19,4 +25,5 @@ function featureinfotemplates(template, featureAttributes, attributeAlias) {
   const renamedObj = renameKeys(attributes, attributeAlias);
   return templates[template](renamedObj);
 }
-export default featureinfotemplates;
+
+export default { getFromTemplate, addFeatureinfotemplate, templateHelpers };

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -195,6 +195,7 @@ function getAttributes(feature, layer, map) {
   featureinfoElement.appendChild(ulList);
   const attributes = feature.getProperties();
   const geometryName = feature.getGeometryName();
+  const attributeAlias = map.get('mapConfig').attributeAlias || [];
   delete attributes[geometryName];
   let content;
   let attribute;
@@ -205,7 +206,7 @@ function getAttributes(feature, layer, map) {
     // If attributes is string then use template named with the string
     if (typeof layerAttributes === 'string') {
       // Use attributes with the template
-      const li = featureinfotemplates(layerAttributes, attributes);
+      const li = featureinfotemplates(layerAttributes, attributes, attributeAlias);
       const templateList = document.createElement('ul');
       featureinfoElement.appendChild(templateList);
       templateList.innerHTML = li;
@@ -214,7 +215,7 @@ function getAttributes(feature, layer, map) {
         attribute = layer.get('attributes')[i];
         val = '';
         if (attribute.template) {
-          const li = featureinfotemplates(attribute.template, attributes);
+          const li = featureinfotemplates(attribute.template, attributes, attributeAlias);
           const templateList = document.createElement('ul');
           featureinfoElement.appendChild(templateList);
           templateList.innerHTML = li;
@@ -242,7 +243,7 @@ function getAttributes(feature, layer, map) {
     }
   } else {
     // Use attributes with the template
-    const li = featureinfotemplates('default', attributes);
+    const li = featureinfotemplates('default', attributes, attributeAlias);
     const templateList = document.createElement('ul');
     featureinfoElement.appendChild(templateList);
     templateList.innerHTML = li;

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -206,7 +206,7 @@ function getAttributes(feature, layer, map) {
     // If attributes is string then use template named with the string
     if (typeof layerAttributes === 'string') {
       // Use attributes with the template
-      const li = featureinfotemplates(layerAttributes, attributes, attributeAlias);
+      const li = featureinfotemplates.getFromTemplate(layerAttributes, attributes, attributeAlias);
       const templateList = document.createElement('ul');
       featureinfoElement.appendChild(templateList);
       templateList.innerHTML = li;
@@ -215,7 +215,7 @@ function getAttributes(feature, layer, map) {
         attribute = layer.get('attributes')[i];
         val = '';
         if (attribute.template) {
-          const li = featureinfotemplates(attribute.template, attributes, attributeAlias);
+          const li = featureinfotemplates.getFromTemplate(attribute.template, attributes, attributeAlias);
           const templateList = document.createElement('ul');
           featureinfoElement.appendChild(templateList);
           templateList.innerHTML = li;
@@ -243,7 +243,7 @@ function getAttributes(feature, layer, map) {
     }
   } else {
     // Use attributes with the template
-    const li = featureinfotemplates('default', attributes, attributeAlias);
+    const li = featureinfotemplates.getFromTemplate('default', attributes, attributeAlias);
     const templateList = document.createElement('ul');
     featureinfoElement.appendChild(templateList);
     templateList.innerHTML = li;
@@ -252,7 +252,5 @@ function getAttributes(feature, layer, map) {
   return content;
 }
 
-// export { getAttributes as default, getContent };
-
 export default getAttributes;
-export { getContent };
+export { getContent, featureinfotemplates };

--- a/src/map.js
+++ b/src/map.js
@@ -4,10 +4,22 @@ import mapInteractions from './mapinteractions';
 
 const Map = (options = {}) => {
   const interactions = mapInteractions({ target: options.target, mapInteractions: options.pageSettings && options.pageSettings.mapInteractions ? options.pageSettings.mapInteractions : {} });
-  const mapConfig = Object.assign({}, options);
-  delete mapConfig.layers;
-  delete mapConfig.styles;
-  delete mapConfig.source;
+  const mapConfig = {};
+  const keys = Object.keys(options);
+  keys.forEach((key) => {
+    switch (key) {
+      case 'controls':
+      case 'defaultControls':
+      case 'groups':
+      case 'layers':
+      case 'source':
+      case 'styles':
+        break;
+      default:
+        mapConfig[key] = options[key];
+    }
+  });
+
   const mapOptions = Object.assign(options, { interactions });
   delete mapOptions.layers;
   mapOptions.controls = [];

--- a/src/map.js
+++ b/src/map.js
@@ -4,13 +4,17 @@ import mapInteractions from './mapinteractions';
 
 const Map = (options = {}) => {
   const interactions = mapInteractions({ target: options.target, mapInteractions: options.pageSettings && options.pageSettings.mapInteractions ? options.pageSettings.mapInteractions : {} });
+  const mapConfig = Object.assign({}, options);
+  delete mapConfig.layers;
+  delete mapConfig.styles;
+  delete mapConfig.source;
   const mapOptions = Object.assign(options, { interactions });
   delete mapOptions.layers;
   mapOptions.controls = [];
 
   const view = new OlView(options);
   const map = new OlMap(Object.assign(mapOptions, { view }));
-
+  map.set('mapConfig', mapConfig);
   return map;
 };
 


### PR DESCRIPTION
Fixes #1681 and #1690
Configured like:
```
  "attributeAlias": {
    "name":"Namn"
  }
```
in the config. Can be tested by removing the attribute setting for the origo cities layer in the standard map.