### PR TITLE
feature: queryParams for wfssource

### DIFF
--- a/src/layer/wfssource.js
+++ b/src/layer/wfssource.js
@@ -100,6 +100,7 @@ class WfsSource extends VectorSource {
    */
   async _loaderHelper(extent, cql, ignoreOriginalFilter, ids) {
     const serverUrl = this._options.url;
+    const queryParams = this._options.queryParams || {};
 
     // Set up the cql filter as a combination of the layer filter and the temporary cql parameter
     let cqlfilter = '';
@@ -142,6 +143,11 @@ class WfsSource extends VectorSource {
     if (ids || ids === 0) {
       url += `&FeatureId=${ids}`;
     }
+
+    Object.keys(queryParams).forEach(key => {
+      url += `&${key}=${queryParams[key]}`;
+    });
+
     url = encodeURI(url);
 
     // Actually fetch some features


### PR DESCRIPTION
Fixes #1932
Makes it possible to set a query parameters as a source option or with the api like: 
`source.getOptions().queryParams={viewParams: 'scenario1'};`
Useful for instance when [[Parameterizing SQL Views](https://docs.geoserver.org/2.23.x/en/user/data/database/sqlview.html#parameterizing-sql-views)]
Yeah the url concatenation ain't beautiful but will do until someone wants to give it some tlc.