### PR TITLE
feature: expose loader and spinner

### DIFF
--- a/origo.js
+++ b/origo.js
@@ -27,6 +27,8 @@ import 'elm-pep';
 import 'pepjs';
 import 'drag-drop-touch';
 import permalink from './src/permalink/permalink';
+import * as Loader from './src/loading';
+import Spinner from './src/utils/spinner';
 
 const Origo = function Origo(configPath, options = {}) {
   /** Reference to the returned Component */
@@ -165,5 +167,10 @@ Origo.Utils = Utils;
 Origo.dropdown = dropdown;
 Origo.renderSvgIcon = renderSvgIcon;
 Origo.SelectedItem = SelectedItem;
+Origo.Loader = {};
+Origo.Loader.show = Loader.showLoading;
+Origo.Loader.hide = Loader.hideLoading;
+Origo.Loader.withLoading = Loader.withLoading;
+Origo.Loader.getInlineSpinner = Spinner;
 
 export default Origo;


### PR DESCRIPTION
Fixes #1972 by adding the following properties to the global Origo object:
- Origo.Loader.show
- Origo.Loader.hide
- Origo.Loader.withLoading
- Origo.Loader.getInlineSpinner
