### PR TITLE
fix: make getfeatureinfo requests not fail together

### DIFF
--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -326,14 +326,16 @@ async function getFeaturesFromRemote(requestOptions, viewer, textHtmlHandler) {
   const featureInfoPromisesResults = await Promise.allSettled(featureInfoPromises);
 
   featureInfoPromisesResults.forEach((result, i) => {
+    const layer = viewer.getLayer(requests[i].layer);
     if (result.status === 'fulfilled' && result.value) {
-      const layer = viewer.getLayer(requests[i].layer);
       const groupLayers = viewer.getGroupLayers();
       const map = viewer.getMap();
       result.value.forEach((feature) => {
         const si = createSelectedItem(feature, layer, map, groupLayers);
         requestResult.push(si);
       });
+    } else {
+      console.warn(`GetFeatureInfo request failed for layer: ${layer.get('name')}`);
     }
   });
 


### PR DESCRIPTION
Seeks to fix #2001  , in the alternative fashion.
Yes, I made `getFeatureInfoUrl` less robust in a recent pr and I could still remedy that function. The only place it is being used though is in the function I am proposing to change, from `Promise.all` to `Promise.allSettled`. So if `getFeatureInfoUrl` trips for any reason, like assuming everything is json when something isn't, that featureInfo call is discarded rather than allowed to render all concurrent featureInfo calls useless.

(The function in the PR is also somewhat rewritten for readability. I did not find it an easy read before)