### PR TITLE
feature: add overlayOptions from the origostyle-object

### DIFF
--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -13,11 +13,9 @@
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 6px;
-  bottom: 12px;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   max-height: 70vh;
-  padding: 1px;
   position: absolute;
   text-align: left;
   white-space: normal;
@@ -36,11 +34,51 @@
   width: 0;
 }
 
-.o-popup::after {
+.popup-top-center .o-popup {
+  bottom: 0;
+}
+
+.popup-bottom-center .o-popup {
+  bottom: 12px;
+}
+
+.popup-center-left .o-popup {
+  left: 10px;
+}
+
+.popup-center-right .o-popup {
+  right: 10px;
+}
+
+.popup-top-center .o-popup::after {
+  border-bottom-color: $white;
+  border-width: 10px;
+  top: -20px;
+  left: 50%;
+  margin-left: -10px;
+}
+
+.popup-bottom-center .o-popup::after {
   border-top-color: $white;
   border-width: 10px;
   bottom: -20px;
   left: 50%;
+  margin-left: -10px;
+}
+
+.popup-center-left .o-popup::after {
+  border-right-color: $white;
+  border-width: 10px;
+  left: -10px;
+  top: calc(50% - 6px);
+  margin-left: -10px;
+}
+
+.popup-center-right .o-popup::after {
+  border-left-color: $white;
+  border-width: 10px;
+  right: -20px;
+  top: calc(50% - 6px);
   margin-left: -10px;
 }
 

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -405,6 +405,7 @@ const Featureinfo = function Featureinfo(options = {}) {
         initCarousel('#o-identify-carousel');
         const firstFeature = items[0].feature;
         const geometry = firstFeature.getGeometry();
+        const origostyle = firstFeature.get('origostyle');
         const clone = firstFeature.clone();
         clone.setId(firstFeature.getId());
         // FIXME: should be layer name, not feature name
@@ -432,6 +433,9 @@ const Featureinfo = function Featureinfo(options = {}) {
         const popupHeight = document.querySelector('.o-popup').offsetHeight + 10;
         popupEl.style.height = `${popupHeight}px`;
         const overlayOptions = { element: popupEl, positioning: 'bottom-center' };
+        if (origostyle && origostyle.overlayOptions) {
+          Object.assign(overlayOptions, origostyle.overlayOptions);
+        }
         if (!ignorePan) {
           overlayOptions.autoPan = {
             margin: 55,

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -433,17 +433,17 @@ const Featureinfo = function Featureinfo(options = {}) {
         const popupHeight = document.querySelector('.o-popup').offsetHeight + 10;
         popupEl.style.height = `${popupHeight}px`;
         const overlayOptions = { element: popupEl, positioning: 'bottom-center' };
+        if (!ignorePan) {
+          overlayOptions.autoPan = {
+            margin: 55,
+            animation: {
+              duration: 500
+            }
+          };
+        }
         if (items[0].layer && items[0].layer.get('styleName')) {
           const styleName = items[0].layer.get('styleName');
           const itemStyle = viewer.getStyle(styleName);
-          if (!ignorePan) {
-            overlayOptions.autoPan = {
-              margin: 55,
-              animation: {
-                duration: 500
-              }
-            };
-          }
           if (itemStyle && itemStyle[0] && itemStyle[0][0] && itemStyle[0][0].overlayOptions) {
             Object.assign(overlayOptions, itemStyle[0][0].overlayOptions);
           }

--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -433,16 +433,26 @@ const Featureinfo = function Featureinfo(options = {}) {
         const popupHeight = document.querySelector('.o-popup').offsetHeight + 10;
         popupEl.style.height = `${popupHeight}px`;
         const overlayOptions = { element: popupEl, positioning: 'bottom-center' };
+        if (items[0].layer && items[0].layer.get('styleName')) {
+          const styleName = items[0].layer.get('styleName');
+          const itemStyle = viewer.getStyle(styleName);
+          if (!ignorePan) {
+            overlayOptions.autoPan = {
+              margin: 55,
+              animation: {
+                duration: 500
+              }
+            };
+          }
+          if (itemStyle && itemStyle[0] && itemStyle[0][0] && itemStyle[0][0].overlayOptions) {
+            Object.assign(overlayOptions, itemStyle[0][0].overlayOptions);
+          }
+        }
         if (origostyle && origostyle.overlayOptions) {
           Object.assign(overlayOptions, origostyle.overlayOptions);
         }
-        if (!ignorePan) {
-          overlayOptions.autoPan = {
-            margin: 55,
-            animation: {
-              duration: 500
-            }
-          };
+        if (overlayOptions.positioning) {
+          popupEl.classList.add(`popup-${overlayOptions.positioning}`);
         }
         overlay = new Overlay(overlayOptions);
         map.addOverlay(overlay);


### PR DESCRIPTION
Fixes #1760
When setting origostyle.overlayOptions.offset for a feature it will offset the popup overlay.
Use with caution because when having multiple features in the carousel it will only check the property of the first feature.

Eg:
![image](https://user-images.githubusercontent.com/6848075/235641079-d2c16ddc-bf8f-45fd-aee0-7102907683e7.png)

Can be used like this:
```
const viewer = origo.api();

const layerOptions = {
group: 'root',
name: 'markerLayer',
title: 'Markers',
zIndex: 6,
styleByAttribute: true,
queryable: true,
removable: true,
visible: true,
source: 'none',
type: 'FEATURE',
attributes: [
{
html: '{{content}}'
}
],
style: viewer.getStylewindow().getStyleFunction
};

const layer = viewer.addLayer(layerOptions);
const coords = [1575114, 8396023];
const newFeature = viewer.getMapUtils().createPointFeature(coords, null);
newFeature.set('origostyle', {pointType: 'marker', overlayOptions: { offset:[0, -35] }});
newFeature.set('content', 'This markers content!');
layer.getSource().addFeature(newFeature);
```