### PR TITLE
feat: sticky legend group header

### DIFF
--- a/scss/ui/_slidenav.scss
+++ b/scss/ui/_slidenav.scss
@@ -2,7 +2,6 @@
   box-sizing: border-box;
   display: inline-block;
   line-height: 0;
-  overflow: hidden;
   position: relative;
   transition: height 0.3s;
 
@@ -10,7 +9,6 @@
     box-sizing: border-box;
     display: inline-block;
     left: 0;
-    overflow: hidden;
     position: relative;
     top: 0;
     transition: all 0.3s;
@@ -70,5 +68,7 @@
       opacity: 1;
       transform: none;
     }
+    
+    overflow: hidden
   }  
 }

--- a/scss/ui/helpers/_helpers.scss
+++ b/scss/ui/helpers/_helpers.scss
@@ -64,6 +64,10 @@
   overflow-y: auto;
 }
 
+.overflow-unset {
+  overflow: unset;
+}
+
 // position
 .absolute {
   position: absolute;

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -112,7 +112,8 @@ const Group = function Group(viewer, options = {}) {
 
   const GroupHeader = function GroupHeader() {
     const headerComponent = CollapseHeader({
-      cls: 'hover padding-x padding-y-small grey-lightest border-bottom text-small',
+      cls: 'hover padding-x padding-y-small grey-lightest border-bottom text-small sticky bg-white z-index-low',
+      style: 'top: 0;',
       icon,
       title
     });

--- a/src/ui/slidenav.js
+++ b/src/ui/slidenav.js
@@ -132,7 +132,7 @@ export default function Slidenav(options = {}) {
     getState,
     onInit() {
       mainContainer = Element({
-        cls: 'main'
+        cls: 'main overflow-unset'
       });
       backButton = Button({
         cls: 'icon-small padding-small',


### PR DESCRIPTION
Fixes #1908 
Sticks group name in top while scrolling a group:
![chrome-capture-2023-10-24](https://github.com/origo-map/origo/assets/6848075/1434cb65-0677-41f4-bb21-d5122ea64457)
