### PR TITLE
fix: decouple default WMS server style and preselected style for the …

### DIFF
--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -37,30 +37,45 @@ function createImageSource(options) {
   }));
 }
 
-function createWmsStyle(wmsOptions, source, viewer, defaultStyle = true) {
-  let altStyleLegendParams;
+function createWmsStyle({ wmsOptions, source, viewer, initialStyle = false }) {
   let maxResolution = viewer.getResolutions()[viewer.getResolutions().length - 1];
+  let newStyle;
 
-  if (!(defaultStyle) && (wmsOptions.stylePicker)) {
-    const altStyle = wmsOptions.stylePicker.find(style => style.style === wmsOptions.styleName);
-    if (altStyle.legendParams) {
-      altStyleLegendParams = altStyle.legendParams;
-      if (Object.keys(altStyle.legendParams).find(key => key.toUpperCase() === 'SCALE')) {
-        maxResolution = null;
-      }
+  if (initialStyle) {
+    if (wmsOptions.stylePicker) {
+      newStyle = wmsOptions.stylePicker.find(style => style.initialStyle);
+    } else {
+      newStyle = {
+        defaultWMSServerStyle: true,
+        hasThemeLegend: wmsOptions.hasThemeLegend || false,
+        legendParams: wmsOptions.legendParams || false
+      };
     }
+  } else {
+    newStyle = wmsOptions.stylePicker[wmsOptions.altStyleIndex];
   }
 
-  const styleName = defaultStyle ? `${wmsOptions.name}_WMSDefault` : wmsOptions.styleName;
-  const getLegendString = defaultStyle ? source.getLegendUrl(maxResolution, wmsOptions.legendParams) : source.getLegendUrl(maxResolution, {
-    STYLE: styleName,
-    ...altStyleLegendParams
-  });
-  let hasThemeLegend = wmsOptions.hasThemeLegend || false;
-  if (!defaultStyle) {
-    hasThemeLegend = wmsOptions.stylePicker[wmsOptions.altStyleIndex].hasThemeLegend || false;
+  const legendParams = wmsOptions.stylePicker ? newStyle.legendParams : wmsOptions.legendParams;
+
+  if ((legendParams) && (Object.keys(legendParams).find(key => key.toUpperCase() === 'SCALE'))) {
+    maxResolution = null;
   }
 
+  let getLegendString;
+  let styleName;
+
+  if (newStyle.defaultWMSServerStyle) {
+    getLegendString = source.getLegendUrl(maxResolution, legendParams);
+    styleName = `${wmsOptions.name}_WMSServerDefault`;
+  } else {
+    getLegendString = source.getLegendUrl(maxResolution, {
+      STYLE: newStyle.style,
+      ...legendParams
+    });
+    styleName = newStyle.style;
+  }
+
+  const hasThemeLegend = newStyle.hasThemeLegend || false;
   const style = [[{
     icon: {
       src: `${getLegendString}`
@@ -74,14 +89,26 @@ function createWmsStyle(wmsOptions, source, viewer, defaultStyle = true) {
 function createWmsLayer(wmsOptions, source, viewer) {
   const wmsOpts = wmsOptions;
   const wmsSource = source;
-  if (wmsOpts.styleName === 'default') {
-    wmsOpts.styleName = createWmsStyle(wmsOptions, source, viewer);
+
+  if (wmsOptions.stylePicker) {
+    let pickedStyle;
+    if (wmsOptions.altStyleIndex > -1) {
+      wmsOpts.defaultStyle = createWmsStyle({ wmsOptions, source, viewer, initialStyle: true });
+      wmsOpts.styleName = createWmsStyle({ wmsOptions, source, viewer });
+      wmsOpts.style = wmsOptions.styleName;
+      pickedStyle = wmsOptions.stylePicker[wmsOptions.altStyleIndex];
+    } else {
+      wmsOpts.styleName = createWmsStyle({ wmsOptions, source, viewer, initialStyle: true });
+      wmsOpts.defaultStyle = wmsOpts.styleName;
+      wmsOpts.style = wmsOptions.styleName;
+      pickedStyle = wmsOpts.stylePicker.find(style => style.initialStyle === true);
+    }
+    if (!(pickedStyle.defaultWMSServerStyle)) {
+      wmsSource.getParams().STYLES = wmsOptions.styleName;
+    }
+  } else if (wmsOpts.styleName === 'default') {
+    wmsOpts.styleName = createWmsStyle({ wmsOptions, source, viewer, initialStyle: true });
     wmsOpts.style = wmsOptions.styleName;
-  } else if (wmsOptions.altStyleIndex > -1) {
-    wmsOpts.defaultStyle = createWmsStyle(wmsOptions, source, viewer);
-    wmsOpts.styleName = createWmsStyle(wmsOptions, source, viewer, false);
-    wmsOpts.style = wmsOptions.styleName;
-    wmsSource.getParams().STYLES = wmsOptions.styleName;
   }
 }
 
@@ -104,9 +131,11 @@ const wms = function wms(layerOptions, viewer) {
   sourceOptions.projection = viewer.getProjection();
   sourceOptions.id = wmsOptions.id;
   sourceOptions.format = wmsOptions.format ? wmsOptions.format : sourceOptions.format;
-  const styleSettings = viewer.getStyle(wmsOptions.styleName);
-  const wmsStyleObject = styleSettings ? styleSettings[0].find(s => s.wmsStyle) : undefined;
-  sourceOptions.style = wmsStyleObject ? wmsStyleObject.wmsStyle : '';
+  if (!wmsOptions.stylePicker) {
+    const styleSettings = viewer.getStyle(wmsOptions.styleName);
+    const wmsStyleObject = styleSettings ? styleSettings[0].find(s => s.wmsStyle) : undefined;
+    sourceOptions.style = wmsStyleObject ? wmsStyleObject.wmsStyle : '';
+  }
 
   if (wmsOptions.tileGrid) {
     sourceOptions.tileGrid = maputils.tileGrid(wmsOptions.tileGrid);

--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -90,7 +90,14 @@ function createWmsLayer(wmsOptions, source, viewer) {
   const wmsOpts = wmsOptions;
   const wmsSource = source;
 
+  function setInitialStyle() {
+    if (!(wmsOpts.stylePicker.some(style => style.initialStyle === true))) {
+      wmsOpts.stylePicker[0].initialStyle = true;
+    }
+  }
+
   if (wmsOptions.stylePicker) {
+    setInitialStyle();
     let pickedStyle;
     if (wmsOptions.altStyleIndex > -1) {
       wmsOpts.defaultStyle = createWmsStyle({ wmsOptions, source, viewer, initialStyle: true });

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -344,7 +344,12 @@ const Viewer = function Viewer(targetOption, options = {}) {
             savedProps.clusterStyle = altStyle.clusterStyle;
             savedProps.style = altStyle.style;
             if (initialProps.type === 'WMS') {
-              savedProps.defaultStyle = initialProps.stylePicker.find(style => style.initialStyle);
+              let WMSStylePickerInitialStyle = initialProps.stylePicker.find(style => style.initialStyle);
+              if (WMSStylePickerInitialStyle === undefined) {
+                WMSStylePickerInitialStyle = initialProps.stylePicker[0];
+                WMSStylePickerInitialStyle.initialStyle = true;
+              }
+              savedProps.defaultStyle = WMSStylePickerInitialStyle;
             } else savedProps.defaultStyle = initialProps.style;
           }
           savedProps.name = initialProps.name;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -343,7 +343,9 @@ const Viewer = function Viewer(targetOption, options = {}) {
             const altStyle = initialProps.stylePicker[savedLayerProps[layerName].altStyleIndex];
             savedProps.clusterStyle = altStyle.clusterStyle;
             savedProps.style = altStyle.style;
-            savedProps.defaultStyle = initialProps.style;
+            if (initialProps.type === 'WMS') {
+              savedProps.defaultStyle = initialProps.stylePicker.find(style => style.initialStyle);
+            } else savedProps.defaultStyle = initialProps.style;
           }
           savedProps.name = initialProps.name;
           const mergedProps = Object.assign({}, initialProps, savedProps);


### PR DESCRIPTION
…stylepicker in order to accomodate preselected alternative WMS server styles when a stylepicker is employed for WMS layers.
Aims to fix #1642 by removing the `default` property from the stylePicker for WMS layers and adding the `defaultWMSServerStyle` property as well as the `initialStyle` property for what style is the WMS server's default style (that need not be named in WMS requests) and what style to employ when loading the map (which is then preselected in the stylePicker dropdown).

It isn't meant to alter the function of vector layer stylePickers. It seeks establish the following priority between a `style` prop, the `hasThemeLegend` and `legendParams` props and the `stylePicker` prop:
1. `stylePicker` (then ignore the other three if present)
2. `style` (then ignore the final two)
3. WMS autostyle which considers `hasThemeLegend` and `legendParams`

This means that when a stylePicker is defined for a WMS layer everything regarding that layer's styles can and must be defined in the stylePicker. 

A sample stylePicker:
```json
      "stylePicker": [
        { "title": "CSS", "style": "Bakgrund_bke_fk_mo_0484_css" },
        { "title": "Mörk", "style": "Bakgrund_bkm_fk_mo_0484", "hasThemeLegend": true,
          "legendParams": {
            "legend_options": "dpi:600"
          }
       },
        { "title": "Standard", "defaultWMSServerStyle": true, "hasThemeLegend": false, "initialStyle": true,
          "legendParams": {
            "scale": 100
            } 
        }
      ]
```

Currently there's no error handling, the schema needs to be followed otherwise expect errors. I can make it more robust if there's a preference for that but there are a multitude of config possibilities here and what is expected behaviour if incorrect input is not always easy to ascertain.
If the given schema is adhered to it should never break, though since the config options are of said multitude there's the saying of forest roads 
> Hinder och fara kan förekomma

 so please do test a few creative scenarios, including without a stylePicker to make sure WMS autostyle never goes astray, as well as a `style` prop that both employs an alternative `wmsStyle` and does not, including sharing and printing.

(See the reasoning in the issue about breaking changes, i.e WMS wasn't in the stylePicker in the last release)