### PR TITLE
fix: only activate buttons on first level when expanding

### DIFF
--- a/src/ui/collapse.js
+++ b/src/ui/collapse.js
@@ -41,9 +41,11 @@ export default function Collapse(options = {}) {
 
   // Set tabindex for all buttons to include or exclude in taborder depending on if expanded or not
   const setTabIndex = function setTabIndex(idx) {
-    // Skips the last button since it's slidenav and should be excluded from tab order
-    for (let i = 0; i < containerEl.getElementsByTagName('button').length - 1; i += 1) {
-      containerEl.getElementsByTagName('button')[i].tabIndex = idx;
+    for (let i = 0; i < containerEl.getElementsByTagName('button').length; i += 1) {
+      // Checks if the button is a direct child of the opened group and not a grandchild which shouldn't be activated until that group is opened
+      if (containerEl.id === containerEl.getElementsByTagName('button')[i].closest('.collapse-container').id) {
+        containerEl.getElementsByTagName('button')[i].tabIndex = idx;
+      }
     }
   };
 


### PR DESCRIPTION
Fixes #1734 