### PR TITLE
fix: Rewrite sass includes

### DIFF
--- a/scss/_ol.scss
+++ b/scss/_ol.scss
@@ -1,29 +1,34 @@
 @use 'externs/ol';
 
-.ol-attribution li a {
-  color: #bbb;
+@mixin default {
+  @include ol.default;
+
+  .ol-attribution li a {
+    color: #bbb;
+  }
+
+  .ol-attribution li a:focus {
+    color: #fff;
+    text-decoration: underline;
+  }
+
+  .ol-attribution li a:focus:not(:focus-visible) {
+    color: #bbb;
+    text-decoration: none;
+  }
+
+  .ol-overlaycontainer-stopevent {
+    z-index: unset !important;
+  }
+
+  .ol-overlaycontainer,
+  .ol-overlaycontainer-stopevent {
+    pointer-events: none;
+  }
+
+  .ol-overlaycontainer > *,
+  .ol-overlaycontainer-stopevent > * {
+    pointer-events: auto;
+  }
 }
 
-.ol-attribution li a:focus {
-  color: #fff;
-  text-decoration: underline;
-}
-
-.ol-attribution li a:focus:not(:focus-visible) {
-  color: #bbb;
-  text-decoration: none;
-}
-
-.ol-overlaycontainer-stopevent {
-  z-index: unset !important;
-}
-
-.ol-overlaycontainer,
-.ol-overlaycontainer-stopevent {
-  pointer-events: none;
-}
-
-.ol-overlaycontainer > *,
-.ol-overlaycontainer-stopevent > * {
-  pointer-events: auto;
-}

--- a/scss/_viewer.scss
+++ b/scss/_viewer.scss
@@ -1,141 +1,143 @@
 @use './ui/variables';
 @use './variables' as vars;
 
-.o-tools-left {
-  display: block;
-  display: flex;
-  flex-flow: column;
-}
-
-.o-tools-left {
-  left: 0;
-  top: 0;
-}
-
-.o-toolbar-maptools {
-  margin-top: .5rem;
-}
-
-.o-toolbar-misc {
-  margin-top: .5rem;
-}
-
-.o-navigation button {
-  position: relative;
-}
-
-.o-maptools button {
-  position: relative;
-}
-
-.o-footer {
-  background-color: variables.$black;
-  background-color: rgba(0, 0, 0, 0.8);
-  color: variables.$white;
-  font-size: 0.7em;
-  height: 2.5em;
-  line-height: variables.$line-height-medium;
-  width: 100%;
-  z-index: 1;
-}
-
-.o-footer a {
-  color: variables.$white;
-  text-decoration: none;
-}
-
-.o-footer a:hover {
-  color: variables.$white;
-  text-decoration: underline;
-}
-
-.o-footer a:focus {
-  color: variables.$white;
-  text-decoration: underline;
-}
-
-.o-footer a:focus:not(:focus-visible) {
-  color: variables.$white;
-  text-decoration: none;
-}
-
-.o-footer .o-footer-middle {
-  float: left;
-  position: relative;
-  text-align: center;
-}
-
-.o-footer .o-footer-middle .o-footer-middle-content {
-  padding: 0.25em 0;
-  width: max-content;
-}
-
-.o-footer .o-footer-middle img {
-  height: 2em;
-  padding-right: 5px;
-}
-
-.o-footer .o-footer-middle .o-footer-middle-content p {
-  display: inline;
-  line-height: variables.$line-height-medium;
-  vertical-align: top;
-}
-
-.o-footer .o-footer-right {
-  float: left;
-  position: relative;
-  width: 50%;
-}
-
-.o-footer .o-footer-left {
-  float: left;
-  padding-left: 5px;
-  padding-top: 3px;
-  position: relative;
-  width: 50%;
-}
-
-.o-footer .o-footer-right .o-footer-attribution {
-  float: right;
-  padding-right: 5px;
-  position: relative;
-  text-align: right;
-}
-
-.o-footer .o-footer-middle ul {
-  display: inline-block;
-  padding-left: 0;
-}
-
-.o-footer .o-footer-middle ul li {
-  border-right: 1px solid #fff;
-  float: left;
-  padding: 0 6px;
-}
-
-.o-footer .o-footer-middle ul li:last-child {
-  border-right: 'none';
-  padding-right: 0;
-}
-[class*= #{vars.$media-l}] {
-  .o-footer {
-    display: none;
-  }
-}
-[class*=#{vars.$media-l-m}] {
+@mixin default {
   .o-tools-left {
-    bottom: 0;
-    top: auto;
+    display: block;
+    display: flex;
+    flex-flow: column;
+  }
+
+  .o-tools-left {
+    left: 0;
+    top: 0;
+  }
+
+  .o-toolbar-maptools {
+    margin-top: .5rem;
   }
 
   .o-toolbar-misc {
-    margin-top: 0;
-    order: -1;
+    margin-top: .5rem;
   }
-}
-[class*=#{vars.$media-l-m-s-xs}] {
-  .o-toolbar-maptools,
-  .o-toolbar-navigation {
-    display: none;
+
+  .o-navigation button {
+    position: relative;
+  }
+
+  .o-maptools button {
+    position: relative;
+  }
+
+  .o-footer {
+    background-color: variables.$black;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: variables.$white;
+    font-size: 0.7em;
+    height: 2.5em;
+    line-height: variables.$line-height-medium;
+    width: 100%;
+    z-index: 1;
+  }
+
+  .o-footer a {
+    color: variables.$white;
+    text-decoration: none;
+  }
+
+  .o-footer a:hover {
+    color: variables.$white;
+    text-decoration: underline;
+  }
+
+  .o-footer a:focus {
+    color: variables.$white;
+    text-decoration: underline;
+  }
+
+  .o-footer a:focus:not(:focus-visible) {
+    color: variables.$white;
+    text-decoration: none;
+  }
+
+  .o-footer .o-footer-middle {
+    float: left;
+    position: relative;
+    text-align: center;
+  }
+
+  .o-footer .o-footer-middle .o-footer-middle-content {
+    padding: 0.25em 0;
+    width: max-content;
+  }
+
+  .o-footer .o-footer-middle img {
+    height: 2em;
+    padding-right: 5px;
+  }
+
+  .o-footer .o-footer-middle .o-footer-middle-content p {
+    display: inline;
+    line-height: variables.$line-height-medium;
+    vertical-align: top;
+  }
+
+  .o-footer .o-footer-right {
+    float: left;
+    position: relative;
+    width: 50%;
+  }
+
+  .o-footer .o-footer-left {
+    float: left;
+    padding-left: 5px;
+    padding-top: 3px;
+    position: relative;
+    width: 50%;
+  }
+
+  .o-footer .o-footer-right .o-footer-attribution {
+    float: right;
+    padding-right: 5px;
+    position: relative;
+    text-align: right;
+  }
+
+  .o-footer .o-footer-middle ul {
+    display: inline-block;
+    padding-left: 0;
+  }
+
+  .o-footer .o-footer-middle ul li {
+    border-right: 1px solid #fff;
+    float: left;
+    padding: 0 6px;
+  }
+
+  .o-footer .o-footer-middle ul li:last-child {
+    border-right: 'none';
+    padding-right: 0;
+  }
+  &[class*= #{vars.$media-l}] {
+    .o-footer {
+      display: none;
+    }
+  }
+  &[class*=#{vars.$media-l-m}] {
+    .o-tools-left {
+      bottom: 0;
+      top: auto;
+    }
+
+    .o-toolbar-misc {
+      margin-top: 0;
+      order: -1;
+    }
+  }
+  &[class*=#{vars.$media-l-m-s-xs}] {
+    .o-toolbar-maptools,
+    .o-toolbar-navigation {
+      display: none;
+    }
   }
 }

--- a/scss/externs/_ol.scss
+++ b/scss/externs/_ol.scss
@@ -1,301 +1,219 @@
 @use '../ui/variables';
 @use '../variables' as vars;
 
-.ol-unsupported {
-  display: none;
-}
-
-.ol-viewport .ol-unselectable {
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  -webkit-touch-callout: none;
-  user-select: none;
-  user-select: none;
-  user-select: none;
-  user-select: none;
-  user-select: none;
-}
-
-.ol-control {
-  background-color: #fff;
-  border-radius: 4px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.45);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.45);
-}
-
-.no-boxshadow .ol-control {
-  border: 1px solid #c5c5c5;
-}
-
-.ol-control:hover {
-  background-color: rgba(255, 255, 255, 0.6);
-}
-
-.ol-zoom {
-  width: 2rem;
-}
-
-.ol-rotate {
-  transition: opacity .25s;
-}
-
-.ol-rotate.ol-hidden {
-  opacity: 0;
-  transition: opacity .25s linear, visibility 0s linear .25s;
-  visibility: hidden;
-}
-@media print {
-  .ol-zoom,
-  .ol-full-screen {
-    display: none;
-  }
-}
-
-.ol-control button {
-  background-color: variables.$white;
-  border: 0;
-  border-radius: 4px;
-  color: #424242;
-  color: rgba(66, 66, 66, 1);
-  cursor: pointer;
-  display: block;
-  font-size: 1em;
-  height: 2em;
-  padding: 0;
-  text-align: center;
-  text-decoration: none;
-  width: 2em;
-}
-
-.ol-control button::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-
-.ol-control button:hover {
-  background-color: #424242;
-  color: #eee;
-  text-decoration: none;
-}
-
-button.ol-zoom-in {
-  border-bottom: 1px solid #c5c5c5 !important;
-  border-radius: 4px 4px 0 0;
-}
-
-button.ol-zoom-out {
-  border-radius: 0 0 4px 4px;
-}
-
-.ol-control.ol-rotate button {
-  background-color: transparent;
-  border-radius: 0;
-}
-
-.ol-rotate.ol-control {
-  background-color: transparent;
-  box-shadow: none;
-}
-
-.ol-compass {
-  background-size: 2em;
-  display: block;
-  font-family: Arial;
-  font-weight: normal;
-  height: 2em;
-  width: 2em;
-}
-
-.ol-scale-line,
-.ol-scale-line:not([ie8andbelow]) {
-  background: #fff;
-  background: rgba(255, 255, 255, 0.7);
-  border-radius: 4px;
-  display: inline-block;
-  padding: 2px;
-  position: relative;
-}
-
-.ol-scale-line-inner {
-  border: 1px solid #424242;
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
-  border-top: 'none';
-  color: #424242;
-  font-size: 10px;
-  margin: 1px;
-  padding: 0 2px;
-  text-align: center;
-}
-
-.ol-scale-bar-inner {
-  display: flex;
-}
-
-.ol-scale-singlebar-even{
-  background-color: #000000;
-}
-
-.ol-scale-singlebar-odd{
-  background-color: #FFFFFF;
-}
-
-/* invisible but not hidden */
-.ol-has-tooltip [role=tooltip] {
-  border: 0;
-  clip: rect(1px 1px 1px 1px); /* < IE8 */
-  clip: rect(1px, 1px, 1px, 1px);
-  font-size: 14px;
-  font-weight: normal;
-  height: 1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  text-shadow: 0 0 2px #fff;
-  width: 1px;
-}
-
-.ol-attribution {
-  bottom: .5em;
-  max-width: calc(100% - 3.5em);
-  padding: .35em 0;
-  position: absolute;
-  right: .5em;
-  text-align: right;
-  z-index: 30;
-}
-
-.ol-attribution ul {
-  color: #fff;
-  font-size: .7rem;
-  line-height: 1.375em;
-  margin: 0;
-  max-width: 60%;
-  padding: 0 .5em;
-}
-
-.ol-attribution li {
-  display: inline;
-  line-height: inherit;
-  list-style: none;
-}
-
-.ol-attribution li:not(:last-child)::after {
-  content: ' ';
-}
-
-.ol-attribution ul,
-.ol-attribution button {
-  display: inline;
-}
-
-.ol-attribution:not(.ol-collapsed) button:hover [role=tooltip],
-.ol-attribution.ol-collapsed ul {
-  display: none;
-}
-
-.ol-attribution.ol-logo-only ul {
-  display: block;
-}
-
-.ol-attribution:not(.ol-collapsed) {
-  background: transparent;
-}
-
-.ol-control.ol-attribution:not(.ol-collapsed) {
-  box-shadow: none;
-}
-
-.ol-attribution:not(.ol-collapsed) button {
-  background: transparent;
-  color: #000;
-}
-
-.ol-attribution:not(.ol-collapsed) button:hover {
-  background: #424242;
-  color: #fff;
-}
-
-.ol-attribution.ol-collapsed button {
-  background: rgba(0, 0, 0, 0.8);
-  border-radius: 15px;
-  color: #fff;
-  height: 1.5em;
-  width: 1.5em;
-}
-
-.ol-attribution.ol-uncollapsible {
-  border-radius: 4px 0 0;
-  bottom: 0;
-  height: 1.1em;
-  line-height: 1em;
-  right: 0;
-}
-
-.ol-attribution.ol-logo-only {
-  background: transparent;
-  bottom: .4em;
-  height: 1.1em;
-  line-height: 1em;
-}
-
-.ol-attribution.ol-uncollapsible img {
-  margin-top: -.2em;
-  max-height: 1.6em;
-}
-
-.ol-attribution.ol-logo-only button,
-.ol-attribution.ol-uncollapsible button {
-  display: none;
-}
-
-/*workaround to remove ol logo until class for the logo*/
-.ol-attribution img {
-  display: none;
-}
-
-.ol-box {
-  border: 2px solid variables.$blue;
-  border-radius: 2px;
-  box-sizing: border-box;
-}
-
-.ol-dragzoom {
-  background-color: rgba(255, 255, 255, 0.4);
-  border-color: #007aff;
-  border-width: 3px;
-}
-[class*=#{vars.$media-l}] {
-  .ol-scale-line,
-  .ol-scale-line-inner {
+@mixin default {
+  .ol-unsupported {
     display: none;
   }
 
-  .ol-attribution {
-    max-width: calc(100% - 3.5em);
+  .ol-viewport .ol-unselectable {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-touch-callout: none;
+    user-select: none;
+    user-select: none;
+    user-select: none;
+    user-select: none;
+    user-select: none;
+  }
+
+  .ol-control {
+    background-color: #fff;
+    border-radius: 4px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.45);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.45);
+  }
+
+  .no-boxshadow .ol-control {
+    border: 1px solid #c5c5c5;
+  }
+
+  .ol-control:hover {
+    background-color: rgba(255, 255, 255, 0.6);
+  }
+
+  .ol-zoom {
+    width: 2rem;
+  }
+
+  .ol-rotate {
+    transition: opacity .25s;
+  }
+
+  .ol-rotate.ol-hidden {
+    opacity: 0;
+    transition: opacity .25s linear, visibility 0s linear .25s;
+    visibility: hidden;
+  }
+  @media print {
+    .ol-zoom,
+    .ol-full-screen {
+      display: none;
+    }
+  }
+
+  .ol-control button {
+    background-color: variables.$white;
+    border: 0;
+    border-radius: 4px;
+    color: #424242;
+    color: rgba(66, 66, 66, 1);
+    cursor: pointer;
+    display: block;
+    font-size: 1em;
+    height: 2em;
+    padding: 0;
+    text-align: center;
+    text-decoration: none;
+    width: 2em;
+  }
+
+  .ol-control button::-moz-focus-inner {
+    border: 0;
     padding: 0;
   }
 
-  .ol-attribution ul {
-    color: #000;
+  .ol-control button:hover {
+    background-color: #424242;
+    color: #eee;
+    text-decoration: none;
   }
 
-  .ol-control.ol-attribution:not(.ol-collapsed) {
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.45);
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.45);
+  button.ol-zoom-in {
+    border-bottom: 1px solid #c5c5c5 !important;
+    border-radius: 4px 4px 0 0;
   }
 
-  .ol-control.ol-attribution.ol-collapsed {
+  button.ol-zoom-out {
+    border-radius: 0 0 4px 4px;
+  }
+
+  .ol-control.ol-rotate button {
+    background-color: transparent;
+    border-radius: 0;
+  }
+
+  .ol-rotate.ol-control {
     background-color: transparent;
     box-shadow: none;
   }
 
+  .ol-compass {
+    background-size: 2em;
+    display: block;
+    font-family: Arial;
+    font-weight: normal;
+    height: 2em;
+    width: 2em;
+  }
+
+  .ol-scale-line,
+  .ol-scale-line:not([ie8andbelow]) {
+    background: #fff;
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 4px;
+    display: inline-block;
+    padding: 2px;
+    position: relative;
+  }
+
+  .ol-scale-line-inner {
+    border: 1px solid #424242;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+    border-top: 'none';
+    color: #424242;
+    font-size: 10px;
+    margin: 1px;
+    padding: 0 2px;
+    text-align: center;
+  }
+
+  .ol-scale-bar-inner {
+    display: flex;
+  }
+
+  .ol-scale-singlebar-even{
+    background-color: #000000;
+  }
+
+  .ol-scale-singlebar-odd{
+    background-color: #FFFFFF;
+  }
+
+  /* invisible but not hidden */
+  .ol-has-tooltip [role=tooltip] {
+    border: 0;
+    clip: rect(1px 1px 1px 1px); /* < IE8 */
+    clip: rect(1px, 1px, 1px, 1px);
+    font-size: 14px;
+    font-weight: normal;
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    text-shadow: 0 0 2px #fff;
+    width: 1px;
+  }
+
+  .ol-attribution {
+    bottom: .5em;
+    max-width: calc(100% - 3.5em);
+    padding: .35em 0;
+    position: absolute;
+    right: .5em;
+    text-align: right;
+    z-index: 30;
+  }
+
+  .ol-attribution ul {
+    color: #fff;
+    font-size: .7rem;
+    line-height: 1.375em;
+    margin: 0;
+    max-width: 60%;
+    padding: 0 .5em;
+  }
+
+  .ol-attribution li {
+    display: inline;
+    line-height: inherit;
+    list-style: none;
+  }
+
+  .ol-attribution li:not(:last-child)::after {
+    content: ' ';
+  }
+
+  .ol-attribution ul,
+  .ol-attribution button {
+    display: inline;
+  }
+
+  .ol-attribution:not(.ol-collapsed) button:hover [role=tooltip],
+  .ol-attribution.ol-collapsed ul {
+    display: none;
+  }
+
+  .ol-attribution.ol-logo-only ul {
+    display: block;
+  }
+
   .ol-attribution:not(.ol-collapsed) {
-    background: rgba(255, 255, 255, 0.9);
+    background: transparent;
+  }
+
+  .ol-control.ol-attribution:not(.ol-collapsed) {
+    box-shadow: none;
   }
 
   .ol-attribution:not(.ol-collapsed) button {
     background: transparent;
     color: #000;
+  }
+
+  .ol-attribution:not(.ol-collapsed) button:hover {
+    background: #424242;
+    color: #fff;
   }
 
   .ol-attribution.ol-collapsed button {
@@ -305,12 +223,96 @@ button.ol-zoom-out {
     height: 1.5em;
     width: 1.5em;
   }
-}
 
-[class*=#{vars.$media-l}] {
-  .ol-attribution {
-    bottom: 1rem;
-    left: 1rem;
-    right: auto;
+  .ol-attribution.ol-uncollapsible {
+    border-radius: 4px 0 0;
+    bottom: 0;
+    height: 1.1em;
+    line-height: 1em;
+    right: 0;
+  }
+
+  .ol-attribution.ol-logo-only {
+    background: transparent;
+    bottom: .4em;
+    height: 1.1em;
+    line-height: 1em;
+  }
+
+  .ol-attribution.ol-uncollapsible img {
+    margin-top: -.2em;
+    max-height: 1.6em;
+  }
+
+  .ol-attribution.ol-logo-only button,
+  .ol-attribution.ol-uncollapsible button {
+    display: none;
+  }
+
+  /*workaround to remove ol logo until class for the logo*/
+  .ol-attribution img {
+    display: none;
+  }
+
+  .ol-box {
+    border: 2px solid variables.$blue;
+    border-radius: 2px;
+    box-sizing: border-box;
+  }
+
+  .ol-dragzoom {
+    background-color: rgba(255, 255, 255, 0.4);
+    border-color: #007aff;
+    border-width: 3px;
+  }
+  &[class*=#{vars.$media-l}] {
+    .ol-scale-line,
+    .ol-scale-line-inner {
+      display: none;
+    }
+
+    .ol-attribution {
+      max-width: calc(100% - 3.5em);
+      padding: 0;
+    }
+
+    .ol-attribution ul {
+      color: #000;
+    }
+
+    .ol-control.ol-attribution:not(.ol-collapsed) {
+      box-shadow: 0 0 5px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 0 5px rgba(0, 0, 0, 0.45);
+    }
+
+    .ol-control.ol-attribution.ol-collapsed {
+      background-color: transparent;
+      box-shadow: none;
+    }
+
+    .ol-attribution:not(.ol-collapsed) {
+      background: rgba(255, 255, 255, 0.9);
+    }
+
+    .ol-attribution:not(.ol-collapsed) button {
+      background: transparent;
+      color: #000;
+    }
+
+    .ol-attribution.ol-collapsed button {
+      background: rgba(0, 0, 0, 0.8);
+      border-radius: 15px;
+      color: #fff;
+      height: 1.5em;
+      width: 1.5em;
+    }
+  }
+
+  &[class*=#{vars.$media-l}] {
+    .ol-attribution {
+      bottom: 1rem;
+      left: 1rem;
+      right: auto;
+    }
   }
 }

--- a/scss/origo.scss
+++ b/scss/origo.scss
@@ -4,6 +4,8 @@
 @use 'variables';
 @use 'ui/ui';
 @use 'bookmark';
+@use 'ol';
+@use 'viewer';
 
 .o-map {
   display: flex;
@@ -13,7 +15,7 @@
   position: relative;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   @include meta.load-css('reset');
-  @include meta.load-css('ol');
+  @include ol.default;
   @include meta.load-css('externs/glidejs/import.scss');
   @include meta.load-css('glide/custom');
   @include meta.load-css('card');
@@ -29,8 +31,8 @@
   @include meta.load-css('stylepicker');
   @include meta.load-css('close');
   @include meta.load-css('icon');
+  @include viewer.default;
   @include meta.load-css('tooltip');
-  @include meta.load-css('viewer');
   @include meta.load-css('rotate');
   @include meta.load-css('mapmenu');
   @include meta.load-css('draw');


### PR DESCRIPTION
This is a PR that replaces #2159 and fixes #2155 
I ain't no sass ninja but I think we have to use use/include syntax along with mixins instead of `include meta.load-css('file')` to use the scss files without a major rewrite. In this PR I have adjusted ol and viewer, but this needs to be done for all files if it is our solution of choice, hence the draft status.

Some docs: https://sass-lang.com/documentation/breaking-changes/import/#nested-imports