### PR TITLE
Always show infowindow

### DIFF
--- a/src/selectionmanager.js
+++ b/src/selectionmanager.js
@@ -32,7 +32,6 @@ const Selectionmanager = function Selectionmanager(options = {}) {
   let highlightedFeatures = [];
 
   const multiselectStyleOptions = options.multiSelectionStyles || styleTypes.getStyle('multiselection');
-  const isInfowindow = options.infowindow === 'infowindow' || false;
   const infowindowManager = options.infowindowOptions && options.infowindowOptions.listLayout ? infowindowManagerV2 : infowindowManagerV1;
 
   function alreadyExists(item) {
@@ -295,11 +294,7 @@ const Selectionmanager = function Selectionmanager(options = {}) {
 
     urval.get(selectionGroup).addFeature(item.getFeature());
     infowindow.createListElement(item);
-
-    if (isInfowindow) {
-      infowindow.show();
-    }
-
+    infowindow.show();
     const sum = urval.get(selectionGroup).getFeatures().length;
     infowindow.updateUrvalElementText(selectionGroup, selectionGroupTitle, sum);
     const aggregationstring = calculateGroupAggregations(selectionGroup);


### PR DESCRIPTION
Fixes #2026 by making SelectionManager to display the selection in InfoWindow even if the "infoWindow"-setting is `overlay` or `sidebar`.

This will result in api-calls to SelectionManager always showing the result in infoWindow while featureInfo will obey the infoWindow-setting. It may seem a bit confusing but the old behavior was to only display the selection in the map and not show any infoWindow at all during the same circumstances.

This will only affect calls directly to SelectionManager using the api, e.g. from the MultiSelect-plugin. 