### PR TITLE
Removed tracelayer from legend

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -1864,6 +1864,7 @@ export default function editHandler(options, v) {
 
       // Set up a layer for displaying trace possibilities. Do it up front as it may become possible to turn it on later
       traceHighligtLayer = new VectorLayer({
+        group: 'none',
         source: new VectorSource(),
         style: {
           'stroke-color': 'rgba(100, 255, 0, 1)',


### PR DESCRIPTION
Fixes #2152 by assigning trace layer to group 'none', making legend not displaying it.

No new configuration.

No new documentation.