### PR TITLE
Fix:support for MultiLine, MultiPolygon and MultiPoint in drawtools

### DIFF
--- a/src/controls/editor/copyTool.js
+++ b/src/controls/editor/copyTool.js
@@ -1,15 +1,14 @@
 import Select from 'ol/interaction/Select';
 import Feature from 'ol/Feature';
-import { MultiPolygon, MultiLineString, MultiPoint } from 'ol/geom';
+
 import dispatcher from './editdispatcher';
 
 // Point of entry. Create on of these each time the tool is selected
 //  viewer: the viewer
 //  editLayer: the destination layer for edits
 //  options: the current drawTools configuration for this layer
-const copyTool = function copyTool(viewer, editLayer, options) {
+const copyTool = function copyTool(viewer, options) {
   const map = viewer.getMap();
-  const destinationLayer = editLayer;
   let selectLayers = [];
   let hasGoups = false;
 
@@ -72,24 +71,7 @@ const copyTool = function copyTool(viewer, editLayer, options) {
       const accept = window.confirm('Kopiera vald geometri? Avbryt för att välja en annan');
       if (accept) {
         const f = new Feature(e.selected[0].getGeometry().clone());
-        const featureGeometryType = f.getGeometry().getType();
-        const layerGeometryType = destinationLayer.get('geometryType');
-        //  Correct geometry type to conform to edit layer
-        //  it will fail in edit handler if geometry is incorrect type
-        if (featureGeometryType !== layerGeometryType) {
-          if (featureGeometryType === 'Polygon' && layerGeometryType === 'MultiPolygon') {
-            const multiPoly = new MultiPolygon([f.getGeometry()]);
-            f.setGeometry(multiPoly);
-          }
-          if (featureGeometryType === 'LineString' && layerGeometryType === 'MultiLineString') {
-            const multiLine = new MultiLineString([f.getGeometry()]);
-            f.setGeometry(multiLine);
-          }
-          if (featureGeometryType === 'Point' && layerGeometryType === 'MultiPoint') {
-            const multiPoint = new MultiPoint([f.getGeometry()]);
-            f.setGeometry(multiPoint);
-          }
-        }
+
         cancelTool();
         // Important! Remove handler so it won't linger
         document.removeEventListener('toggleEdit', onToggleEdit, { once: true });

--- a/src/controls/editor/drawtools.js
+++ b/src/controls/editor/drawtools.js
@@ -11,8 +11,11 @@ let layer;
 const drawToolsSelector = function drawToolsSelector(tools, defaultLayer, v) {
   const toolNames = {
     Polygon: 'Polygon',
+    MultiPolygon: 'Polygon',
     Point: 'Punkt',
+    MultiPoint: 'Punkt',
     Line: 'Linje',
+    MultiLine: 'Linje',
     box: 'Rektangel',
     Copy: 'Kopiera'
   };
@@ -73,7 +76,7 @@ const drawToolsSelector = function drawToolsSelector(tools, defaultLayer, v) {
           // Copy tool is handled entirely in copyTool. Only notify edithandler to back off
           // and call copyTool to do its stuff.
           dispatcher.emitChangeEditorShapes('custom');
-          copyTool(viewer, layer, drawTools.find((tool) => tool.toolName === 'Copy'));
+          copyTool(viewer, drawTools.find((tool) => tool.toolName === 'Copy'));
           break;
         default:
           // This is an OL shape tool. Let edithandler handle it

--- a/src/controls/editor/shapes.js
+++ b/src/controls/editor/shapes.js
@@ -9,11 +9,20 @@ export default (drawType) => {
     Line: {
       type: 'LineString'
     },
+    MultiLine: {
+      type: 'MultiLineString'
+    },
     Polygon: {
       type: 'Polygon'
     },
+    MultiPolygon: {
+      type: 'MultiPolygon'
+    },
     Point: {
       type: 'Point'
+    },
+    MultiPoint: {
+      type: 'MultiPoint'
     }
   };
 


### PR DESCRIPTION
Fixes #1872.

It is now possible to configure drawtools on _MultiLine, MultiPolygon and MultiPoint_ both on editor level and on layer level.

No actual new configuration needed, but it is possible to use the aforementioned geometry types in configuration. Note that layers with geometry typ _MultiLineString_ is configured as _MultiLine_ as _LineString_ already was configured as _Line_.

Also note that there are no draw tools available for any kind of points and lines, but that's outside the scope of this PR. If there ever emerges any tools for these geometry types it will be possible to configure them.

Documentation will be updated accordingly.