### PR TITLE
fix: Left toolbar scrollable

### DIFF
--- a/scss/_viewer.scss
+++ b/scss/_viewer.scss
@@ -4,6 +4,9 @@
   flex-flow: column;
   left: 0;
   top: 0;
+}
+
+#o-tools-left {
   width: 100%;
   scrollbar-width: none;
   overflow: auto;

--- a/scss/_viewer.scss
+++ b/scss/_viewer.scss
@@ -2,11 +2,11 @@
   display: block;
   display: flex;
   flex-flow: column;
-}
-
-.o-tools-left {
   left: 0;
   top: 0;
+  width: 100%;
+  scrollbar-width: none;
+  overflow: auto;
 }
 
 .o-toolbar-maptools {


### PR DESCRIPTION
Fixes #2021 
Makes left toolbar scrollable if too long for browser window