### PR TITLE
feature: make dropdown list able to support a label and a value

### DIFF
--- a/src/ui/dropdown.js
+++ b/src/ui/dropdown.js
@@ -31,11 +31,13 @@ export default function Dropdown(options = {}) {
 
   const style = createStyle(styleSettings);
 
-  const selectItem = function selectItem(item, doClick = true) {
+  const selectItem = function selectItem(itemEl, doClick = true) {
+    const value = document.getElementById(itemEl.getId()).getAttribute('data-value');
     const customEvt = new CustomEvent('dropdown:select', {
-      bubbles: true
+      bubbles: true,
+      detail: value // Pass the value in the event detail
     });
-    document.getElementById(item.getId()).dispatchEvent(customEvt);
+    document.getElementById(itemEl.getId()).dispatchEvent(customEvt);
     if (doClick) dropdownButton.dispatch('click');
   };
 
@@ -51,15 +53,23 @@ export default function Dropdown(options = {}) {
   };
 
   const setItems = function setItems(listItems) {
-    items = listItems;
+    // Check if listItems are strings and if so then convert them to objects for backward compatibility
+    items = listItems.map(item => {
+      if (typeof item === 'string') {
+        return { label: item, value: item };
+      }
+      return item;
+    });
+
     const contentEl = document.getElementById(contentComponent.getId());
     if (contentEl) {
       contentComponent.clearComponents();
       contentEl.replaceChildren();
-      listItems.forEach((listItem) => {
+      items.forEach((listItem) => {
         const itemEl = El({
           tagName: 'li',
-          innerHTML: `<span>${listItem}</span>`
+          innerHTML: `<span>${listItem.label}</span>`, // Use label for display
+          attributes: { data: { value: listItem.value } } // Employ the data prop for the value (will become a data-value attribute)
         });
         contentComponent.addComponent(itemEl);
         contentEl.appendChild(html(itemEl.render()));


### PR DESCRIPTION
Aims to fix #2193 by introducing a `data-` attribute to the dropdown item element.

The scalepicker could then do this 
```js
dropdown.setItems([
 { label: '1:100,000',
   value: 1000
 },
 {
  label: '1:25,000',
  value: 25000
 }
 ])
```

instead of this
```js
dropdown.setItems([
'10,000',
'25,000'])
```

And listeners for dropdown select actions:
```js
.addEventListener('dropdown:select', (evt) => {
```
could access the value via the `evt.detail` prop.

For scale selectors this would enable us to localize the numbers without breaking their functionality depending on what locale were chosen.

Draft PR because linked issue not classified (no pr accepted status yet) 
