### PR TITLE
fix: make scale selectors work again

### DIFF
--- a/src/controls/scalepicker.js
+++ b/src/controls/scalepicker.js
@@ -18,7 +18,7 @@ const Scalepicker = function Scalepicker(options = {}) {
   }
 
   function getScales() {
-    return resolutions.map(resolution => `${listItemPrefix}${mapUtils.resolutionToFormattedScale(resolution, projection, localization)}`);
+    return resolutions.map(resolution => `${listItemPrefix}${mapUtils.resolutionToFormattedScale(resolution, projection)}`);
   }
 
   function setMapScale(scale) {
@@ -29,7 +29,7 @@ const Scalepicker = function Scalepicker(options = {}) {
   }
 
   function onZoomChange() {
-    dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection, localization)}`);
+    dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection)}`);
   }
 
   return Component({

--- a/src/utils/numberformatter.js
+++ b/src/utils/numberformatter.js
@@ -8,7 +8,10 @@ export default function numberFormatter(numberToFormat, localization) {
     nr = Math.round(nr / factor) * factor;
   }
 
-  // Format acc to locale
-  const formatter = localization?.getCurrentLocaleId() ? new Intl.NumberFormat(localization?.getCurrentLocaleId()) : new Intl.NumberFormat();
-  return formatter.format(nr);
+  // Format acc to locale if localization object was provided
+  if (localization) {
+    const formatter = new Intl.NumberFormat(localization.getCurrentLocaleId());
+    nr = formatter.format(nr);
+  }
+  return nr;
 }


### PR DESCRIPTION
This proposed change reverts some of the localization from the scalepicker control and makes the numberformatter not attempt to localize the number it produces if no localization object accompanies the invocation.

The target is to make print's and the scalepicker's scale selectors work again (regardless of the currently chosen language) and as such fix #2192 

(To localize the scale selector numbers I believe #2193 needs to be remedied first)