### PR TITLE
feature: add hide function for draw

### DIFF
--- a/src/controls/draw.js
+++ b/src/controls/draw.js
@@ -643,6 +643,12 @@ const Draw = function Draw(options = {}) {
         viewer.dispatch('toggleClickInteraction', { name: 'draw', active: true });
       }
     },
+    hide() {
+      document.getElementById(screenButtonContainer.getId()).classList.add('hidden');
+    },
+    unhide() {
+      document.getElementById(screenButtonContainer.getId()).classList.remove('hidden');
+    },
     render() {
       if (placement.indexOf('screen') > -1) {
         let htmlString = `${screenButtonContainer.render()}`;

--- a/src/controls/draw.js
+++ b/src/controls/draw.js
@@ -644,10 +644,14 @@ const Draw = function Draw(options = {}) {
       }
     },
     hide() {
-      document.getElementById(screenButtonContainer.getId()).classList.add('hidden');
+      if (placement.some(place => place === 'screen')) {
+        document.getElementById(screenButtonContainer.getId()).classList.add('hidden');
+      }
     },
     unhide() {
-      document.getElementById(screenButtonContainer.getId()).classList.remove('hidden');
+      if (placement.some(place => place === 'screen')) {
+        document.getElementById(screenButtonContainer.getId()).classList.remove('hidden');
+      }
     },
     render() {
       if (placement.indexOf('screen') > -1) {


### PR DESCRIPTION
Aims to resolve #1778 . 
Edit: This changes draw so that it is always added and still shown in the menu, if placed in the menu. If placed on screen it is hidden. (Currently draw isn't added if `hideWhenEmbedded`)