### PR TITLE
fix: make layer removal happen after setting popupmenu visibility

### DIFF
--- a/src/controls/legend/moreinfobutton.js
+++ b/src/controls/legend/moreinfobutton.js
@@ -125,11 +125,11 @@ export default function createMoreInfoButton(params) {
         labelEl.addEventListener('click', (e) => {
           const doRemove = (layer.get('promptlessRemoval') === true) || window.confirm(localize('removeLayerQuestion'));
           if (doRemove) {
+            popupMenu.setVisibility(false);
             viewer.getMap().removeLayer(layer);
             e.preventDefault();
             e.stopPropagation();
-          }
-          popupMenu.setVisibility(false);
+          } else popupMenu.setVisibility(false);
         });
       },
       render() {

--- a/src/controls/legend/moreinfobutton.js
+++ b/src/controls/legend/moreinfobutton.js
@@ -125,7 +125,6 @@ export default function createMoreInfoButton(params) {
         labelEl.addEventListener('click', (e) => {
           const doRemove = (layer.get('promptlessRemoval') === true) || window.confirm(localize('removeLayerQuestion'));
           if (doRemove) {
-            popupMenu.setVisibility(false);
             viewer.getMap().removeLayer(layer);
             e.preventDefault();
             e.stopPropagation();


### PR DESCRIPTION
Aims to fix #2127 and preserve current behavior (minus the crash).