### PR TITLE
feature: add draggable option for groups

### DIFF
--- a/origo.js
+++ b/origo.js
@@ -25,6 +25,7 @@ import { renderSvgIcon } from './src/utils/legendmaker';
 import SelectedItem from './src/models/SelectedItem';
 import 'elm-pep';
 import 'pepjs';
+import 'drag-drop-touch';
 import permalink from './src/permalink/permalink';
 
 const Origo = function Origo(configPath, options = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1778,6 +1778,11 @@
       "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
       "integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw="
     },
+    "drag-drop-touch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/drag-drop-touch/-/drag-drop-touch-1.3.1.tgz",
+      "integrity": "sha512-Q0/ZgsnW7VUjn+YqSnp1rvxjjPnZX5YLyVaw28einood+eTMcLzgOgHk8nyqIF9O18J68l+2htlEnbw5GsyTvQ=="
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "awesomplete": "^1.1.5",
     "cuid": "^2.1.8",
     "downloadjs": "^1.4.7",
+    "drag-drop-touch": "^1.3.1",
     "elm-pep": "^1.0.6",
     "html2canvas": "^1.4.1",
     "ol-mapbox-style": "9.4.0",

--- a/scss/ui/_collapse.scss
+++ b/scss/ui/_collapse.scss
@@ -37,3 +37,8 @@
     height: calc(100% - 2rem);
   }
 }
+
+.move-item {
+  background-color: $blue;
+  opacity: 0.2;
+}

--- a/src/controls/draganddrop.js
+++ b/src/controls/draganddrop.js
@@ -73,6 +73,7 @@ const DragAndDrop = function DragAndDrop(options = {}) {
       }
       const groupName = options.groupName || 'egna-lager';
       const groupTitle = options.groupTitle || 'Egna lager';
+      const draggable = options.draggable || true;
       const styleByAttribute = options.styleByAttribute || false;
       const featureStyles = options.featureStyles || {
         Point: [{
@@ -156,7 +157,7 @@ const DragAndDrop = function DragAndDrop(options = {}) {
           }
         });
         if (!viewer.getGroup(groupName)) {
-          viewer.addGroup({ title: groupTitle, name: groupName, expanded: true });
+          viewer.addGroup({ title: groupTitle, name: groupName, expanded: true, draggable });
         }
         vectorLayer = new VectorLayer({
           source: vectorSource,

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -189,22 +189,26 @@ const Group = function Group(viewer, options = {}) {
   }
 
   function handleDragEnd(evt, groupCmp) {
-    selectedItem.classList.remove('move-item');
-    orderZIndex(selectedItem.parentElement, groupCmp);
-    selectedItem = null;
+    if (selectedItem) {
+      selectedItem.classList.remove('move-item');
+      orderZIndex(selectedItem.parentElement, groupCmp);
+      selectedItem = null;
+    }
   }
 
   function handleDragEnter(evt) {
-    const event = evt;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-    const list = selectedItem.parentNode;
-    const x = evt.clientX;
-    const y = evt.clientY;
-    let swapItem = document.elementFromPoint(x, y) === null ? selectedItem : document.elementFromPoint(x, y);
-    if (list === swapItem.parentNode) {
-      swapItem = swapItem !== selectedItem.nextSibling ? swapItem : swapItem.nextSibling;
-      list.insertBefore(selectedItem, swapItem);
+    if (selectedItem) {
+      const event = evt;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+      const list = selectedItem.parentNode;
+      const x = evt.clientX;
+      const y = evt.clientY;
+      let swapItem = document.elementFromPoint(x, y) === null ? selectedItem : document.elementFromPoint(x, y);
+      if (list === swapItem.parentNode) {
+        swapItem = swapItem !== selectedItem.nextSibling ? swapItem : swapItem.nextSibling;
+        list.insertBefore(selectedItem, swapItem);
+      }
     }
   }
 
@@ -250,7 +254,7 @@ const Group = function Group(viewer, options = {}) {
           tickButton.setState(stateCls[visibleState]);
           tickButton.setIcon(getCheckIcon(visibleState));
         }
-        if (draggable) {
+        if (draggable && typeof overlay.getId === 'function') {
           const el = document.getElementById(overlay.getId());
           enableDragItem(el, this);
         }


### PR DESCRIPTION
Fixes #1692 
Set `draggable: true` to make a group sortable by dragging layers. Useful for groups with user added layers.