### PR TITLE
fix: update linter ecmascript version and keep up to date

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,10 @@
   "env": {
     "browser": true
   },
+  "parserOptions": {
+    "ecmaVersion": "latest"
+},
+
   "rules": {
     "comma-dangle": [
       "error",


### PR DESCRIPTION
Aims to fix #1956 

(The lint workflow runs the "lint" script which uses eslint so it should receive the same update) 