### PR TITLE
feature: add another member to mask and cities

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Not convinced? Or maybe you need some inspiration? Check out these examples of w
  * [Hallstakartan](http://karta.hallstahammar.se)
  * [Haninge kommun webbkarta](https://karta.haninge.se/)
  * [Karlstadskartan](http://gi.karlstad.se)
+ * [Malmö](https://stadsatlas.malmo.se/stadsatlas/)
  * [Mälardalskartan](http://www.malardalskartan.se)
  * [Sigtunakartan](https://karta.sigtuna.se)
  * [Strängnäskartan](https://kartor.strangnas.se)

--- a/data/origo-cities-3857.geojson
+++ b/data/origo-cities-3857.geojson
@@ -24,6 +24,7 @@
 { "type": "Feature", "properties": { "id": 20, "name": "Kristianstad" }, "geometry": { "type": "Point", "coordinates": [ 1575633.0, 7565358.0 ] } },
 { "type": "Feature", "properties": { "id": 21, "name": "Mora" }, "geometry": { "type": "Point", "coordinates": [ 1618908.0, 8627715.0 ] } },
 { "type": "Feature", "properties": { "id": 22, "name": "Orsa" }, "geometry": { "type": "Point", "coordinates": [ 1627705.0, 8653421.0 ] } },
-{ "type": "Feature", "properties": { "id": 23, "name": "Tomelilla" }, "geometry": { "type": "Point", "coordinates": [ 1553290.0, 7467849.0 ] } }
+{ "type": "Feature", "properties": { "id": 23, "name": "Tomelilla" }, "geometry": { "type": "Point", "coordinates": [ 1553290.0, 7467849.0 ] } },
+{ "type": "Feature", "properties": { "id": 24, "name": "Malmö" }, "geometry": { "type": "Point", "coordinates": [ 1447133.0, 7480181.0 ] } }
 ]
 }


### PR DESCRIPTION
I know that pull request #1966 also adjusted the transparency mask in order to properly highlight the relevant city. I can't figure out how one knows what coordinates to add for the mask. Maybe someone can help out with that? :)