### PR TITLE
fix: expose layertype

### DIFF
--- a/origo.js
+++ b/origo.js
@@ -29,6 +29,7 @@ import 'drag-drop-touch';
 import permalink from './src/permalink/permalink';
 import * as Loader from './src/loading';
 import Spinner from './src/utils/spinner';
+import layerType from './src/layer/layertype';
 
 const Origo = function Origo(configPath, options = {}) {
   /** Reference to the returned Component */
@@ -172,5 +173,6 @@ Origo.Loader.show = Loader.showLoading;
 Origo.Loader.hide = Loader.hideLoading;
 Origo.Loader.withLoading = Loader.withLoading;
 Origo.Loader.getInlineSpinner = Spinner;
+Origo.layerType = layerType;
 
 export default Origo;


### PR DESCRIPTION
Found out that this will work with plugins that has a layer type which is missing in Origo and want to add it.
The key is that the layer type should be added before starting Origo.

Closes #2031 