### PR TITLE
Edit split line tool

### DIFF
--- a/src/controls/editor.js
+++ b/src/controls/editor.js
@@ -172,6 +172,11 @@ const Editor = function Editor(options = {}) {
     createFeature,
     editFeatureAttributes,
     deleteFeature,
+    // TODO: Ta bort, skall ej exponeras, bara anropas från menyn.
+    clip: () => {
+      editHandler.setModifyTool('split-line-by-point');
+    },
+
     changeActiveLayer: (layerName) => {
       // Only need to actually change layer if editor is active. Otherwise state is just set in toolbar and will
       // activate set layer when toggled visible

--- a/src/controls/editor.js
+++ b/src/controls/editor.js
@@ -1,5 +1,5 @@
 import { Component, Button, dom } from '../ui';
-import editorToolbar from './editor/editortoolbar';
+import EditorToolbar from './editor/editortoolbar';
 import EditHandler from './editor/edithandler';
 
 const Editor = function Editor(options = {}) {
@@ -13,6 +13,7 @@ const Editor = function Editor(options = {}) {
   let target;
   let viewer;
   let isVisible = isActive;
+  let editorToolbar;
   let toolbarVisible = false;
   /** Keeps track of the last selected item in featureinfo. We need to use our own variable for this
    * in order to determine if editor got activated directly from featureinfo or some other tool has been active between. */
@@ -77,7 +78,9 @@ const Editor = function Editor(options = {}) {
         autoSave,
         currentLayer,
         editableLayers: editableFeatureLayers,
-        isActive
+        isActive,
+        viewer,
+        modifyTools: options.modifyTools
       });
       const handlerOptions = Object.assign({}, options, {
         autoForm,
@@ -88,6 +91,15 @@ const Editor = function Editor(options = {}) {
         featureList
       });
       editHandler = EditHandler(handlerOptions, viewer);
+      // Relay selected features from handler to toolbar so toolbar can calculate which tools are available for the current situation
+      editHandler.on('select', (f) => {
+        editorToolbar.setSelection(f);
+      });
+      editorToolbar = EditorToolbar(toolbarOptions);
+      // Set active modify tool when selected in toolbar
+      editorToolbar.on('modifytoolchanged', (e) => {
+        editHandler.setModifyTool(e);
+      });
 
       // Set up eventhandler for when featureinfo selects (or highlights) a feature
       const featureInfo = viewer.getFeatureinfo();
@@ -126,9 +138,8 @@ const Editor = function Editor(options = {}) {
         }
       });
       this.addComponent(editorButton);
-      this.on('render', this.onRender);
+      this.addComponent(editorToolbar);
       this.render();
-      editorToolbar.init(toolbarOptions, viewer);
     },
     onInit() {
       const state = isActive ? 'active' : 'initial';
@@ -163,6 +174,8 @@ const Editor = function Editor(options = {}) {
       const htmlString = editorButton.render();
       const el = dom.html(htmlString);
       document.getElementById(target).appendChild(el);
+      // Toolbar injects itself to DOM, so no need to handle return value
+      editorToolbar.render();
       this.dispatch('render');
       viewer.dispatch('toggleClickInteraction', {
         name: 'editor',
@@ -172,10 +185,6 @@ const Editor = function Editor(options = {}) {
     createFeature,
     editFeatureAttributes,
     deleteFeature,
-    // TODO: Ta bort, skall ej exponeras, bara anropas från menyn.
-    clip: () => {
-      editHandler.setModifyTool('split-line-by-point');
-    },
 
     changeActiveLayer: (layerName) => {
       // Only need to actually change layer if editor is active. Otherwise state is just set in toolbar and will

--- a/src/controls/editor/editortemplate.js
+++ b/src/controls/editor/editortemplate.js
@@ -29,6 +29,14 @@ export default `<div id="o-editor-toolbar" class="o-editor-toolbar o-toolbar o-t
         <span data-tooltip="Lager" data-placement="north"></span>
       </button>
     </div>
+     <div class="o-popover-container">
+      <button id="o-editor-modifytools" class="o-button-lg o-tooltip o-disabled" style aria-label="Modifiera" type="button" name="button">
+        <svg class="o-icon-24">
+            <use xlink:href="#ic_edit_24px"></use>
+        </svg>
+        <span data-tooltip="Modifiera" data-placement="north"></span>
+      </button>
+    </div>
     <button id="o-editor-save" class="o-button-lg o-disabled o-tooltip" style aria-label="Spara" type="button" name="button">
       <svg class="o-icon-24">
           <use xlink:href="#ic_save_24px"></use>

--- a/src/controls/editor/editortoolbar.js
+++ b/src/controls/editor/editortoolbar.js
@@ -1,211 +1,290 @@
 import editortemplate from './editortemplate';
 import dispatcher from './editdispatcher';
 import editorLayers from './editorlayers';
+import { Component, Element as El } from '../../ui';
+import dropDown from '../../dropdown';
 import drawTools from './drawtools';
 
 const activeClass = 'o-control-active';
 const disableClass = 'o-disabled';
-let currentLayer;
-let editableLayers;
-let $editAttribute;
-let $editDraw;
-let $editDelete;
-let $editLayers;
-let $editSave;
-let viewer;
-let layerSelector;
-let drawToolsSelector;
-
-function render() {
-  const { body: editortemplateHTML } = new DOMParser().parseFromString(editortemplate, 'text/html');
-  document.getElementById('o-tools-bottom').appendChild(editortemplateHTML);
-  $editAttribute = document.getElementById('o-editor-attribute');
-  $editDraw = document.getElementById('o-editor-draw');
-  $editDelete = document.getElementById('o-editor-delete');
-  $editLayers = document.getElementById('o-editor-layers');
-  $editSave = document.getElementById('o-editor-save');
-}
-
-function toggleToolbar(state) {
-  if (state) {
-    const enableInteraction = new CustomEvent('enableInteraction', {
-      bubbles: true,
-      detail: {
-        interaction: 'editor'
-      }
-    });
-    document.querySelectorAll('.o-map')[0].dispatchEvent(enableInteraction);
-  } else {
-    const enableInteraction = new CustomEvent('enableInteraction', {
-      bubbles: true,
-      detail: {
-        interaction: 'featureInfo'
-      }
-    });
-    document.querySelectorAll('.o-map')[0].dispatchEvent(enableInteraction);
-  }
-}
-
-function bindUIActions() {
-  $editDraw.addEventListener('click', (e) => {
-    dispatcher.emitToggleEdit('draw');
-    $editDraw.blur();
-    e.preventDefault();
-    return false;
-  });
-  $editAttribute.addEventListener('click', (e) => {
-    dispatcher.emitToggleEdit('attribute');
-    $editAttribute.blur();
-    e.preventDefault();
-  });
-  $editDelete.addEventListener('click', (e) => {
-    dispatcher.emitToggleEdit('delete');
-    $editDelete.blur();
-    e.preventDefault();
-  });
-  $editLayers.addEventListener('click', (e) => {
-    dispatcher.emitToggleEdit('layers');
-    $editLayers.blur();
-    e.preventDefault();
-  });
-  $editSave.addEventListener('click', (e) => {
-    dispatcher.emitToggleEdit('save');
-    $editSave.blur();
-    e.preventDefault();
-  });
-}
 
 /**
+ * Creates an EditorToolbar Component. Written as a Component, but in reality there can be only one instance as it depends
+ * on hard coded element ids and DOM events.
+ * @param {any} options
+ * @returns Component
+ */
+const EditorToolbar = function EditorToolbar(options = {}) {
+  let currentLayer = options.currentLayer;
+  const editableLayers = options.editableLayers;
+  const viewer = options.viewer;
+  const modifyTools = options.modifyTools;
+
+  let $editAttribute;
+  let $editDraw;
+  let $editDelete;
+  let $editLayers;
+  let $editSave;
+  let layerSelector;
+  let drawToolsSelector;
+  let modifyToolsBtn;
+  let modifyToolsPopoverEl;
+  let component;
+  let selection;
+
+  /**
+   * Renders the toolbar. Injects itself to DOM, so no need for caller to insert it
+   * @returns nothing
+   */
+  function render() {
+    const { body: editortemplateHTML } = new DOMParser().parseFromString(editortemplate, 'text/html');
+    document.getElementById('o-tools-bottom').appendChild(editortemplateHTML);
+    $editAttribute = document.getElementById('o-editor-attribute');
+    $editDraw = document.getElementById('o-editor-draw');
+    $editDelete = document.getElementById('o-editor-delete');
+    $editLayers = document.getElementById('o-editor-layers');
+    $editSave = document.getElementById('o-editor-save');
+    // Hide layers choice button if only 1 layer in editable
+    if (editableLayers.length < 2) {
+      $editLayers.parentNode.classList.add('o-hidden');
+    }
+    // Hide save button if configured with autoSave
+    if (options.autoSave) {
+      $editSave.classList.add('o-hidden');
+    }
+    layerSelector = editorLayers(editableLayers, viewer, {
+      activeLayer: currentLayer
+    });
+    drawToolsSelector = drawTools(options.drawTools, currentLayer, viewer);
+    modifyToolsBtn = document.getElementById('o-editor-modifytools');
+    if (!modifyTools) {
+      modifyToolsBtn.classList.add('o-hidden');
+    }
+    const pop = modifyToolsBtn.parentElement;
+    const modifyToolsPopover = El({ target: pop, cls: 'o-popover' });
+    modifyToolsPopoverEl = modifyToolsPopover.render();
+  }
+
+  function toggleToolbar(state) {
+    if (state) {
+      const enableInteraction = new CustomEvent('enableInteraction', {
+        bubbles: true,
+        detail: {
+          interaction: 'editor'
+        }
+      });
+      document.querySelectorAll('.o-map')[0].dispatchEvent(enableInteraction);
+    } else {
+      const enableInteraction = new CustomEvent('enableInteraction', {
+        bubbles: true,
+        detail: {
+          interaction: 'featureInfo'
+        }
+      });
+      document.querySelectorAll('.o-map')[0].dispatchEvent(enableInteraction);
+    }
+  }
+
+  function toggleModifyToolsPopover() {
+    modifyToolsPopoverEl.classList.toggle('o-active');
+  }
+
+  /**
+   * hides the modify tools popover. Should be called when other tool is clicked to avoid having the popover lingering
+   */
+  function closeModifyToolsPopover() {
+    modifyToolsPopoverEl.classList.remove('o-active');
+  }
+
+  function bindUIActions() {
+    $editDraw.addEventListener('click', (e) => {
+      closeModifyToolsPopover();
+      dispatcher.emitToggleEdit('draw');
+      $editDraw.blur();
+      e.preventDefault();
+      return false;
+    });
+    $editAttribute.addEventListener('click', (e) => {
+      closeModifyToolsPopover();
+      dispatcher.emitToggleEdit('attribute');
+      $editAttribute.blur();
+      e.preventDefault();
+    });
+    $editDelete.addEventListener('click', (e) => {
+      closeModifyToolsPopover();
+      dispatcher.emitToggleEdit('delete');
+      $editDelete.blur();
+      e.preventDefault();
+    });
+    $editLayers.addEventListener('click', (e) => {
+      closeModifyToolsPopover();
+      dispatcher.emitToggleEdit('layers');
+      $editLayers.blur();
+      e.preventDefault();
+    });
+    $editSave.addEventListener('click', (e) => {
+      closeModifyToolsPopover();
+      dispatcher.emitToggleEdit('save');
+      $editSave.blur();
+      e.preventDefault();
+    });
+    modifyToolsBtn.addEventListener('click', (e) => {
+      if (!modifyToolsBtn.classList.contains(disableClass)) {
+        toggleModifyToolsPopover();
+        modifyToolsBtn.blur();
+      }
+      e.preventDefault();
+    });
+    // Event listener for when modify tool dropdown selects a tool
+    modifyToolsPopoverEl.addEventListener('changeDropdown', (e) => {
+      e.stopImmediatePropagation(e);
+      closeModifyToolsPopover();
+      // Dispatch the selected tool as a Component event to our listeners (edit component)
+      component.dispatch('modifytoolchanged', e.detail.dataAttribute);
+    });
+  }
+
+  /**
  * Sets visibility of the tools in the toolbar according to the current layer's configuration.
  * Note that it only sets the visibility of the the tools in the toolbar, it does not enforce anything.
  * */
-function setAllowedTools() {
-  const layer = viewer.getLayer(currentLayer);
-  const allowedOperations = layer.get('allowedEditOperations');
-  if (allowedOperations && !allowedOperations.includes('updateAttributes')) {
-    $editAttribute.classList.add('o-hidden');
-  } else {
-    $editAttribute.classList.remove('o-hidden');
-  }
-  if (allowedOperations && !allowedOperations.includes('create')) {
-    $editDraw.classList.add('o-hidden');
-  } else {
-    $editDraw.classList.remove('o-hidden');
-  }
-  if (allowedOperations && !allowedOperations.includes('delete')) {
-    $editDelete.classList.add('o-hidden');
-  } else {
-    $editDelete.classList.remove('o-hidden');
-  }
-}
-
-function setActive(state) {
-  if (state === true) {
-    setAllowedTools();
-    document.getElementById('o-editor-toolbar').classList.remove('o-hidden');
-  } else {
-    document.getElementById('o-editor-toolbar').classList.add('o-hidden');
-  }
-}
-
-function onEnableInteraction(e) {
-  const { detail: { interaction } } = e;
-  e.stopPropagation();
-  if (interaction === 'editor') {
-    setActive(true);
-    dispatcher.emitToggleEdit('edit', {
-      currentLayer
-    });
-  } else {
-    setActive(false);
-    dispatcher.emitToggleEdit('cancel');
-  }
-}
-
-function onChangeEdit(e) {
-  const { detail: { tool, active } } = e;
-  if (tool === 'draw') {
-    if (active === false) {
-      $editDraw.classList.remove(activeClass);
+  function setAllowedTools() {
+    const layer = viewer.getLayer(currentLayer);
+    const allowedOperations = layer.get('allowedEditOperations');
+    if (allowedOperations && !allowedOperations.includes('updateAttributes')) {
+      $editAttribute.classList.add('o-hidden');
     } else {
-      $editDraw.classList.add(activeClass);
+      $editAttribute.classList.remove('o-hidden');
+    }
+    if (allowedOperations && !allowedOperations.includes('create')) {
+      $editDraw.classList.add('o-hidden');
+    } else {
+      $editDraw.classList.remove('o-hidden');
+    }
+    if (allowedOperations && !allowedOperations.includes('delete')) {
+      $editDelete.classList.add('o-hidden');
+    } else {
+      $editDelete.classList.remove('o-hidden');
+    }
+    // Set allowed modifyTools depending on selection and layer type
+    const availableTools = [];
+    if (selection && selection.length === 1 && selection[0].getGeometry().getType() === 'LineString') {
+      // Split line is only available when exactly one LineString is selected
+      availableTools.push({
+        name: 'Dela linje',
+        value: 'split-line-by-point'
+      });
+    }
+    // Rebuild content of popover and grey out button if no valid tools.
+    modifyToolsBtn.classList.add(disableClass);
+    modifyToolsPopoverEl.innerHTML = '';
+    if (availableTools.length > 0) {
+      modifyToolsBtn.classList.remove(disableClass);
+      dropDown(modifyToolsPopoverEl.id, availableTools, {});
+    } else {
+      closeModifyToolsPopover();
     }
   }
-  if (tool === 'layers') {
-    if (active === false) {
+
+  function setActive(state) {
+    if (state === true) {
+      setAllowedTools();
+      document.getElementById('o-editor-toolbar').classList.remove('o-hidden');
+    } else {
+      closeModifyToolsPopover();
+      document.getElementById('o-editor-toolbar').classList.add('o-hidden');
+    }
+  }
+
+  function onEnableInteraction(e) {
+    const { detail: { interaction } } = e;
+    e.stopPropagation();
+    if (interaction === 'editor') {
+      setActive(true);
+      dispatcher.emitToggleEdit('edit', {
+        currentLayer
+      });
+    } else {
+      setActive(false);
+      dispatcher.emitToggleEdit('cancel');
+    }
+  }
+
+  function onChangeEdit(e) {
+    const { detail: { tool, active } } = e;
+    if (tool === 'draw') {
+      if (active === false) {
+        $editDraw.classList.remove(activeClass);
+      } else {
+        $editDraw.classList.add(activeClass);
+      }
+    }
+    if (tool === 'layers') {
+      if (active === false) {
+        $editLayers.classList.remove(activeClass);
+      } else {
+        $editLayers.classList.add(activeClass);
+      }
+    } else if (active) {
       $editLayers.classList.remove(activeClass);
+    }
+  }
+
+  function toggleSave(e) {
+    const { detail: { edits } } = e;
+    if (edits) {
+      if ($editSave.classList.contains(disableClass)) {
+        $editSave.classList.remove(disableClass);
+      }
     } else {
-      $editLayers.classList.add(activeClass);
+      $editSave.classList.add(disableClass);
     }
-  } else if (active) {
-    $editLayers.classList.remove(activeClass);
   }
-}
 
-function toggleSave(e) {
-  const { detail: { edits } } = e;
-  if (edits) {
-    if ($editSave.classList.contains(disableClass)) {
-      $editSave.classList.remove(disableClass);
+  function changeLayerInternal(layer) {
+    currentLayer = layer;
+    setAllowedTools();
+  }
+
+  /**
+   * Called when toggleEdit event is raised
+   * @param {any} e Custom event
+   */
+  function onToggleEdit(e) {
+    const { detail: { tool } } = e;
+    // If the event contains a currentLayer, the currentLayer has either changed
+    // or the editor toolbar is activated and should display the last edited layer or default if first time
+    if (tool === 'edit' && e.detail.currentLayer) {
+      changeLayerInternal(e.detail.currentLayer);
     }
-  } else {
-    $editSave.classList.add(disableClass);
+    e.stopPropagation();
   }
-}
 
-function changeLayerInternal(layer) {
-  currentLayer = layer;
-  setAllowedTools();
-}
-
-/**
- * Called when toggleEdit event is raised
- * @param {any} e Custom event
- */
-function onToggleEdit(e) {
-  const { detail: { tool } } = e;
-  // If the event contains a currentLayer, the currentLayer has either changed
-  // or the editor toolbar is activated and should display the last edited layer or default if first time
-  if (tool === 'edit' && e.detail.currentLayer) {
-    changeLayerInternal(e.detail.currentLayer);
-  }
-  e.stopPropagation();
-}
-
-function init(options, v) {
-  currentLayer = options.currentLayer;
-  editableLayers = options.editableLayers;
-  // Keep a reference to viewer. Used later.
-  viewer = v;
-  render();
-  // Hide layers choice button if only 1 layer in editable
-  if (editableLayers.length < 2) {
-    $editLayers.parentNode.classList.add('o-hidden');
-  }
-  // Hide save button if configured with autoSave
-  if (options.autoSave) {
-    $editSave.classList.add('o-hidden');
-  }
-  layerSelector = editorLayers(editableLayers, v, {
-    activeLayer: currentLayer
-  });
-  drawToolsSelector = drawTools(options.drawTools, currentLayer, v);
-
-  document.addEventListener('enableInteraction', onEnableInteraction);
-  document.addEventListener('changeEdit', onChangeEdit);
-  document.addEventListener('editsChange', toggleSave);
-  document.addEventListener('toggleEdit', onToggleEdit);
-
-  bindUIActions();
-
-  if (options.isActive) {
-    setActive(true);
-  }
-}
-
-export default (function exportInit() {
-  return {
-    init,
+  // Here be the return statement that returns the Component created
+  return Component({
+    onInit() {
+      document.addEventListener('enableInteraction', onEnableInteraction);
+      document.addEventListener('changeEdit', onChangeEdit);
+      document.addEventListener('editsChange', toggleSave);
+      document.addEventListener('toggleEdit', onToggleEdit);
+      component = this;
+    },
+    onRender() {
+      bindUIActions();
+      if (options.isActive) {
+        setActive(true);
+      }
+      this.dispatch('render');
+    },
+    render,
+    /**
+     * Notifies the toolbar of the current selection and updates available tools for the current selection/layer combination
+     * @param {Any[]} features The currently selected features as an array of features
+     */
+    setSelection(features) {
+      selection = features;
+      setAllowedTools();
+    },
     toggleToolbar,
     /**
    * Updates layer selection list to reflect the current setting
@@ -216,5 +295,7 @@ export default (function exportInit() {
       layerSelector.changeLayer(layerName);
       drawToolsSelector.updateTools(layerName);
     }
-  };
-}());
+  });
+};
+
+export default EditorToolbar;

--- a/src/utils/topology.js
+++ b/src/utils/topology.js
@@ -8,6 +8,16 @@ import { intersects } from 'ol/extent';
 const topology = {
 
   /**
+   * Simple coordinate comparator.
+   * @param {any} c1 First coordinate as an array as [x,y]
+   * @param {any} c2 Second coordinate as an array as [x,y]
+   * @returns true if coordinates are equal
+   */
+  coordIsEqual: function coordIsEqual(c1, c2) {
+    return ((c1[0] === c2[0]) && (c1[1] === c2[1]));
+  },
+
+  /**
    * Intersects two line segments and returns the intersection. If lines are crossing it returns a point, if overlapping it return a line.
    * Two consecutive line segments in a linestring will always intersect in at least one point (but possibly a line if turning 180 deg).
    * @param {LineString} s1 First line


### PR DESCRIPTION
Fixes #2073

Adds a new button to the editor toolbar with modify tools that is activated when the correct geometry for that tool is selected. Currently the only available tool is split-line-by-point, which does just that: select a line feature, select the split tool and click where on the selected line it should be split. It cuts the original feature and creates a new with the rest of the line. The copy gets all attributes from the original feature (except id).

To activate the modify tools menu the editor control must be configured with:
`"modifyTools": true`
The configuration is only on editor level for now. In the future one could imaging having it on layer level as well or specify which tools are available.

As a bonus Edithandler and EditToolbar are rewritten as Components so they can emit events as I didn't wanted to follow the pattern the way the editor toolbar uses DOM events.