### PR TITLE
fix: enable keyboard navigation on load

### DIFF
--- a/origo.js
+++ b/origo.js
@@ -37,6 +37,7 @@ const Origo = function Origo(configPath, options = {}) {
     featureinfoOptions: {},
     crossDomain: true,
     target: '#app-wrapper',
+    keyboardEventTarget: document,
     svgSpritePath: 'css/svg/',
     svgSprites: ['fa-icons.svg', 'material-icons.svg', 'miscellaneous.svg', 'origo-icons.svg', 'custom.svg'],
     breakPoints: {


### PR DESCRIPTION
Fixes #667.

Quick and dirty. Doesn't work with iframe embedded maps, though.