### PR TITLE
feature: Made modal draggable

### DIFF
--- a/src/ui/modal.js
+++ b/src/ui/modal.js
@@ -2,6 +2,7 @@ import Component from './component';
 import Element from './element';
 import Button from './button';
 import { html } from './dom/dom';
+import utils from '../utils';
 
 /**
  * Creates a modal and displays it. The modal is created as a div tag that is attached to the DOM as a child of the options.target element.
@@ -93,7 +94,7 @@ export default function Modal(options = {}) {
       headerCmps.push(closeButton);
 
       headerEl = Element({
-        cls: 'flex row justify-end grey-lightest',
+        cls: 'flex row justify-end grey-lightest draggable',
         components: headerCmps
       });
       const elOptions = { cls: 'o-modal-content' };
@@ -121,6 +122,8 @@ export default function Modal(options = {}) {
     },
     onRender() {
       modal = document.getElementById(this.getId());
+      const modalBox = modal.getElementsByClassName('o-modal')[0];
+      utils.makeElementDraggable(modalBox);
       document.getElementById(screenEl.getId()).addEventListener('click', () => {
         if (!isStatic) {
           closeButton.dispatch('click');

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,6 +61,15 @@ export default {
   makeElementDraggable(el) {
     const touchMode = 'ontouchstart' in document.documentElement;
     const elmnt = el;
+    let draggableEl;
+    if (elmnt.getElementsByClassName('draggable')[0]) {
+      /* if present, move the DIV from a child element with draggable class: */
+      draggableEl = elmnt.getElementsByClassName('draggable')[0];
+    } else {
+      /* otherwise, move the DIV from anywhere inside the DIV: */
+      draggableEl = elmnt;
+    }
+
     let pos1 = 0;
     let pos2 = 0;
     let pos3 = 0;
@@ -77,16 +86,16 @@ export default {
       pos3 = clientX;
       pos4 = clientY;
 
-      elmnt.style.top = `${elmnt.offsetTop - pos2}px`;
-      elmnt.style.left = `${elmnt.offsetLeft - pos1}px`;
+      elmnt.style.top = `${el.offsetTop - pos2}px`;
+      elmnt.style.left = `${el.offsetLeft - pos1}px`;
     }
 
     function closeDragElement() {
-      elmnt.classList.toggle('grabbing');
+      draggableEl.classList.toggle('grabbing');
 
       if (touchMode) {
-        elmnt.ontouchend = null;
-        elmnt.ontouchmove = null;
+        draggableEl.ontouchend = null;
+        draggableEl.ontouchmove = null;
       } else {
         document.onmouseup = null;
         document.onmousemove = null;
@@ -95,13 +104,13 @@ export default {
 
     function dragMouseDown(evt) {
       const e = evt || window.event;
-      elmnt.classList.toggle('grabbing');
+      draggableEl.classList.toggle('grabbing');
       pos3 = e.clientX;
       pos4 = e.clientY;
 
       if (touchMode) {
-        elmnt.ontouchend = closeDragElement;
-        elmnt.ontouchmove = elementDrag;
+        draggableEl.ontouchend = closeDragElement;
+        draggableEl.ontouchmove = elementDrag;
       } else {
         document.onmouseup = closeDragElement;
         document.onmousemove = elementDrag;
@@ -109,9 +118,9 @@ export default {
     }
 
     if (touchMode) {
-      elmnt.ontouchstart = dragMouseDown;
+      draggableEl.ontouchstart = dragMouseDown;
     } else {
-      elmnt.onmousedown = dragMouseDown;
+      draggableEl.onmousedown = dragMouseDown;
     }
   }
 };


### PR DESCRIPTION
Closes #1729

Makes all instances of `modal` draggable. No configuration necessary or even possible. Just click-drag the header of any modal and watch the magic happen.

There will be a race for merge conflict in _utils.js_ with #1751, but I stole the code from there so the conflict will be easy to merge unless @jokd changes more stuff.