### PR TITLE
fix: default fill in legend symbol

### DIFF
--- a/src/utils/legendmaker.js
+++ b/src/utils/legendmaker.js
@@ -98,7 +98,7 @@ export const renderSvgIcon = function renderSvgIcon(styleRule, {
   if (styleType in renderIcon) {
     if (styleType === 'Polygon') {
       const polygonOptions = styleRule.find(style => style.fill);
-      const icon = renderIcon.Circle({
+      const icon = renderIcon.Polygon({
         fill: polygonOptions.fill,
         stroke: polygonOptions.stroke
       });
@@ -106,7 +106,7 @@ export const renderSvgIcon = function renderSvgIcon(styleRule, {
     } else if (styleType === 'Line') {
       const icon = styleRule.reduce((prev, style) => {
         if (style.stroke) {
-          return prev + renderIcon.Circle({
+          return prev + renderIcon.Line({
             stroke: style.stroke
           });
         }

--- a/src/utils/legendrender.js
+++ b/src/utils/legendrender.js
@@ -12,36 +12,44 @@ export const renderSvg = function renderSvg(content, {
 };
 
 export const renderIcon = {
-  Line({
-    color,
-    lineDash,
-    width: widthOption = 2
-  } = {}) {
-    const strokeDasharray = lineDash ? 'stroke-dasharray: 4 4;' : '';
-    const width = widthOption > 7 ? 7 : widthOption;
-    const margin = 4;
-    const stroke = `stroke: ${color}; stroke-width: ${width}; ${strokeDasharray}`;
-    return `<line x1 ="${margin}" y1="${(size - margin)}" x2="${(size - margin)}" y2="${margin}" style="${stroke}"/>`;
-  },
-  Polygon(
-    {
+  Polygon(options = {}, circleSize = size) {
+    const fillOptions = options.fill || {};
+    const strokeOptions = options.stroke || {};
+    let {
       color: fillColor
-    } = {},
-    {
-      color: strokeColor,
-      lineDash
-    } = {}
-  ) {
-    const r = 2;
-    const strokeWidth = 2;
-    const margin = 2;
-    const fill = fillColor ? `fill: ${fillColor};` : 'fill: none;';
+    } = fillOptions;
+    let {
+      color: strokeColor
+    } = strokeOptions;
+    const {
+      lineDash,
+      width: widthOption = 2
+    } = strokeOptions;
+    const {
+      radius: radiusOption = circleSize / 2
+    } = options;
+    const width = widthOption > 4 ? 4 : widthOption;
+    const radius = radiusOption - width;
     let stroke = 'stroke: none;';
+    if (strokeColor && typeof strokeColor === 'object') {
+      strokeColor = `rgba(${strokeColor[0]},${strokeColor[1]},${strokeColor[2]},${strokeColor[3] || 1})`;
+    }
     if (strokeColor) {
       const strokeDasharray = lineDash ? 'stroke-dasharray: 4 4;' : '';
-      stroke = `stroke: ${strokeColor}; stroke-width: ${strokeWidth}; ${strokeDasharray}`;
+      stroke = `stroke: ${strokeColor}; stroke-width: ${width}; ${strokeDasharray}`;
     }
-    return `<rect x="${strokeWidth + margin}" y="${strokeWidth + margin}" height="${size - (strokeWidth * 2) - (margin * 2)}" width="${size - (strokeWidth * 2) - (margin * 2)}" rx="${r}" style="${fill} ${stroke}"/>`;
+    if (typeof fillColor === 'object') {
+      fillColor = `rgba(${fillColor[0]},${fillColor[1]},${fillColor[2]},${fillColor[3] || 1})`;
+    }
+    const fill = fillColor ? `fill: ${fillColor};` : 'fill: none;';
+    const centerDistance = circleSize / 2;
+    // Actually depictures it as a circle.
+    return `<circle cx="${centerDistance}" cy="${centerDistance}" r="${radius}" style="${fill} ${stroke}"/>`;
+  },
+  Line(options = {}, circleSize = size) {
+    // Right now we're treating the same way as a polygon, but the Line property must exist on the
+    // renderIcon object as legendmaker checks style type
+    return this.Polygon(options, circleSize);
   },
   Circle(options = {}, circleSize = size) {
     const fillOptions = options.fill || {};


### PR DESCRIPTION
Fixes #2160.

A tricky one this one... Old implementation used `Circle()` to render a legend icon for symbols of type `Line` and `Polygon`. #2120 redefined some defaults for Circle() to match the defaults for OpenLayers' defaults for the regular shape circle in the map. But when called to generate an icon for a polygon or line symbol there shouldn't be any default fill.

I solved it by separating Polygon and Line icon functions from Circle. The diff may look a bit strange but there was already a function called Polygon and one called Line. They were never called, but had to exist as legendmaker checked for their existance against the _styleType_. I copied the old implementation of `Circle()` to `Polygon()` and had `Line()` call `Polygon()` to restore the behavior for lines and polygons without affecting the regular shape "Circle".

In short the _styleType_ is determined from the top level symbol properties. If it has stroke it is a line. If it has both stroke and fill it is a Polygon and if it has a named regular shape, it is that shape. My guess is that the intention was to render different icons for line and polygons, like a snake for lines and an irregular patch for polygons, but in reality they were all circles. With this separation it would be easy to create different svg:s with different shapes depending on the styleType, but since that is a feature request, I didn't do it in this PR. But it would be cool to do so. Maybe give the chance to select from a variety of shapes, like smooth curved lines for water, straight corners for streets, smooth patches for lakes, squared patches for land parcels etc.

