### PR TITLE
Fix missing typenames for QGIS Server sources

### DIFF
--- a/src/layer/wfssource.js
+++ b/src/layer/wfssource.js
@@ -204,8 +204,8 @@ class WfsSource extends VectorSource {
     if (ids || ids === 0) {
       switch (this._options.filterType) {
         case 'qgis': {
-          const idArray = ids.toString().split(','); // Split to array
-          idArray.map(id => {
+          let idArray = ids.toString().split(','); // Split to array
+          idArray = idArray.map(id => {
             // Prepend the layername using id if needed (in case the name is using double underscore notation)
             if (!id.toString().startsWith(`${this._options.featureType}.`)) {
               return `${this._options.featureType}.${id}`;


### PR DESCRIPTION
Fixes #1997.

Corrects a mistake that caused typenames to not be prepended when fetching features from a QGIS Server source using IDs.