### PR TITLE
feature: added settingsExpanded option for print control

### DIFF
--- a/src/controls/print/index.js
+++ b/src/controls/print/index.js
@@ -50,7 +50,8 @@ const Print = function Print(options = {}) {
     filename,
     mapInteractionsActive = false,
     supressResolutionsRecalculation = false,
-    suppressNewDPIMethod = false
+    suppressNewDPIMethod = false,
+    settingsExpanded = false
   } = options;
   let {
     showNorthArrow = true,
@@ -114,6 +115,7 @@ const Print = function Print(options = {}) {
         showMargins,
         showCreated,
         createdPrefix,
+        settingsExpanded,
         showScale,
         showNorthArrow,
         showPrintLegend,

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -50,7 +50,8 @@ const PrintComponent = function PrintComponent(options = {}) {
     leftFooterText,
     mapInteractionsActive,
     supressResolutionsRecalculation,
-    suppressNewDPIMethod
+    suppressNewDPIMethod,
+    settingsExpanded
   } = options;
 
   let {
@@ -320,6 +321,7 @@ const PrintComponent = function PrintComponent(options = {}) {
     resolution,
     scales,
     scaleInitial,
+    settingsExpanded,
     showMargins,
     showCreated,
     showScale,

--- a/src/controls/print/print-settings.js
+++ b/src/controls/print/print-settings.js
@@ -44,6 +44,7 @@ const PrintSettings = function PrintSettings(options = {}) {
     resolution,
     scales,
     scaleInitial,
+    settingsExpanded,
     showMargins,
     showCreated,
     showScale,
@@ -117,7 +118,7 @@ const PrintSettings = function PrintSettings(options = {}) {
         icon: openIcon,
         tooltipText: 'Visa inställningar',
         tooltipPlacement: 'east',
-        state: 'initial',
+        state: settingsExpanded === true ? 'hidden' : 'initial',
         validStates: ['initial', 'hidden'],
         click() {
           toggle();
@@ -126,7 +127,7 @@ const PrintSettings = function PrintSettings(options = {}) {
       closeButton = Button({
         cls: 'small round margin-top-small margin-right small icon-smaller grey-lightest',
         icon: closeIcon,
-        state: 'hidden',
+        state: settingsExpanded === true ? 'initial' : 'hidden',
         validStates: ['initial', 'hidden'],
         ariaLabel: 'Stäng',
         click() {
@@ -216,7 +217,8 @@ const PrintSettings = function PrintSettings(options = {}) {
         collapseY: true,
         headerComponent,
         contentComponent,
-        mainCls: 'collapse-scroll'
+        mainCls: 'collapse-scroll',
+        expanded: settingsExpanded === true
       });
       this.addComponent(printSettingsContainer);
 


### PR DESCRIPTION
Fixes #1807 
Adding ``settingsExpanded": true`` print option will make the settings window appear when opening the print preview page.