### PR TITLE
Fix print composite layer legend

### DIFF
--- a/src/controls/print/print-legend.js
+++ b/src/controls/print/print-legend.js
@@ -50,6 +50,15 @@ const LayerRow = function LayerRow(options) {
   };
 
   /**
+   * Helper that creates a WMS getLegendGraphics request url string
+   * @param {any} url base url
+   * @param {any} layerName name of layer to create legend for
+   * @param {any} format valid mime type
+   * @returns {string} A WMS getLegendGraphics request url string
+   */
+  const createGetlegendGrapicUrl = (url, layerName, format) => `${url}?SERVICE=WMS&layer=${layerName}&format=${format}&version=1.1.1&request=getLegendGraphic&scale=401&legend_options=dpi:300`;
+
+  /**
    * Returns the URL to the WMS legend in the specified format
    *
    * @param {Layer} aLayer
@@ -66,7 +75,7 @@ const LayerRow = function LayerRow(options) {
       }
       return `${style[0][0].icon.src}?format=${format}`;
     }
-    return `${url}?SERVICE=WMS&layer=${layerName}&format=${format}&version=1.1.1&request=getLegendGraphic&scale=401&legend_options=dpi:300`;
+    return createGetlegendGrapicUrl(url, layerName, format);
   };
 
   /**
@@ -209,14 +218,46 @@ const LayerRow = function LayerRow(options) {
     }
 
     const thematicStyle = (layer.get('thematicStyling') === true) ? viewer.getStyle(layer.get('styleName')) : undefined;
-    const rules = json.Legend[0].rules.reduce((okRules, rule, index) => {
-      if (!(layer.get('thematicStyling')) || thematicStyle[0]?.thematic[index]?.visible) {
-        const ruleImageUrl = `${getLegendGraphicUrl}&rule=${rule.name}`;
-        const rowTitle = rule.title ? rule.title : index + 1;
-        okRules.push(getListItem(rowTitle, ruleImageUrl, true));
-      }
-      return okRules;
-    }, []);
+    const rules = [];
+    let index = 0;
+    const layerName = layer.get('id');
+    const isLayerGroup = json.Legend.length > 1;
+    // Loop all layers in json response. Usually there is only one, but Layer Groups have several.
+    json.Legend.forEach(currLayer => {
+      let currLayerName = currLayer.layerName;
+      currLayer.rules.forEach(currRule => {
+        if (!(layer.get('thematicStyling')) || thematicStyle[0]?.thematic[index]?.visible) {
+          let layerImageUrl;
+          if (isLayerGroup) {
+            // This is layer group and the contained layer is most likely not known to us,
+            // so we can't treat is as an Origo layer.
+            // Generate a request and hope that the server has a layer by that name.
+            const baseUrl = getOneUrl(layer);
+            const layerWs = layerName.split(':');
+            if (layerWs.length > 1) {
+              currLayerName = `${layerWs[0]}:${currLayer.layerName}`;
+            }
+            // This is a little bit shaky, if Layer Group name constains workspace, contained layers must come from
+            // the same workspace, but if layer group is a top level layer group (no workspace), contained layers can
+            // come from any workspace but the json response NEVER contains info about workspace.
+            // So for Layer Groups with a workspace prefix we can assume that the actual layers should have the same workspace prefix,
+            // but for top level Layer Groups we have absolutely no idea which workspace the layer is in.
+            // But not all is lost as Geoserver tries its best to get the legend for any workspace with that layer name.
+            // Problem is when the same layer name appears in several workspaces. In that case you get from what is configured as default.
+            // One more tricky thing is that layer groups can configure different symbols than the actual layer.
+            // Querying the layer Group for png will return the group layer style, but the getLegendGrapich for each layer
+            // will return the symbol for the actual layer, so legend and print legend will differ.
+            layerImageUrl = createGetlegendGrapicUrl(baseUrl, currLayerName, 'image/png');
+          } else {
+            layerImageUrl = getLegendGraphicUrl;
+          }
+          const ruleImageUrl = `${layerImageUrl}&rule=${currRule.name}`;
+          const rowTitle = currRule.title ? currRule.title : index + 1;
+          rules.push(getListItem(rowTitle, ruleImageUrl, true));
+        }
+        index += 1;
+      });
+    });
 
     return getTitleWithChildren(title, rules);
   };

--- a/src/controls/print/print-legend.js
+++ b/src/controls/print/print-legend.js
@@ -212,7 +212,8 @@ const LayerRow = function LayerRow(options) {
           <img src="${getLegendGraphicUrl}" alt="${title}" />
         </div>`;
     }
-    if (json.Legend[0].rules.length <= 1) {
+    // Handle the simple one first. One layer, one rule
+    if (json.Legend.length === 1 && json.Legend[0].rules.length <= 1) {
       const icon = `<img class="cover" src="${getLegendGraphicUrl}"  alt="${title}"/>`;
       return getTitleWithIcon(title, icon);
     }
@@ -251,7 +252,13 @@ const LayerRow = function LayerRow(options) {
           } else {
             layerImageUrl = getLegendGraphicUrl;
           }
-          const ruleImageUrl = `${layerImageUrl}&rule=${currRule.name}`;
+          let ruleImageUrl = `${layerImageUrl}`;
+          // Add specific rule if necessary. If there is only one rule there is no need (in fact it will probably break as most
+          // styles using only one rule will not have a named rule). This is to handle Layer Groups without rules in some of the contained
+          // layer's style
+          if (currLayer.rules.length > 1) {
+            ruleImageUrl += `&rule=${currRule.name}`;
+          }
           const rowTitle = currRule.title ? currRule.title : index + 1;
           rules.push(getListItem(rowTitle, ruleImageUrl, true));
         }


### PR DESCRIPTION
Fixes #2092 by generating valid legend graphics for Geoserver _Layer Groups._

Should generate all rules for all layers in a _Layer Group_ in print legend.

There are some limitations:
1. If a style has several rules, the rules must be named (same as with ordinary WMS layers)
2. A Group Layer must use the default style for each contained layer, i.e. not define another style when used inside the Group Layer, otherwise the map legend and print legend will display different symbols.
3. A top level (without workspace) Group Layer can only contain layers with unique names through all workspaces.

These limitations are all a result of missing information in the response from the  getLegendGraphic as JSON request. To overcome that a bunch of Geoserver api request would have to be performed, but that seemed a bit overmuch.

Also `thematicStyling` is not supported as it not supported by the map legend and would require an issue of its own.

No new configuration is added.