### PR TITLE
feature: Store getCapabilites document for source

### DIFF
--- a/src/getCapabilities.js
+++ b/src/getCapabilities.js
@@ -21,7 +21,8 @@ const getCapabilities = function getCapabilities(name, getCapabilitiesURL) {
       if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
         resolve({
           name,
-          capabilites: responseParser(xmlHttp.responseText)
+          capabilites: responseParser(xmlHttp.responseText),
+          capabilitesDoc: xmlHttp.responseText
         });
       }
     };

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -83,7 +83,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
       const layers = {};
       capabilitiesResults.forEach(result => {
         layers[result.name] = result.capabilites;
-        if(source[result.name].saveCapabilitiesDoc !== false){
+        if(source[result.name]?.saveCapabilitiesDoc !== false){
           source[result.name].capabilitiesDoc = result.capabilitesDoc;
         }
       });

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -83,6 +83,9 @@ const Viewer = function Viewer(targetOption, options = {}) {
       const layers = {};
       capabilitiesResults.forEach(result => {
         layers[result.name] = result.capabilites;
+        if(source[result.name].saveCapabilitiesDoc !== false){
+          source[result.name].capabilitiesDoc = result.capabilitesDoc;
+        }
       });
       return layers;
     }).catch(error => console.log(error));

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -83,7 +83,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
       const layers = {};
       capabilitiesResults.forEach(result => {
         layers[result.name] = result.capabilites;
-        if(source[result.name]?.saveCapabilitiesDoc !== false){
+        if (source[result.name]?.saveCapabilitiesDoc !== false) {
           source[result.name].capabilitiesDoc = result.capabilitesDoc;
         }
       });


### PR DESCRIPTION
Fixes #1588

When capabilitiesURL for a source is set, the getCap doc will be saved unless opted out ( `"saveCapabilitiesDoc": false` ). 

Configured like:

```
 	"source": {
		"local": {
			"url": "http://localhost:8080/geoserver/ows",
			"capabilitiesURL": "http://localhost:8080/geoserver/ows?service=wms&version=1.1.1&request=GetCapabilities",
			"saveCapabilitiesDoc": false
		}
	},
```

and accessible with `origo.api().getMapSource()['local'].capabilitiesDoc`