### PR TITLE
fix: update lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 14
+        node-version: 20
         cache: 'npm'
     - name: Install dependencies
       run: npm install


### PR DESCRIPTION
Aims to fix #1958 

I've checked https://github.com/actions/setup-node which indicates the major versions of Node are supported (and 20 is the current lts, well together with 18).  ( Bard says with confidence that the provided yml changes are appropriate. ) 

Here goes