### PR TITLE
fix: Test other infoFormat when getFeatureInfo fails

### DIFF
--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -143,8 +143,8 @@ async function getFeatureInfoUrl({
   }
 
   if (layer.get('infoFormat') === 'application/geo+json' || layer.get('infoFormat') === 'application/geojson') {
-    const format = layer.get('infoFormat');
-    const formatArr = [...new Set([format, 'application/geo+json', 'application/geojson', 'application/json'])];
+    const infoFormat = layer.get('infoFormat');
+    const formatArr = [...new Set([infoFormat, 'application/geo+json', 'application/geojson', 'application/json'])];
     let text;
     for (let i = 0; i < formatArr.length; i += 1) {
       const format = formatArr[i];
@@ -154,7 +154,7 @@ async function getFeatureInfoUrl({
       });
       // eslint-disable-next-line no-await-in-loop
       const result = await fetch(url, { method: 'GET' }).then((res) => res.text())
-      .catch(error => console.error(error));
+        .catch(error => console.error(error));
       if (isValidJSON(result)) {
         text = result;
         layer.set('infoFormat', format);

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -146,15 +146,18 @@ async function getFeatureInfoUrl({
     const format = layer.get('infoFormat');
     const formatArr = [...new Set([format, 'application/geo+json', 'application/geojson', 'application/json'])];
     let text;
-    for (const f of formatArr) {
+    for (let i = 0; i < formatArr.length; i += 1) {
+      const format = formatArr[i];
       const url = layer.getSource().getFeatureInfoUrl(coordinate, resolution, projection, {
-        INFO_FORMAT: f,
+        INFO_FORMAT: format,
         FEATURE_COUNT: '20'
       });
-      const res = await fetch(url, { method: 'GET' });
-      text = await res.text();
-      if (isValidJSON(text)) {
-        layer.set('infoFormat', f);
+      // eslint-disable-next-line no-await-in-loop
+      const result = await fetch(url, { method: 'GET' }).then((res) => res.text())
+      .catch(error => console.error(error));
+      if (isValidJSON(result)) {
+        text = result;
+        layer.set('infoFormat', format);
         break;
       }
     }

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -5,6 +5,15 @@ import infoTemplates from './featureinfotemplates';
 import maputils from './maputils';
 import SelectedItem from './models/SelectedItem';
 
+const isValidJSON = str => {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+    
 /**
  * Factory method to create a SelectedItem instance. Note that this method is exposed in api.
  * Does not add async content (related tables and attachments). If you need async content use
@@ -134,12 +143,21 @@ async function getFeatureInfoUrl({
   }
 
   if (layer.get('infoFormat') === 'application/geo+json' || layer.get('infoFormat') === 'application/geojson') {
-    const url = layer.getSource().getFeatureInfoUrl(coordinate, resolution, projection, {
-      INFO_FORMAT: layer.get('infoFormat'),
-      FEATURE_COUNT: '20'
-    });
-    const res = await fetch(url, { method: 'GET' });
-    const text = await res.text();
+    let format = layer.get('infoFormat');
+    let formatArr = [...new Set([format, 'application/geo+json', 'application/geojson', 'application/json'])];
+    let text;
+    for (const f of formatArr) {
+      const url = layer.getSource().getFeatureInfoUrl(coordinate, resolution, projection, {
+        INFO_FORMAT: f,
+        FEATURE_COUNT: '20'
+      });
+      const res = await fetch(url, { method: 'GET' });
+      text = await res.text();
+      if(isValidJSON(text)){
+        layer.set('infoFormat', f);
+        break;
+      }
+    };
     let json = {};
     try {
       json = JSON.parse(text);

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -13,7 +13,7 @@ const isValidJSON = str => {
     return false;
   }
 };
-    
+
 /**
  * Factory method to create a SelectedItem instance. Note that this method is exposed in api.
  * Does not add async content (related tables and attachments). If you need async content use
@@ -143,8 +143,8 @@ async function getFeatureInfoUrl({
   }
 
   if (layer.get('infoFormat') === 'application/geo+json' || layer.get('infoFormat') === 'application/geojson') {
-    let format = layer.get('infoFormat');
-    let formatArr = [...new Set([format, 'application/geo+json', 'application/geojson', 'application/json'])];
+    const format = layer.get('infoFormat');
+    const formatArr = [...new Set([format, 'application/geo+json', 'application/geojson', 'application/json'])];
     let text;
     for (const f of formatArr) {
       const url = layer.getSource().getFeatureInfoUrl(coordinate, resolution, projection, {
@@ -153,11 +153,11 @@ async function getFeatureInfoUrl({
       });
       const res = await fetch(url, { method: 'GET' });
       text = await res.text();
-      if(isValidJSON(text)){
+      if (isValidJSON(text)) {
         layer.set('infoFormat', f);
         break;
       }
-    };
+    }
     let json = {};
     try {
       json = JSON.parse(text);


### PR DESCRIPTION
Fixes #2108 Try different infoFormats if getFeatureInfo request fails with the configured infoFormat (application/geojson or application/geo+json)