### PR TITLE
feature: cycleButton for background layers

### DIFF
--- a/scss/ui/_button.scss
+++ b/scss/ui/_button.scss
@@ -314,13 +314,8 @@ button.active,
   }
 }
 
-.cycle-even {
+.cycle {
   background: linear-gradient(45deg, #8db2d7, #ddddee);
-  width: 37px; 
-  height: 37px; 
-}
-.cycle-odd {
-  background: linear-gradient(45deg,  #ddddee, #8db2d7);
   width: 37px; 
   height: 37px; 
 }

--- a/scss/ui/_button.scss
+++ b/scss/ui/_button.scss
@@ -313,3 +313,14 @@ button.active,
     border-right: 0;
   }
 }
+
+.cycle-even {
+  background: linear-gradient(45deg, #8db2d7, #ddddee);
+  width: 37px; 
+  height: 37px; 
+}
+.cycle-odd {
+  background: linear-gradient(45deg,  #ddddee, #8db2d7);
+  width: 37px; 
+  height: 37px; 
+}

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -158,12 +158,8 @@ const Legend = function Legend(options = {}) {
       title: layer.get('title'),
       state: layer.get('visible') ? 'active' : undefined,
       methods: {
-        active: () => {
-          layer.setVisible(true);
-        },
-        initial: () => {
-          layer.setVisible(false);
-        }
+        active: () => layer.setVisible(true),
+        initial: () => layer.setVisible(false)
       },
       click() {
         const overlayComponent = visibleLayersControl && visibleLayersViewActive ? visibleOverlaysCmp : overlaysCmp;
@@ -455,9 +451,7 @@ const Legend = function Legend(options = {}) {
       const groupExclusive = (viewer.getGroup(layerGroup) && (viewer.getGroup(layerGroup).exclusive || viewer.getGroup(layerGroup).name === 'background'));
       if (groupExclusive) {
         const layers = viewer.getLayersByProperty('group', layerGroup);
-        layers.forEach(l => {
-          l.setVisible(false);
-        });
+        layers.forEach(l => l.setVisible(false));
       }
       layer.setVisible(true);
       document.getElementsByClassName('o-search-layer-field')[0].value = '';

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -95,18 +95,7 @@ const Legend = function Legend(options = {}) {
 
       const styleName = theButton.data.activeLayer[0].get('styleName') || 'default';
       const icon = viewer.getStyle(styleName) ? imageSource(viewer.getStyle(styleName)) : 'img/png/farg.png';
-      theButton.setIcon(icon, theButton.data.activeLayer[0].get('title'));
-      const element = document.getElementById(theButton.getId());
-
-      if (theButton.data.isEven) {
-        element.classList.remove('cycle-even');
-        element.classList.add('cycle-odd');
-        theButton.data.isEven = false;
-      } else {
-        element.classList.add('cycle-even');
-        element.classList.remove('cycle-odd');
-        theButton.data.isEven = true;
-      }
+      theButton.setIcon(icon, `Växla: ${theButton.data.activeLayer[0].get('title')}`);
     };
     Object.values(cycleGroups).forEach((cycleGroup) => {
       let activeLayer = cycleGroup.find((layer) => layer.get('visible') === true);
@@ -118,14 +107,13 @@ const Legend = function Legend(options = {}) {
       const title = activeLayer[0].get('title');
       const cycleButton = Button({
         icon,
-        title,
-        cls: 'round smallest border icon-small icon-bg cycle-even',
+        title: `Växla: ${title}`,
+        cls: 'round smallest border icon-small icon-bg cycle',
         state: activeLayer[0].get('visible') ? 'active' : 'initial',
         data: {
           layers: cycleGroup,
           activeLayer,
-          numberOfLayers: cycleGroup.length,
-          isEven: true
+          numberOfLayers: cycleGroup.length
         },
         methods: {
           active: () => {

--- a/src/ui/button.js
+++ b/src/ui/button.js
@@ -137,9 +137,9 @@ export default function Button(options = {}) {
                 ${getTooltip()}
               </button>`;
     },
-    setIcon(newIcon) {
+    setIcon(newIcon, newTitle) {
       if (iconComponent) {
-        iconComponent.setIcon(newIcon);
+        iconComponent.setIcon(newIcon, newTitle);
       }
     },
     setState

--- a/src/ui/icon.js
+++ b/src/ui/icon.js
@@ -4,11 +4,11 @@ import { createStyle, html } from './dom/dom';
 
 export default function Icon(options = {}) {
   let {
-    icon
+    icon,
+    title = ''
   } = options;
   const {
     cls = '',
-    title = '',
     style: styleOptions
   } = options;
 
@@ -19,7 +19,7 @@ export default function Icon(options = {}) {
     render() {
       if (iconType === 'image') {
         return `
-          <img class="${cls}" style="${style}" src=${icon} title="${title}" alt="${title}">
+          <img id="${this.getId()}" class="${cls}" style="${style}" src=${icon} title="${title}" alt="${title}">
         `;
       }
       if (iconType === 'sprite') {
@@ -47,9 +47,10 @@ export default function Icon(options = {}) {
         el.parentNode.replaceChild(newEl, el);
       }
     },
-    setIcon(newIcon) {
+    setIcon(newIcon, newTitle) {
       iconType = typeOfIcon(newIcon);
       icon = newIcon;
+      if (newTitle) title = newTitle;
       this.update();
     }
   });


### PR DESCRIPTION
Suggestion to fix #1379 

Background layers can have a `cycleGroup` prop. Those of the same `cycleGroup` value are part of one cycleButton (where the normal kind is a backgroundButton). 

The cycleButtons are delineated via a greyish background color. Clicking them once turns on the currently shown (icon, tooltip) layer for that button, clicking on an already active (grey border) cycleButton does not bring up the details pane, it cycles the button to the next layer in the cycleGroup.

It is in no shape or form a perfect solution since the "Örebro" solution is inherently somewhat limited. Local feedback has shown a preference for an unspecified form that appears when a background layer icon is clicked, that would be a kind of visual selector. There isn't anything like that that I know of currently in Origo, I guess the Legend layout could be rearranged.

But the current solution is like the Örebro button and it does, at least temporarily, solve a problem we were having with too many background maps (put two similar ones behind one cycleButton).

![cycleButton](https://github.com/origo-map/origo/assets/5138906/2bf28cb2-7f3e-43fe-a54e-bdf227bd9fb8)
