### PR TITLE
feature: make prompt configurable for removable layers

### DIFF
--- a/src/controls/draganddrop.js
+++ b/src/controls/draganddrop.js
@@ -71,6 +71,7 @@ const DragAndDrop = function DragAndDrop(options = {}) {
       const groupName = options.groupName || 'egna-lager';
       const groupTitle = options.groupTitle || 'Egna lager';
       const draggable = options.draggable || true;
+      const promptlessRemoval = options.promptlessRemoval !== false;
       const styleByAttribute = options.styleByAttribute || false;
       const featureStyles = options.featureStyles || {
         Point: [{
@@ -153,6 +154,7 @@ const DragAndDrop = function DragAndDrop(options = {}) {
           styleByAttribute,
           queryable: true,
           removable: true,
+          promptlessRemoval,
           visible: true,
           source: 'none',
           type: 'GEOJSON',

--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -222,10 +222,11 @@ const OverlayLayer = function OverlayLayer(options) {
       onRender() {
         const labelEl = document.getElementById(this.getId());
         labelEl.addEventListener('click', (e) => {
-          if (window.confirm('Vill du radera lagret?')) {
+          const doRemove = (layer.get('promptlessRemoval') === true) || window.confirm('Vill du radera lagret?');
+          if (doRemove) {
             viewer.getMap().removeLayer(layer);
+            e.preventDefault();
           }
-          e.preventDefault();
         });
       },
       render() {


### PR DESCRIPTION
Seeks to resolve #1758 . Drag-and-drop receives the `promptlessRemoval` option and makes it true by default, so it's opt-out.
Layers can have this property and then not cause a prompt to verify when being removed. 