### PR TITLE
Add configuration option to icon styles: referenceMapScale, minScale, maxScale

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -336,6 +336,16 @@ function checkOptions(options = {}) {
           const radians = degrees * (Math.PI / 180);
           styleList[j][index].getImage().setRotation(radians);
         }
+        if (element.icon?.referenceMapScale) {
+          let iconScale = element.icon.referenceMapScale / scale;
+          if (element.icon.maxScale) {
+            iconScale = Math.min(iconScale, element.icon.maxScale);
+          }
+          if (element.icon.minScale) {
+            iconScale = Math.max(iconScale, element.icon.minScale);
+          }
+          styleList[j][index].getImage().setScale(iconScale);
+        }
         return null;
       });
       if (Object.prototype.hasOwnProperty.call(s[j][0], 'filter')) {


### PR DESCRIPTION
Fixes #2210.

Lets icons grow and shrink when a user zooms in and out in the map.
<pre>
"origo-logo": [
      [
        {
          "label": "Origokommuner",
          "icon": {
            "src": "img/kompass.svg",
            <b>"referenceMapScale": 50000,
            "minScale": 0.01,
            "maxScale": 0.2</b>
          }
        }
      ]
    ],
</pre>

- _referenceMapScale_ defines the map scale at which the icon will be displayed at its normal size (provide the map scale denominator as a number, e g `10000` for a reference map scale of 1:10 000).
- _minScale_ defines how small the icon is allowed to be relative to its normal size.
- _maxScale_ defines how large the icon is allowed to be relative to its normal size.

Also, if the `"updateWhileAnimating": true` property is added to a layer with an icon style with a referenceMapScale will make the scaling of the icons smooth as the user zooms:
<pre>
"layers": [
    {
      "name": "origo-cities",
      "title": "Origokommuner",
      "group": "root",
      "source": "data/origo-cities-3857.geojson",
      "style": "origo-logo",
      <b>"updateWhileAnimating": true,</b>
      "type": "GEOJSON",
      [...]
</pre>