### PR TITLE
feature: overlayproperties event

### DIFF
--- a/src/controls/legend/overlayproperties.js
+++ b/src/controls/legend/overlayproperties.js
@@ -146,6 +146,7 @@ const OverlayProperties = function OverlayProperties(options = {}) {
       });
     },
     onRender() {
+      viewer.getControlByName('legend').dispatch('renderOverlayProperties', { cmp: this, layer });
       this.dispatch('render');
       sliderEl = document.getElementById(transparencySlider.getId());
       overlayEl = document.getElementById(this.getId());


### PR DESCRIPTION
Fixes #1788 

Used like this:
```
origo.api().getControlByName('legend').on('renderOverlayProperties', function(obj){
console.log(obj)
})
```
The event object is the overlayProperties component and the layer