### PR TITLE
Make it possible to have more backgroud layers

### DIFF
--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -711,7 +711,7 @@ const Legend = function Legend(options = {}) {
         components: mainContainerComponents,
         style: {
           'max-height': `${maxHeight}px`,
-          'width': 'min-content'
+          width: 'min-content'
         }
       });
 

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -698,7 +698,7 @@ const Legend = function Legend(options = {}) {
         cls: 'flex padding-small no-shrink',
         style: {
           'background-color': '#fff',
-          height: '50px',
+          'max-width: '300px',
           'border-top': '1px solid #dbdbdb',
           'border-radius': '0.5rem'
         },

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -707,7 +707,7 @@ const Legend = function Legend(options = {}) {
       const mainContainerComponents = [overlaysCmp, visibleOverlaysCmp, toolsCmp, baselayersCmp];
 
       mainContainerCmp = El({
-        cls: 'flex column relative width-100',
+        cls: 'flex column relative',
         components: mainContainerComponents,
         style: {
           'max-height': `${maxHeight}px`,

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -195,7 +195,8 @@ const Legend = function Legend(options = {}) {
       viewer.dispatch('active:togglevisibleLayers');
     },
     style: {
-      'align-self': 'right',
+      'vertical-align': 'bottom',
+      'margin-bottom': '4px',
       'padding-right': '6px'
     },
     icon: '#ic_close_fullscreen_24px',

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -698,7 +698,7 @@ const Legend = function Legend(options = {}) {
         cls: 'flex padding-small no-shrink',
         style: {
           'background-color': '#fff',
-          'max-width: '300px',
+          'max-width': '300px',
           'border-top': '1px solid #dbdbdb',
           'border-radius': '0.5rem'
         },

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -698,7 +698,6 @@ const Legend = function Legend(options = {}) {
         cls: 'flex padding-small no-shrink',
         style: {
           'background-color': '#fff',
-          'max-width': '300px',
           'border-top': '1px solid #dbdbdb',
           'border-radius': '0.5rem'
         },
@@ -711,7 +710,8 @@ const Legend = function Legend(options = {}) {
         cls: 'flex column relative width-100',
         components: mainContainerComponents,
         style: {
-          'max-height': `${maxHeight}px`
+          'max-height': `${maxHeight}px`,
+          'width': 'min-content'
         }
       });
 

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -689,6 +689,9 @@ const Legend = function Legend(options = {}) {
 
       const legendControlCmp = El({
         cls: 'grow flex justify-end align-center no-shrink',
+        style: {
+          'display': 'inline'
+        },
         components: legendControlCmps
       });
 

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -690,7 +690,7 @@ const Legend = function Legend(options = {}) {
       const legendControlCmp = El({
         cls: 'grow flex justify-end align-center no-shrink',
         style: {
-          'display': 'inline'
+          display: 'inline'
         },
         components: legendControlCmps
       });

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -212,7 +212,8 @@ const Legend = function Legend(options = {}) {
       viewer.dispatch('active:togglevisibleLayers');
     },
     style: {
-      'align-self': 'right',
+      'vertical-align': 'bottom',
+      'margin-bottom': '7px',
       'padding-right': '6px'
     },
     icon: '#ic_open_in_full_24px',
@@ -693,9 +694,11 @@ const Legend = function Legend(options = {}) {
       legendControlCmps.push(closeButton);
 
       const legendControlCmp = El({
-        cls: 'grow flex justify-end align-center no-shrink',
+        cls: 'grow flex no-shrink',
         style: {
-          display: 'inline'
+          display: 'inline',
+          'text-align': 'right',
+          'margin-right': '6px'
         },
         components: legendControlCmps
       });

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -666,7 +666,7 @@ const Legend = function Legend(options = {}) {
         style: {
           'vertical-align': 'bottom',
           'margin-bottom': '4px'
-        }
+        },
         icon: '#ic_close_24px',
         state: closeButtonState,
         validStates: ['initial', 'hidden'],

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -196,7 +196,7 @@ const Legend = function Legend(options = {}) {
     },
     style: {
       'vertical-align': 'bottom',
-      'margin-bottom': '4px',
+      'margin-bottom': '7px',
       'padding-right': '6px'
     },
     icon: '#ic_close_fullscreen_24px',

--- a/src/controls/legend.js
+++ b/src/controls/legend.js
@@ -662,6 +662,10 @@ const Legend = function Legend(options = {}) {
       const closeButtonState = isExpanded ? 'initial' : 'hidden';
       closeButton = Button({
         cls: 'icon-smaller small round grey-lightest',
+        style: {
+          'vertical-align': 'bottom',
+          'margin-bottom': '4px'
+        }
         icon: '#ic_close_24px',
         state: closeButtonState,
         validStates: ['initial', 'hidden'],


### PR DESCRIPTION
Makes the background layer buttons wrap. https://github.com/origo-map/origo/issues/1981
![bild](https://github.com/origo-map/origo/assets/5260503/756bb886-e8fc-42f1-a689-1d84b4f74355)
