### PR TITLE
fix: let img attribute have precedence before name

### DIFF
--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -223,8 +223,6 @@ function getAttributes(feature, layer, map) {
         } else {
           if (attribute.img || attribute.type === 'image') {
             val = getContent.img(feature, attribute, attributes, map);
-          } else if (attribute.name) {
-            val = getContent.name(feature, attribute, attributes, map);
           } else if (attribute.url) {
             val = getContent.url(feature, attribute, attributes, map);
           } else if (attribute.html) {
@@ -232,6 +230,8 @@ function getAttributes(feature, layer, map) {
           } else if (attribute.carousel) {
             val = getContent.carousel(feature, attribute, attributes, map);
             ulList.classList.add('o-carousel-list');
+          } else if (attribute.name) {
+            val = getContent.name(feature, attribute, attributes, map);
           } else {
             val = customAttribute(feature, attribute, attributes, map);
           }

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -221,12 +221,12 @@ function getAttributes(feature, layer, map) {
           featureinfoElement.appendChild(templateList);
           templateList.innerHTML = li;
         } else {
-          if (attribute.name) {
+          if (attribute.img || attribute.type === 'image') {
+            val = getContent.img(feature, attribute, attributes, map);
+          } else if (attribute.name) {
             val = getContent.name(feature, attribute, attributes, map);
           } else if (attribute.url) {
             val = getContent.url(feature, attribute, attributes, map);
-          } else if (attribute.img || attribute.type === 'image') {
-            val = getContent.img(feature, attribute, attributes, map);
           } else if (attribute.html) {
             val = getContent.html(feature, attribute, attributes, map);
           } else if (attribute.carousel) {


### PR DESCRIPTION
Fixes #1774 

Test config:
```
        {
          "img": "bild",
          "name": "bild",
          "title": "Bild: ",
          "type": "image"
        }
```