### PR TITLE
feature: start point style geometry option

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -95,6 +95,12 @@ function createStyleOptions(orgStyleParams, scaleToDpi) {
           return new Point(coordinates);
         };
         break;
+      case 'startPoint':
+        styleOptions.geometry = function startPoint(feature) {
+          const coordinates = feature.getGeometry().getFirstCoordinate();
+          return new Point(coordinates);
+        };
+        break;
       default:
       {
         break;


### PR DESCRIPTION
Fixes #1797.

Use like this:
```
"line": [
  [
    {
      "stroke": {
        "color": "rgba(103,60,31,1.0)",
        "width": 1
      }
    },
    {
      "icon": {
        "size": [
          23,
          36
        ],
        "src": "img/png/droppe.png"
      },
      "geometry": "startPoint"
    }
  ]
]
```