### PR TITLE
fix: set maxheight for layer search

### DIFF
--- a/scss/externs/_awesomplete.base.scss
+++ b/scss/externs/_awesomplete.base.scss
@@ -47,6 +47,8 @@
   top: auto;
   bottom: 100%;
   z-index: 9999999;
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 .awesomplete > ul:empty {

--- a/scss/externs/_awesomplete.base.scss
+++ b/scss/externs/_awesomplete.base.scss
@@ -39,8 +39,8 @@
   left: 0px;
   list-style: none;
   margin: 0;
-  min-width: 180px;
-  max-width: 100%;
+  width: 100%;
+  min-width: unset;
   overflow-wrap: break-word;
   padding: 0;
   position: absolute;

--- a/scss/externs/_awesomplete.base.scss
+++ b/scss/externs/_awesomplete.base.scss
@@ -30,6 +30,7 @@
   position: absolute;
   top: 40px;
   z-index: 1;
+  overflow-y: auto;
 }
 
 .awesomplete.black > ul {
@@ -47,7 +48,6 @@
   top: auto;
   bottom: 100%;
   z-index: 9999999;
-  max-height: 100%;
   overflow-y: auto;
 }
 

--- a/scss/externs/_awesomplete.theme.scss
+++ b/scss/externs/_awesomplete.theme.scss
@@ -88,6 +88,6 @@
 &[class*=#{$media-l-m}] {
   .awesomplete > ul {
     max-width: calc(100% + 2rem);
-    min-width: calc(100% + 2rem);
+    min-width: 100%;
   }
 }

--- a/scss/externs/_awesomplete.theme.scss
+++ b/scss/externs/_awesomplete.theme.scss
@@ -84,10 +84,3 @@
 .awesomplete li[aria-selected='true'] mark {
   background-color: $search-hover-backround;
 }
-
-&[class*=#{$media-l-m}] {
-  .awesomplete > ul {
-    max-width: calc(100% + 2rem);
-    min-width: 100%;
-  }
-}

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -508,7 +508,6 @@ const Legend = function Legend(options = {}) {
         }
       });
       awesomplete.ul.style.maxHeight = `${calcMaxHeight(getTargetHeight()) / 2}px`;
-      awesomplete.ul.style.overflowY = 'auto';
       input.parentNode.classList.add('black');
       input.parentNode.classList.add('grow');
       input.addEventListener('keyup', (e) => {

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -510,6 +510,7 @@ const Legend = function Legend(options = {}) {
 
       input.parentNode.classList.add('black');
       input.parentNode.classList.add('grow');
+      input.parentNode.style.height = `${calcMaxHeight(getTargetHeight()) - 84}px`;
       input.addEventListener('keyup', (e) => {
         const keyCode = e.keyCode;
         if (input.value.length >= searchLayersMinLength) {

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -507,10 +507,10 @@ const Legend = function Legend(options = {}) {
           return suggestionValue.toLowerCase().includes(userInput.toLowerCase()) ? suggestionValue : false;
         }
       });
-
+      awesomplete.ul.style.maxHeight = `${calcMaxHeight(getTargetHeight()) / 2}px`;
+      awesomplete.ul.style.overflowY = 'auto';
       input.parentNode.classList.add('black');
       input.parentNode.classList.add('grow');
-      input.parentNode.style.height = `${calcMaxHeight(getTargetHeight()) - 84}px`;
       input.addEventListener('keyup', (e) => {
         const keyCode = e.keyCode;
         if (input.value.length >= searchLayersMinLength) {

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -312,6 +312,8 @@ const Search = function Search(options = {}) {
 
   function initAutocomplete() {
     const input = document.getElementsByClassName('o-search-field')[0];
+    const mapEl = viewer.getMap().getTargetElement();
+    const listHeight = mapEl.offsetHeight / 2;
 
     awesomplete = new Awesomplete('.o-search-field', {
       minChars: minLength,
@@ -324,10 +326,8 @@ const Search = function Search(options = {}) {
         return suggestionValue.toLowerCase().includes(userInput.toLowerCase()) ? suggestionValue : false;
       }
     });
-    const mapEl = viewer.getMap().getTargetElement();
-    const listHeight = mapEl.offsetHeight / 2;
     awesomplete.ul.style.maxHeight = `${listHeight}px`;
-    awesomplete.ul.style.overflowY = 'auto';
+
     const handler = function func(list) {
       awesomplete.list = list;
       awesomplete.evaluate();

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -324,7 +324,7 @@ const Search = function Search(options = {}) {
         return suggestionValue.toLowerCase().includes(userInput.toLowerCase()) ? suggestionValue : false;
       }
     });
-    const mapEl = origo.api().getMap().getTargetElement();
+    const mapEl = viewer.getMap().getTargetElement();
     const listHeight = mapEl.offsetHeight / 2;
     awesomplete.ul.style.maxHeight = `${listHeight}px`;
     awesomplete.ul.style.overflowY = 'auto';

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -324,7 +324,10 @@ const Search = function Search(options = {}) {
         return suggestionValue.toLowerCase().includes(userInput.toLowerCase()) ? suggestionValue : false;
       }
     });
-
+    const mapEl = origo.api().getMap().getTargetElement();
+    const listHeight = mapEl.offsetHeight / 2;
+    awesomplete.ul.style.maxHeight = `${listHeight}px`;
+    awesomplete.ul.style.overflowY = 'auto';
     const handler = function func(list) {
       awesomplete.list = list;
       awesomplete.evaluate();


### PR DESCRIPTION
Fixes #1827 
Set max height element containing search result so it won't overflow the legend container and make it scrollable. Also set the width to match the legend.

![image](https://github.com/origo-map/origo/assets/6848075/096563fe-8659-4a39-bebf-b0bcedcdc66b)
