### PR TITLE
Fix: Correct print scales even when constrainResolution is true

### DIFF
--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -271,7 +271,8 @@ const PrintComponent = function PrintComponent(options = {}) {
     titleComponent,
     descriptionComponent,
     createdComponent,
-    closeButton
+    closeButton,
+    constrainResolution: view.getConstrainResolution()
   });
 
   const setScale = function setScale(scale) {

--- a/src/controls/print/print-resize.js
+++ b/src/controls/print/print-resize.js
@@ -19,7 +19,8 @@ export default function PrintResize(options = {}) {
     titleComponent,
     descriptionComponent,
     createdComponent,
-    closeButton
+    closeButton,
+    constrainResolution
   } = options;
 
   let {
@@ -404,6 +405,8 @@ export default function PrintResize(options = {}) {
   // Alters layer in map, if vector then set scale for feature, if image set DPI parameter for source
   const setLayerScale = function setLayerScale(layer) {
     const source = layer.getSource();
+    const view = map.getView();
+    view.setConstrainResolution(false);
 
     if (isVector(layer)) {
       const styleName = layer.get('styleName');
@@ -467,6 +470,8 @@ export default function PrintResize(options = {}) {
   // "Resets" layer by resetting the style and removing DPI parameter
   const resetLayerScale = function resetLayerScale(layer) {
     const source = layer.getSource();
+    const view = map.getView();
+    view.setConstrainResolution(constrainResolution);
     if (isVector(layer)) {
       const features = source.getFeatures();
       const styleName = layer.get('styleName');


### PR DESCRIPTION
Correct print scales are now retained even when the ConstrainResolution option is true.

ConstrainResolution gets temporarily set to false when using the print component and is restored once the print component is closed.

Fixes #1934 in regard to ConstrainResolution. The scales are however still constrained by the max and min resolutions of the map, regardless of if ConstrainResolution is true or false.

