### PR TITLE
feature: spinner for print map loading indicator

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -118,11 +118,11 @@ $print-scale-line-font-size: $font-size-smallest;
 
 .print-map-loading-spinner {
   display: inline-block;
-  width: 35px;
-  height: 35px;
-  border: 2px solid rgba(255,255,255,.3);
+  width: 45px;
+  height: 45px;
+  border: 16px solid rgba(255, 255, 255, 0.884);
   border-radius: 50%;
-  border-top-color: #fff;
+  border-top-color: #008ff5;
   animation: spin 1s ease-in-out infinite;
  }
 

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -116,6 +116,16 @@ $print-scale-line-font-size: $font-size-smallest;
   display: block;
 }
 
+.print-map-loading-spinner {
+  display: inline-block;
+  width: 35px;
+  height: 35px;
+  border: 2px solid rgba(255,255,255,.3);
+  border-radius: 50%;
+  border-top-color: #fff;
+  animation: spin 1s ease-in-out infinite;
+ }
+
 // media print settings
 @media print {
   .no-print {

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -7,7 +7,7 @@ import TileWMSSource from 'ol/source/TileWMS';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import { Group } from 'ol/layer';
 import {
-  Button, Component, cuid, dom
+  Button, Component, cuid, dom, Element as El
 } from '../../ui';
 import pageTemplate from './page.template';
 import PrintMap from './print-map';
@@ -253,6 +253,10 @@ const PrintComponent = function PrintComponent(options = {}) {
 
   const printMapComponent = PrintMap({ logo, northArrow, map, viewer, showNorthArrow, printLegend, showPrintLegend });
 
+  const centerComponent = El({ cls: 'flex column align-start absolute center-center transparent z-index-ontop-middle' });
+  const printMapSpinner = El({ cls: 'print-map-loading-spinner' });
+  centerComponent.addComponent(printMapSpinner);
+
   const closeButton = Button({
     cls: 'fixed top-right medium round icon-smaller light box-shadow z-index-ontop-high',
     icon: '#ic_close_24px',
@@ -339,10 +343,12 @@ const PrintComponent = function PrintComponent(options = {}) {
 
   function disablePrintToolbar() {
     printToolbar.setDisabled(true);
+    document.querySelector(`#${printMapSpinner.getId()}`).style.display = '';
   }
 
   function enablePrintToolbar() {
     printToolbar.setDisabled(false);
+    document.querySelector(`#${printMapSpinner.getId()}`).style.display = 'none';
   }
 
   function updateScaleOnMove() {
@@ -698,6 +704,7 @@ const PrintComponent = function PrintComponent(options = {}) {
             </div>
           </div>
         </div>
+        ${centerComponent.render()}
         <div id="o-print-tools-left" class="top-left fixed no-print flex column spacing-vertical-small z-index-ontop-top height-full">
           ${printSettings.render()}
           ${printInteractionToggle.render()}


### PR DESCRIPTION
Suggestion for an indicator in addition to tiles appearing at the edges of the print map and the two print buttons being greyed out that the print map is loading. Aims to fix #1871 

It looks like the larger "global" print spinner that shows when printing -> png and shows in the middle of the print map preview, more directly tied to the map not being finished that way I thought.

Draft pr less because I think it needs anything else and more because it may need to be something different. There are various ways of implementing a spinner or progress bar. As for the resident options in Origo, the "global" spinner is in a different place in the DOM (for a reason I guess) and has logic for that purpose (well looks rather). The "progress" control doesn't take configuration presently and is purposed as a singleton of the main map. The "spinner in utils/ appears a bit visually unappealing.