### PR TITLE
fix: give the iw title area a minimum height

### DIFF
--- a/scss/_infowindow.scss
+++ b/scss/_infowindow.scss
@@ -66,6 +66,7 @@
 .urval-textnode-container {
   font-size: 15px;
   margin-bottom: 0.5em;
+  min-height: 22.5px;
 }
 
 .expandable_list {


### PR DESCRIPTION
Aims to fix #2148  (22.5px seems to be the element's height when text is supplied (incl when the option isn't supplied)