### PR TITLE
Use icon rotation from attribute if referenced

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -333,7 +333,7 @@ function checkOptions(options = {}) {
         }
         if (element.icon && Object.prototype.hasOwnProperty.call(element.icon, 'rotation')) {
           let degrees;
-          const rotationFromAttribute = typeof element.icon.rotation === "string" && element.icon.rotation.match(/{{(.+)}}/i)[1];
+          const rotationFromAttribute = typeof element.icon.rotation === 'string' && element.icon.rotation.match(/^{{(.+)}}$/i)[1];
           if (rotationFromAttribute) {
             degrees = feature.getProperties()[rotationFromAttribute] || 0;
           } else {

--- a/src/style.js
+++ b/src/style.js
@@ -332,7 +332,13 @@ function checkOptions(options = {}) {
           styleList[j][index].getText().setText(replacer.replace(element.text.text, feature.getProperties()));
         }
         if (element.icon && Object.prototype.hasOwnProperty.call(element.icon, 'rotation')) {
-          const degrees = replacer.replace(element.icon.rotation, feature.getProperties());
+          let degrees;
+          const rotationFromAttribute = typeof element.icon.rotation === "string" && element.icon.rotation.match(/{{(.+)}}/i)[1];
+          if (rotationFromAttribute) {
+            degrees = feature.getProperties()[rotationFromAttribute] || 0;
+          } else {
+            degrees = replacer.replace(element.icon.rotation, feature.getProperties());
+          }
           const radians = degrees * (Math.PI / 180);
           styleList[j][index].getImage().setRotation(radians);
         }


### PR DESCRIPTION
Fixes #2208.

Allows setting an icon style like so;
```
{
  "label": "Origokommuner",
  "icon": {
    "size": [32,32],
    "src": "img/geolocation_marker_heading.png",
    "rotation": "{{rotation_attribute}}"
  }
}
```

If the referenced attribute does not exist, the rotation defaults to 0.