### PR TITLE
feature: add zoomToExtent option for draw layers

### DIFF
--- a/src/controls/draw/drawhandler.js
+++ b/src/controls/draw/drawhandler.js
@@ -387,6 +387,7 @@ const DrawHandler = function DrawHandler(options = {}) {
       queryable,
       removable,
       exportable,
+      zoomToExtent = true,
       drawlayer
     } = layerOptions;
     let newLayer;
@@ -408,6 +409,7 @@ const DrawHandler = function DrawHandler(options = {}) {
         queryable,
         removable,
         exportable,
+        zoomToExtent,
         drawlayer,
         type: 'GEOJSON',
         attributes: [


### PR DESCRIPTION
Fixes #1862 
To NOT use this feature:
`"zoomToExtent": false`

Defaults to true