### PR TITLE
Feature: Make subgroups draggable

### DIFF
--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -205,24 +205,19 @@ const Group = function Group(viewer, options = {}) {
       const overlayArray = grpCmp.getOverlayList().getOverlays();
       const groupArray = grpCmp.getOverlayList().getGroups();
       elementIds.forEach(element => {
-        // eslint-disable-next-line no-use-before-define
-        doCheck(element, overlayArray, groupArray);
-      });
-    }
-
-    function doCheck(element, overlays, groups) {
-      const foundLayer = overlays.find((overlay) => element === overlay.getId());
-      if (foundLayer) {
-        layerArr.push(foundLayer);
-      } else {
-        const foundGroup = groups.find((group) => element === group.getId());
-        if (foundGroup) {
-          const listEl = document.getElementById(foundGroup.getId())?.getElementsByTagName('ul')[0];
-          if (listEl) {
-            recList(listEl, foundGroup);
+        let foundLayer = overlayArray.find((overlay) => element === overlay.getId());
+          if (foundLayer) {
+            layerArr.push(foundLayer)
+          } else {
+            let foundGroup = groupArray.find((group) => element === group.getId());
+            if (foundGroup) {
+              const listEl = document.getElementById(foundGroup.getId())?.getElementsByTagName('ul')[0];
+              if (listEl) {
+                recList(listEl, foundGroup);
+              }
+            }
           }
-        }
-      }
+      });
     }
 
     recList(list, groupCmp);

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -198,18 +198,18 @@ const Group = function Group(viewer, options = {}) {
   };
 
   function orderZIndex(list, groupCmp) {
-    let layerArr = [];
+    const layerArr = [];
 
     function recList(listEl, grpCmp) {
       const elementIds = [...listEl.children].map(x => x.id).reverse();
       const overlayArray = grpCmp.getOverlayList().getOverlays();
       const groupArray = grpCmp.getOverlayList().getGroups();
       elementIds.forEach(element => {
+        // eslint-disable-next-line no-use-before-define
         doCheck(element, overlayArray, groupArray);
       });
     }
 
-    // eslint-disable-next-line no-use-before-define
     function doCheck(element, overlays, groups) {
       const foundLayer = overlays.find((overlay) => element === overlay.getId());
       if (foundLayer) {
@@ -225,14 +225,12 @@ const Group = function Group(viewer, options = {}) {
       }
     }
 
-
     recList(list, groupCmp);
 
     layerArr.forEach((element, idx) => {
       const layerIndex = idx;
       element.getLayer().setZIndex(zIndexStart + (layerIndex / 100));
     });
-
   }
 
   function handleDragStart(evt) {

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -38,10 +38,10 @@ const Group = function Group(viewer, options = {}) {
   };
   const checkIcon = '#ic_check_circle_24px';
   const uncheckIcon = '#ic_radio_button_unchecked_24px';
+  const draggableGroups = [];
   let visibleState = 'all';
   let groupEl;
   let selectedItem;
-  let draggableGroups = [];
 
   const listCls = type === 'grouplayer' ? 'divider-start padding-left padding-top-small' : '';
   const groupList = GroupList({ viewer, cls: listCls, abstract, showAbstractInLegend });
@@ -198,7 +198,8 @@ const Group = function Group(viewer, options = {}) {
   };
 
   function orderZIndex(list, groupCmp) {
-    
+    let layerArr = [];
+
     function recList(listEl, grpCmp) {
       const elementIds = [...listEl.children].map(x => x.id).reverse();
       const overlayArray = grpCmp.getOverlayList().getOverlays();
@@ -207,13 +208,14 @@ const Group = function Group(viewer, options = {}) {
         doCheck(element, overlayArray, groupArray);
       });
     }
-    
-    function doCheck(element, overlays, groups){
-      let foundLayer = overlays.find((overlay) => element === overlay.getId());
+
+    // eslint-disable-next-line no-use-before-define
+    function doCheck(element, overlays, groups) {
+      const foundLayer = overlays.find((overlay) => element === overlay.getId());
       if (foundLayer) {
-        layerArr.push(foundLayer)
+        layerArr.push(foundLayer);
       } else {
-        let foundGroup = groups.find((group) => element === group.getId());
+        const foundGroup = groups.find((group) => element === group.getId());
         if (foundGroup) {
           const listEl = document.getElementById(foundGroup.getId())?.getElementsByTagName('ul')[0];
           if (listEl) {
@@ -223,7 +225,6 @@ const Group = function Group(viewer, options = {}) {
       }
     }
 
-    let layerArr = [];
 
     recList(list, groupCmp);
 
@@ -231,7 +232,7 @@ const Group = function Group(viewer, options = {}) {
       const layerIndex = idx;
       element.getLayer().setZIndex(zIndexStart + (layerIndex / 100));
     });
-    
+
   }
 
   function handleDragStart(evt) {

--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -205,18 +205,18 @@ const Group = function Group(viewer, options = {}) {
       const overlayArray = grpCmp.getOverlayList().getOverlays();
       const groupArray = grpCmp.getOverlayList().getGroups();
       elementIds.forEach(element => {
-        let foundLayer = overlayArray.find((overlay) => element === overlay.getId());
-          if (foundLayer) {
-            layerArr.push(foundLayer)
-          } else {
-            let foundGroup = groupArray.find((group) => element === group.getId());
-            if (foundGroup) {
-              const listEl = document.getElementById(foundGroup.getId())?.getElementsByTagName('ul')[0];
-              if (listEl) {
-                recList(listEl, foundGroup);
-              }
+        const foundLayer = overlayArray.find((overlay) => element === overlay.getId());
+        if (foundLayer) {
+          layerArr.push(foundLayer);
+        } else {
+          const foundGroup = groupArray.find((group) => element === group.getId());
+          if (foundGroup) {
+            const ulList = document.getElementById(foundGroup.getId())?.getElementsByTagName('ul')[0];
+            if (ulList) {
+              recList(ulList, foundGroup);
             }
           }
+        }
       });
     }
 


### PR DESCRIPTION
Fixes #2113 
Subgroups in a group with `draggable: true` can be moved just like other layers.