### PR TITLE
feature: new subgroup options

### DIFF
--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -555,6 +555,7 @@ const Legend = function Legend(options = {}) {
     },
     getuseGroupIndication() { return useGroupIndication; },
     getOverlaysCollapse() { return overlaysCmp.overlaysCollapse; },
+    getOverlays() { return overlaysCmp; },
     setVisibleLayersViewActive,
     addButtonToTools(button, buttonGroup) {
       if (buttonGroup === 'addLayerButton') {

--- a/src/controls/legend/moreinfobutton.js
+++ b/src/controls/legend/moreinfobutton.js
@@ -1,0 +1,189 @@
+import { Component, Button, dom } from '../../ui';
+import PopupMenu from '../../ui/popupmenu';
+import exportToFile from '../../utils/exporttofile';
+
+export default function createMoreInfoButton(params) {
+  const {
+    layer,
+    group = {},
+    viewer
+  } = params;
+  const popupMenuItems = [];
+  let moreInfoButton;
+  let popupMenu;
+  const showPopup = group.zoomToExtent && group.extent; //In case of zoomToExtent we always want to show popupmenu
+
+  const eventOverlayProps = new CustomEvent('overlayproperties', {
+    bubbles: true,
+    detail: {
+      layer,
+      group
+    }
+  });
+
+  if (layer || group.opacityControl || group.description) {
+    const layerInfoMenuItem = Component({
+      onRender() {
+        const labelEl = document.getElementById(this.getId());
+        labelEl.addEventListener('click', (e) => {
+          popupMenu.setVisibility(false);
+          document.getElementById(moreInfoButton.getId()).dispatchEvent(eventOverlayProps);
+          e.preventDefault();
+        });
+      },
+      render() {
+        const labelCls = 'text-smaller padding-x-small grow pointer no-select overflow-hidden';
+        return `<li id="${this.getId()}" class="${labelCls}">Visa ${layer ? 'lagerinformation' : 'gruppinformation'}</li>`;
+      }
+    });
+    popupMenuItems.push(layerInfoMenuItem);
+  }
+
+  if ((layer && layer.get('zoomToExtent')) || (group.zoomToExtent && group.extent)) {
+    const zoomToExtentMenuItem = Component({
+      onRender() {
+        const labelEl = document.getElementById(this.getId());
+        labelEl.addEventListener('click', (e) => {
+          if (layer) {
+            const extent = typeof layer.getSource !== 'undefined' && typeof layer.getSource().getExtent !== 'undefined' ? layer.getSource().getExtent() : layer.getExtent();
+            if (layer.getVisible()) {
+              viewer.getMap().getView().fit(extent, {
+                padding: [50, 50, 50, 50],
+                duration: 1000
+              });
+              e.preventDefault();
+            }
+          } else if (group.zoomToExtent) {
+            const extent = group.extent;
+            viewer.getMap().getView().fit(extent, {
+              padding: [50, 50, 50, 50],
+              duration: 1000
+            });
+            e.preventDefault();
+          }
+        });
+      },
+      render() {
+        const labelCls = 'text-smaller padding-x-small grow pointer no-select overflow-hidden';
+        return `<li id="${this.getId()}" class="${labelCls}">Zooma till</li>`;
+      }
+    });
+    popupMenuItems.push(zoomToExtentMenuItem);
+  }
+
+  if (layer && layer.get('exportable')) {
+    const exportFormat = layer.get('exportFormat') || layer.get('exportformat');
+    let exportFormatArray = [];
+    if (exportFormat && typeof exportFormat === 'string') {
+      exportFormatArray.push(exportFormat);
+    } else if (exportFormat && Array.isArray(exportFormat)) {
+      exportFormatArray = exportFormat;
+    }
+    const formats = exportFormatArray.map(format => format.toLowerCase()).filter(format => format === 'geojson' || format === 'gpx' || format === 'kml');
+    if (formats.length === 0) { formats.push('geojson'); }
+    formats.forEach((format) => {
+      const exportLayerMenuItem = Component({
+        onRender() {
+          const labelEl = document.getElementById(this.getId());
+          labelEl.addEventListener('click', (e) => {
+            const features = layer.getSource().getFeatures();
+            exportToFile(features, format, {
+              featureProjection: viewer.getProjection().getCode(),
+              filename: layer.get('title') || 'export'
+            });
+            e.preventDefault();
+          });
+        },
+        render() {
+          let exportLabel;
+          if (exportFormatArray.length > 1) {
+            exportLabel = `Spara lager (.${format})`;
+          } else { exportLabel = 'Spara lager'; }
+          const labelCls = 'text-smaller padding-x-small grow pointer no-select overflow-hidden';
+          return `<li id="${this.getId()}" class="${labelCls}">${exportLabel}</li>`;
+        }
+      });
+      popupMenuItems.push(exportLayerMenuItem);
+    });
+  }
+
+  if (layer && layer.get('removable')) {
+    const removeLayerMenuItem = Component({
+      onRender() {
+        const labelEl = document.getElementById(this.getId());
+        labelEl.addEventListener('click', (e) => {
+          const doRemove = (layer.get('promptlessRemoval') === true) || window.confirm('Vill du radera lagret?');
+          if (doRemove) {
+            viewer.getMap().removeLayer(layer);
+            e.preventDefault();
+          }
+        });
+      },
+      render() {
+        const labelCls = 'text-smaller padding-x-small grow pointer no-select overflow-hidden';
+        return `<li id="${this.getId()}" class="${labelCls}">Ta bort lager</li>`;
+      }
+    });
+    popupMenuItems.push(removeLayerMenuItem);
+  }
+
+  const popupMenuList = Component({
+    onInit() {
+      this.addComponents(popupMenuItems);
+    },
+    render() {
+      let html = `<ul id="${this.getId()}">`;
+      popupMenuItems.forEach((item) => {
+        html += `${item.render()}`;
+      });
+      html += '</ul>';
+      return html;
+    }
+  });
+
+  const createPopupMenu = function createPopupMenu() {
+    const moreInfoButtonEl = document.getElementById(moreInfoButton.getId());
+    const onUnfocus = (e) => {
+      if (!moreInfoButtonEl.contains(e.target)) {
+        popupMenu.setVisibility(false);
+      }
+    };
+    popupMenu = PopupMenu({ onUnfocus, cls: 'overlay-popup' });
+    const newDiv = document.createElement('div');
+    newDiv.classList.add('justify-end', 'flex', 'relative', 'basis-100');
+    moreInfoButtonEl.insertAdjacentElement('afterend', newDiv);
+    newDiv.appendChild(dom.html(popupMenu.render()));
+    popupMenu.setContent(popupMenuList.render());
+    popupMenuList.dispatch('render');
+    popupMenu.setVisibility(true);
+  };
+
+  const togglePopupMenu = function togglePopupMenu() {
+    if (!popupMenu) {
+      createPopupMenu();
+    } else {
+      popupMenu.toggleVisibility();
+    }
+  };
+
+  if (popupMenuItems.length > 0) {
+    moreInfoButton = Button({
+      cls: 'round small icon-smaller no-shrink',
+      click() {
+        if (popupMenuItems.length > 1 || showPopup) {
+          togglePopupMenu();
+        } else {
+          document.getElementById(this.getId()).dispatchEvent(eventOverlayProps);
+        }
+      },
+      style: {
+        'align-self': 'center'
+      },
+      icon: '#ic_more_vert_24px',
+      ariaLabel: 'Visa lagerinfo',
+      tabIndex: -1
+    });
+    return moreInfoButton;
+  }
+  return false;
+}

--- a/src/controls/legend/moreinfobutton.js
+++ b/src/controls/legend/moreinfobutton.js
@@ -11,7 +11,7 @@ export default function createMoreInfoButton(params) {
   const popupMenuItems = [];
   let moreInfoButton;
   let popupMenu;
-  const showPopup = group.zoomToExtent && group.extent; //In case of zoomToExtent we always want to show popupmenu
+  const showPopup = group.zoomToExtent && group.extent; // In case of zoomToExtent we always want to show popupmenu
 
   const eventOverlayProps = new CustomEvent('overlayproperties', {
     bubbles: true,

--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -1,7 +1,5 @@
 import { Component, Button, dom, Collapse } from '../../ui';
 import { HeaderIcon, Legend } from '../../utils/legendmaker';
-import PopupMenu from '../../ui/popupmenu';
-import exportToFile from '../../utils/exporttofile';
 import createMoreInfoButton from './moreinfobutton';
 
 const OverlayLayer = function OverlayLayer(options) {


### PR DESCRIPTION
Fixes #1896 
Adds three new options for subgroups:

"description": "Group descripton", // If set, this is shown on second page along with opacitySlider (if set)
"opacityControl": true, // If set, this is shown on second page along with description (if set). Changing the opacity will change the opacity for all layers in the subgroup. It will not affect groups in the subgroup. (Should it?!)
"zoomToExtent": true, // If set to true and there is an extent set for the group a link in the popupMenu will be created

Example config:
```
{
      "name": "grupp",
      "title": "grupp",
      "expanded": true,
      "groups": [
        {
          "name": "grupp2",
          "title": "grupp2",
          "expanded": true,
          "abstract": "Kort abstract",
          "description": "Detta är en grupp för test, visas på sida 2",
          "opacityControl": true,
          "zoomToExtent": true,
          "extent": [
            -20026376.39,
            -20048966.10,
            20026376.39,
            20048966.10
          ]
        },{
          "name": "grupp3",
          "title": "grupp3"
        }
      ]
    }
```