### PR TITLE
feature: localize area, length functions when used for layer attributes

### DIFF
--- a/src/featureinfo.js
+++ b/src/featureinfo.js
@@ -26,7 +26,8 @@ const Featureinfo = function Featureinfo(options = {}) {
     savedPin: savedPinOptions,
     savedSelection,
     selectionStyles: selectionStylesOptions,
-    autoplay = false
+    autoplay = false,
+    localization
   } = options;
 
   let selectionLayer;
@@ -560,7 +561,7 @@ const Featureinfo = function Featureinfo(options = {}) {
       hitTolerance,
       map,
       pixel
-    }, viewer);
+    }, viewer, localization);
     // Abort if clientResult is false
     if (clientResult !== false) {
       getFeatureInfo.getFeaturesFromRemote({

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -197,7 +197,7 @@ function customAttribute(feature, attribute, attributes, map) {
  * @param {any} map
  * @returns
  */
-function getAttributesHelper(feature, layer, map) {
+function getAttributesHelper(feature, layer, map, localization) {
   const featureinfoElement = document.createElement('div');
   featureinfoElement.classList.add('o-identify-content');
   const ulList = document.createElement('ul');
@@ -239,6 +239,7 @@ function getAttributesHelper(feature, layer, map) {
           } else if (attribute.url) {
             val = getContent.url(feature, attribute, attributes, map);
           } else if (attribute.html) {
+            attribute.localization = localization;
             val = getContent.html(feature, attribute, attributes, map);
           } else if (attribute.carousel) {
             val = getContent.carousel(feature, attribute, attributes, map);
@@ -274,7 +275,7 @@ function getAttributesHelper(feature, layer, map) {
  * @param {any} map
  * @returns
  */
-function getAttributes(feature, layer, map) {
+function getAttributes(feature, layer, map, localization) {
   // Add all hoisting attributes as actual properties on feature beacuse attributes configuration may try to use them
   // Should only happen if user calls from api and has configured async content but are using sync function to create content
   // Properties are removed when content is created because if we leave them they will exist permanently on the feature,
@@ -304,7 +305,7 @@ function getAttributes(feature, layer, map) {
       }
     });
   }
-  const content = getAttributesHelper(feature, layer, map);
+  const content = getAttributesHelper(feature, layer, map, localization);
   // remove the temporary attributes now that we're done with them
   attributesToRemove.forEach(currAttrToRemove => feature.unset(currAttrToRemove, true));
   return content;
@@ -406,12 +407,12 @@ async function hoistRelatedAttributes(parentLayer, parentFeature, hoistedAttribu
  * @param {any} layer
  * @param {any} map
  */
-async function getAttributesAsync(feature, layer, map) {
+async function getAttributesAsync(feature, layer, map, localization) {
   const hoistedAttributes = [];
   const layers = map.getLayers().getArray();
   // Add the temporary attributes with their values
   await hoistRelatedAttributes(layer, feature, hoistedAttributes, layers);
-  const content = getAttributesHelper(feature, layer, map);
+  const content = getAttributesHelper(feature, layer, map, localization);
 
   // Remove all temporary added attributes. They mess up saving edits as there are no such fields in db.
   hoistedAttributes.forEach(hoist => {

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -22,6 +22,7 @@ const isValidJSON = str => {
  * @param {any} layer
  * @param {any} map
  * @param {any} groupLayers
+ * @param {any} [localization]
  * @returns {SelectedItem}
  */
 function createSelectedItem(feature, layer, map, groupLayers, localization) {

--- a/src/getfeatureinfo.js
+++ b/src/getfeatureinfo.js
@@ -24,7 +24,7 @@ const isValidJSON = str => {
  * @param {any} groupLayers
  * @returns {SelectedItem}
  */
-function createSelectedItem(feature, layer, map, groupLayers) {
+function createSelectedItem(feature, layer, map, groupLayers, localization) {
   // Above functions have no way of knowing whether the layer is part of a LayerGroup or not, therefore we need to check every layer against the groupLayers.
   const layerName = layer.get('name');
   let groupLayer;
@@ -47,7 +47,7 @@ function createSelectedItem(feature, layer, map, groupLayers) {
     selectionGroupTitle = layer.get('title');
   }
 
-  return new SelectedItem(feature, layer, map, selectionGroup, selectionGroupTitle);
+  return new SelectedItem(feature, layer, map, selectionGroup, selectionGroupTitle, localization);
 }
 
 async function getFeatureInfoUrl({
@@ -356,7 +356,7 @@ function getFeaturesAtPixel({
   hitTolerance,
   map,
   pixel
-}, viewer) {
+}, viewer, localization) {
   const result = [];
   let cluster = false;
   const resolutions = map.getView().getResolutions();
@@ -379,15 +379,15 @@ function getFeaturesAtPixel({
           return true;
         }
         collection.forEach((f) => {
-          const si = createSelectedItem(f, layer, map, groupLayers);
+          const si = createSelectedItem(f, layer, map, groupLayers, localization);
           result.push(si);
         });
       } else if (collection.length === 1 && queryable) {
-        const si = createSelectedItem(collection[0], layer, map, groupLayers);
+        const si = createSelectedItem(collection[0], layer, map, groupLayers, localization);
         result.push(si);
       }
     } else if (queryable) {
-      const si = createSelectedItem(feature, layer, map, groupLayers);
+      const si = createSelectedItem(feature, layer, map, groupLayers, localization);
       result.push(si);
     }
 

--- a/src/models/SelectedItem.js
+++ b/src/models/SelectedItem.js
@@ -12,15 +12,17 @@ export default class SelectedItem {
    * @param {any} map
    * @param {any} selectionGroup
    * @param {any} selectionGroupTitle
+   * @param {any} localization
    */
-  constructor(feature, layer, map, selectionGroup, selectionGroupTitle) {
+  constructor(feature, layer, map, selectionGroup, selectionGroupTitle, localization) {
     this.feature = feature;
     this.layer = layer;
     this.map = map;
+    this.localization = localization;
     if (layer && map) {
       // Create the visual representation of this feature
       // must not fail or be async as this is called from the contructor
-      this.content = getAttributes(feature, layer, map);
+      this.content = getAttributes(feature, layer, map, localization);
     }
 
     this.selectionGroup = selectionGroup || layer.get('name');
@@ -31,7 +33,7 @@ export default class SelectedItem {
    * Builds the content including async content.
    */
   async createContentAsync() {
-    this.content = await getAttributesAsync(this.feature, this.layer, this.map);
+    this.content = await getAttributesAsync(this.feature, this.layer, this.map, this.localization);
   }
 
   getId() {

--- a/src/models/SelectedItem.js
+++ b/src/models/SelectedItem.js
@@ -12,7 +12,7 @@ export default class SelectedItem {
    * @param {any} map
    * @param {any} selectionGroup
    * @param {any} selectionGroupTitle
-   * @param {any} localization
+   * @param {any} [localization]
    */
   constructor(feature, layer, map, selectionGroup, selectionGroupTitle, localization) {
     this.feature = feature;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -594,6 +594,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
           }
 
           featureinfoOptions.viewer = this;
+          featureinfoOptions.localization = controls.find((control) => control.name === 'localization');
 
           selectionmanager = Selectionmanager(featureinfoOptions);
           featureinfo = Featureinfo(featureinfoOptions);


### PR DESCRIPTION
Seeks to fix #2164 .

Random thoughts:
- localizing units of measurement as @MattiasSp mentioned today would include number conversion and unit appending and it would go outside of the scope of intl.NumberFormat afaIct It could be a nice improvement down the line, especially if users in London are accustomed to seeing miles and feet when employing the ruler tool in their local web map.
- I don't pretend to understand why getAttributes and getAttributesAsync are both used when infoclicking a vector layer :) 
