### PR TITLE
fix: make imageLoadFunction revokeObjectURL

### DIFF
--- a/src/layer/wms.js
+++ b/src/layer/wms.js
@@ -119,7 +119,7 @@ function imageLoadFunction(loadedImage, src) {
     if (data) {
       const img = loadedImage.getImage();
       const url = URL.createObjectURL(data);
-      img.addEventListener('loadend', () => {
+      img.addEventListener('load', () => {
         URL.revokeObjectURL(url);
       });
       img.src = url;


### PR DESCRIPTION
Aims to fix #1805 . (Seems to createObjectUrls before revokingObjectUrls)