### PR TITLE
fix: respect layers parameter in getFeatureInfoRequests

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -634,7 +634,6 @@ const Featureinfo = function Featureinfo(options = {}) {
     const pixel = evt.pixel;
     const map = viewer.getMap();
     const coordinate = evt.coordinate;
-    const layers = viewer.getQueryableLayers();
     const clientResult = getFeatureInfo.getFeaturesAtPixel({
       coordinate,
       clusterFeatureinfoLevel,
@@ -646,7 +645,6 @@ const Featureinfo = function Featureinfo(options = {}) {
     if (clientResult !== false) {
       getFeatureInfo.getFeaturesFromRemote({
         coordinate,
-        layers,
         map,
         pixel
       }, viewer)

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -215,7 +215,8 @@ function getFeatureInfoRequests({
         });
       }
     });
-  };
+  }
+
   const imageLayers = queryableLayers.filter(layer => layer instanceof BaseTileLayer || layer instanceof ImageLayer);
   imageLayers.forEach(layer => {
     let item;

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -189,28 +189,33 @@ function getGetFeatureInfoRequest({ layer, coordinate }, viewer) {
 
 function getFeatureInfoRequests({
   coordinate,
-  pixel
+  pixel,
+  layers
 }, viewer) {
   const imageFeatureInfoMode = viewer.getViewerOptions().featureinfoOptions.imageFeatureInfoMode || 'pixel';
   const requests = [];
-  const queryableLayers = viewer.getLayersByProperty('queryable', true);
-  const layerGroups = viewer.getGroupLayers();
-  layerGroups.forEach(layerGroup => {
-    if (layerGroup.get('visible')) {
-      layerGroup.getLayersArray().forEach(layer => {
-        if ((layer.get('queryable'))) {
-          queryableLayers.push(layer);
-        }
-      });
-    } else {
-      layerGroup.getLayersArray().forEach(layer => {
-        if (layer.get('queryable') && ((layer.get('imageFeatureInfoMode') && layer.get('imageFeatureInfoMode') === 'always') || (!layer.get('imageFeatureInfoMode') && imageFeatureInfoMode === 'always'))) {
-          queryableLayers.push(layer);
-        }
-      });
-    }
-  });
-
+  let queryableLayers;
+  if (layers) {
+    queryableLayers = layers;
+  } else {
+    queryableLayers = viewer.getLayersByProperty('queryable', true);
+    const layerGroups = viewer.getGroupLayers();
+    layerGroups.forEach(layerGroup => {
+      if (layerGroup.get('visible')) {
+        layerGroup.getLayersArray().forEach(layer => {
+          if ((layer.get('queryable'))) {
+            queryableLayers.push(layer);
+          }
+        });
+      } else {
+        layerGroup.getLayersArray().forEach(layer => {
+          if (layer.get('queryable') && ((layer.get('imageFeatureInfoMode') && layer.get('imageFeatureInfoMode') === 'always') || (!layer.get('imageFeatureInfoMode') && imageFeatureInfoMode === 'always'))) {
+            queryableLayers.push(layer);
+          }
+        });
+      }
+    });
+  };
   const imageLayers = queryableLayers.filter(layer => layer instanceof BaseTileLayer || layer instanceof ImageLayer);
   imageLayers.forEach(layer => {
     let item;


### PR DESCRIPTION
Fixes #1863 
With this fix the multiselection tool will fully work and getfeatureinfo will exclude layers that are outside their zoom limits.