### PR TITLE
feature: pick feature in editor

### DIFF
--- a/src/components/infowindow.js
+++ b/src/components/infowindow.js
@@ -1,0 +1,117 @@
+import { Component, Button, Element as El, dom } from '../ui';
+import utils from '../utils';
+
+const Infowindow = function Infowindow(options = {}) {
+  const {
+    closeIcon = '#ic_close_24px',
+    title = 'Inforuta',
+    viewer,
+    type = 'floating',
+    contentComponent = El({
+      tagName: 'div',
+      cls: 'padding-y-small overflow-auto text-small'
+    })
+  } = options;
+  let {
+    isActive = false
+  } = options;
+  let headerComponent;
+  let titleComponent;
+  let infowindow;
+  let iwEl;
+  let closeButton;
+
+  const toggle = function toggle() {
+    iwEl.classList.toggle('faded');
+    isActive = !isActive;
+  };
+
+  const close = function close() {
+    if (isActive) {
+      toggle();
+    }
+  };
+
+  const changeContent = function changeContent(component, objTitle) {
+    document.getElementById(titleComponent.getId()).innerHTML = objTitle || title;
+    const contentEl = document.getElementById(contentComponent.getId());
+    while (contentEl.hasChildNodes()) {
+      contentEl.removeChild(contentEl.firstChild);
+    }
+    contentComponent.clearComponents();
+    contentComponent.addComponent(component);
+    if (!isActive) {
+      toggle();
+    }
+    const el = dom.html(`<div id="${component.getId()}">${component.render()}</div>`);
+    contentEl.appendChild(el);
+    component.dispatch('render');
+  };
+
+  return Component({
+    name: 'infowindow',
+    close,
+    changeContent,
+    onAdd() {
+      this.on('render', this.onRender);
+      this.render();
+    },
+    onInit() {
+      let iwElCls = isActive ? '' : ' faded';
+      let iwElStyle = '';
+      let hcElCls = '';
+
+      switch (type) {
+        case 'floating':
+          hcElCls = ' draggable move';
+          iwElStyle = 'top: 4rem; left: 4rem; max-height: calc(100% - (6rem))';
+          break;
+        case 'left':
+          iwElCls += ' top-left no-margin height-full';
+          break;
+        default:
+          hcElCls = ' draggable move';
+          iwElStyle = 'top: 4rem; left: 4rem; max-height: calc(100% - (6rem))';
+      }
+
+      closeButton = Button({
+        cls: 'small round margin-top-smaller margin-bottom-auto margin-right icon-smaller grey-lightest no-shrink o-tooltip',
+        ariaLabel: 'Stäng',
+        icon: closeIcon,
+        click() {
+          toggle();
+        }
+      });
+
+      titleComponent = El({
+        cls: 'flex row justify-start margin-y-smaller margin-left text-weight-bold',
+        style: { width: '100%' },
+        innerHTML: title
+      });
+
+      headerComponent = El({
+        cls: `flex row justify-end grey-lightest${hcElCls}`,
+        style: { width: '100%' },
+        components: [titleComponent, closeButton]
+      });
+
+      infowindow = El({
+        cls: `absolute flex column control bg-white overflow-hidden z-index-top no-select${iwElCls}`,
+        style: iwElStyle,
+        collapseX: true,
+        components: [headerComponent, contentComponent]
+      });
+
+      this.addComponent(infowindow);
+    },
+    render() {
+      const newEl = dom.html(infowindow.render());
+      document.getElementById(viewer.getMain().getId()).appendChild(newEl);
+      iwEl = document.getElementById(infowindow.getId());
+      utils.makeElementDraggable(iwEl);
+      this.dispatch('render');
+    }
+  });
+};
+
+export default Infowindow;

--- a/src/controls/editor.js
+++ b/src/controls/editor.js
@@ -6,7 +6,8 @@ const Editor = function Editor(options = {}) {
   const {
     autoForm = false,
     autoSave = true,
-    isActive = true
+    isActive = true,
+    featureList = true
   } = options;
   let editorButton;
   let target;
@@ -70,7 +71,8 @@ const Editor = function Editor(options = {}) {
         autoSave,
         currentLayer,
         editableLayers,
-        isActive
+        isActive,
+        featureList
       });
       editHandler = EditHandler(handlerOptions, viewer);
 

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -536,6 +536,7 @@ function setInteractions(drawType) {
               select.getFeatures().clear();
               select.getFeatures().push(feature);
               infowindowCmp.dispatch('resetButtonStates');
+              infowindowCmp.dispatch('removeMouseenter');
               this.setState('active');
             },
             mouseenter() {
@@ -552,7 +553,12 @@ function setInteractions(drawType) {
           listCmp.push(listItem);
           infowindowCmp.on('resetButtonStates', () => {
             featureButton.setState('initial');
-            document.getElementById(featureButton.getId()).blur();
+            if (document.getElementById(featureButton.getId())) {
+              document.getElementById(featureButton.getId()).blur();
+            }
+          });
+          infowindowCmp.on('removeMouseenter', () => {
+            featureButton.dispatch('removeMouseenter');
           });
         });
         const content = El({

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -498,6 +498,7 @@ function setInteractions(drawType) {
     drawOptions.finishCondition = finishConditionCallback;
   }
   removeInteractions();
+  infowindowCmp.close();
   draw = new Draw(drawOptions);
   hasDraw = false;
   select = new Select({

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -530,10 +530,19 @@ function setInteractions(drawType) {
           }
           const featureButton = Button({
             text: buttonText,
-            cls: 'text-align-left',
+            state: 'initial',
+            cls: 'text-align-left hover light',
             click() {
               select.getFeatures().clear();
               select.getFeatures().push(feature);
+              infowindowCmp.dispatch('resetButtonStates');
+              this.setState('active');
+            },
+            mouseenter() {
+              select.getFeatures().clear();
+              select.getFeatures().push(feature);
+              infowindowCmp.dispatch('resetButtonStates');
+              this.setState('active');
             }
           });
           const listItem = El({
@@ -541,6 +550,10 @@ function setInteractions(drawType) {
             components: [featureButton]
           });
           listCmp.push(listItem);
+          infowindowCmp.on('resetButtonStates', () => {
+            featureButton.setState('initial');
+            document.getElementById(featureButton.getId()).blur();
+          });
         });
         const content = El({
           tagName: 'ul',

--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -512,6 +512,10 @@ function setInteractions(drawType) {
         const listCmp = [];
         const featureArray = select.getFeatures().getArray();
         featureArray.forEach(feature => {
+          if (typeof feature.getStyle() === 'function') {
+            const styleArr = feature.getStyle()(feature);
+            styleArr.forEach(style => style.setZIndex(10));
+          }
           let buttonText = '';
           if (featureListAttributes && featureListAttributes.length > 0) {
             featureListAttributes.forEach(attribute => {

--- a/src/ui/button.js
+++ b/src/ui/button.js
@@ -110,9 +110,9 @@ export default function Button(options = {}) {
         });
       }
       if (mouseenter) {
-        this.on('mouseenter', mouseenter.bind(this));
-        this.on('clear', () => {
-          this.un('mouseenter', mouseenter.bind(this));
+        this.on('mouseenter', mouseenter);
+        this.on('removeMouseenter', () => {
+          this.un('mouseenter', mouseenter);
         });
       }
     },

--- a/src/ui/button.js
+++ b/src/ui/button.js
@@ -15,6 +15,7 @@ export default function Button(options = {}) {
     iconCls = '',
     iconStyle = {},
     click,
+    mouseenter,
     style: styleSettings,
     textCls = '',
     tooltipText,
@@ -108,11 +109,21 @@ export default function Button(options = {}) {
           this.un('click', click.bind(this));
         });
       }
+      if (mouseenter) {
+        this.on('mouseenter', mouseenter.bind(this));
+        this.on('clear', () => {
+          this.un('mouseenter', mouseenter.bind(this));
+        });
+      }
     },
     onRender() {
       buttonEl = document.getElementById(this.getId());
       buttonEl.addEventListener('click', (e) => {
         this.dispatch('click');
+        e.preventDefault();
+      });
+      buttonEl.addEventListener('mouseenter', (e) => {
+        this.dispatch('mouseenter');
         e.preventDefault();
       });
       if (validStates.indexOf(state) > 0) {


### PR DESCRIPTION
Fixes #612 List the features to be able to select overlapping features.
Can be turned off by setting `"featureList": false` in the editor options

Attributes to be showed in the infowindow is setup like this on layer level. Empty attributes won't be showed and the default is to just show the feature ID:
`"featureListAttributes": ["id", "name", "type"]`

![chrome-capture-2023-4-16](https://github.com/origo-map/origo/assets/6848075/056d178e-2984-4dad-a99f-14823e895ab5)
