### PR TITLE
Fix: Image in related table

### DIFF
--- a/src/controls/editor/editform.js
+++ b/src/controls/editor/editform.js
@@ -78,7 +78,7 @@ const createForm = function createForm(obj) {
       const imageClass = val ? '' : 'o-hidden';
       el = `<div class="validate ${cls}"><label>${label}<br>`;
       el += `<img src="${val}" id="image-upload" class="${imageClass}"/>`;
-      el += `<input type="file" name="bildfil" id="${id}" value="${val}" accept="image/*"${disabled}></label>`;
+      el += `<input type="file" name="bildfil" id="${id}" accept="image/*"${disabled}></label>`;
       el += `<input id="o-delete-image-button" class="${imageClass}" type="button" aria-label="Ta bort bild" value="Ta bort bild"${disabled}>`;
       el += '</div>';
       break;

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -1010,7 +1010,6 @@ function addImageListener() {
     // Find the remove button and attach event handler.
     document.querySelector(`${containerClass} input[type=button]`).addEventListener('click', (e) => {
       // Clear the filename
-      document.getElementById(obj.elId).setAttribute('value', '');
       document.getElementById(obj.elId).value = '';
       // Also clear the model value
       // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
Fixes #1757

Problem was that there was an asynchronous resize when the form is saved which messed up the current layer state variable.

Resolved by moving the resize to when the file is loaded (which in my opinion is more logical anyway). Previous implementation resized the image on save, which meant that the preview image was full resolution and the image was read twice.

The result should be the same which includes that the image is always resized to a max size of 600 pixels in the largest dimension. That can be overridden by setting a new max size by the undocumented maxSize option.

```JSON
"attributes": [
        {
          "name": "name",
          "type": "text"
        },
        {
          "name": "imgsrc",
          "type": "image",
          "maxSize":  50
        }
      ]
```

