### PR TITLE
Removed tracelayer from legend

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -1734,6 +1734,7 @@ export default function editHandler(options, v) {
   // Set up a layer for displaying trace possibilities. Do it up front as it may become possible to turn it on later
   traceHighligtLayer = new VectorLayer({
     source: new VectorSource(),
+    group: 'none',
     style: {
       'stroke-color': 'rgba(100, 255, 0, 1)',
       'stroke-width': 3


### PR DESCRIPTION
Fixes #2152.

Fixed by adding trace layer to group 'none' to make legend not display it.

No new configuration.

No new documentation required.
