### PR TITLE
fix: make featureStyles apply to dragdrop layers by partially mimicin…

### DIFF
--- a/src/controls/draganddrop.js
+++ b/src/controls/draganddrop.js
@@ -155,6 +155,7 @@ const DragAndDrop = function DragAndDrop(options = {}) {
           queryable: true,
           removable: true,
           promptlessRemoval,
+          isDragDroppedLayer: true,
           visible: true,
           source: 'none',
           type: 'GEOJSON',

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -424,6 +424,11 @@ const Viewer = function Viewer(targetOption, options = {}) {
     if (insertBefore) {
       map.getLayers().insertAt(map.getLayers().getArray().indexOf(insertBefore), layer);
     } else {
+      if (layerProps.isDragDroppedLayer === true) {
+        if (layerProps.styleByAttribute === false) {
+          layer.setStyle(thisProps.style);
+        }
+      }
       map.addLayer(layer);
     }
     this.dispatch('addlayer', {


### PR DESCRIPTION
…g the past. Aims to resolve #1764 . The functionality became unavailable after https://github.com/origo-map/origo/blob/1451535bf749236ab4e54034492fce4d472d89b6/src/controls/draganddrop.js it seems.  This PR "fixes it" by making drag and drop layers definitely recognizable and then just letting the style machinery behind the viewer do its somewhat complicated thing and then more or less behave like at the mentioned point in the history of draganddrop.js (add a layer with a style to the map no matter if it isn't registered with the viewer). It shouldn't interfere with anything else.
We can hopefully discuss how appropriate this is tomorrow.