### PR TITLE
feature: mapState as map parameter

### DIFF
--- a/src/loadresources.js
+++ b/src/loadresources.js
@@ -1,4 +1,5 @@
 import permalink from './permalink/permalink';
+import permalinkParser from './permalink/permalinkparser';
 import getUrl from './utils/geturl';
 import isUrl from './utils/isurl';
 import trimUrl from './utils/trimurl';
@@ -141,6 +142,16 @@ const loadResources = async function loadResources(mapOptions, config) {
             map.options.url = mapUrl;
             map.options.map = json;
             map.options.params = urlParams;
+
+            if (config.mapState) {
+              const mapObj = {};
+              const state = config.mapState;
+              Object.keys(state).forEach(key => {
+                if (permalinkParser[key]) mapObj[key] = permalinkParser[key](state[key]);
+                else mapObj[key] = state[key];
+              });
+              map.options.params = mapObj;
+            }
 
             for (let i = 0; i < map.options.controls.length; i += 1) {
               if (map.options.controls[i].name === 'sharemap') {


### PR DESCRIPTION
Fixes #1716 
Makes it possible to add a mapState when initializing a map. A way to alter the default config eg when customizing a map based on the user