### PR TITLE
feature: add svg markers to draw style

### DIFF
--- a/src/style/drawstyles.js
+++ b/src/style/drawstyles.js
@@ -15,7 +15,7 @@ function isValidRgbaString(colorString) {
   return regex.test(colorString);
 }
 
-function createRegularShape(type, pointSize, pointFill, pointStroke, pointRotation, svgMarkers) {
+function createRegularShape(type, pointSize, pointFill, pointStroke, pointRotation, extraMarkers) {
   let style;
   const size = pointSize || 10;
   const stroke = pointStroke || new Stroke({
@@ -25,7 +25,7 @@ function createRegularShape(type, pointSize, pointFill, pointStroke, pointRotati
     color: 'rgba(0, 153, 255, 0.8)'
   });
   const rotation = pointRotation || 0;
-  const foundMarker = svgMarkers.find(({ name }) => name === type);
+  const foundMarker = extraMarkers.find(({ name }) => name === type);
   switch (type) {
     case 'square':
       style = new Style({
@@ -131,7 +131,7 @@ function createRegularShape(type, pointSize, pointFill, pointStroke, pointRotati
     }
 
     default:
-      // Check if there is a corresponding SVG marker.
+      // Check if there is a corresponding extra marker.
       if (foundMarker) {
         let fillColor = 'blue';
         let strokeColor = 'black';
@@ -146,23 +146,38 @@ function createRegularShape(type, pointSize, pointFill, pointStroke, pointRotati
           strokeColor = encodeURIComponent(stroke.getColor());
         }
 
-        // Create and modify SVG string
-        let svg = foundMarker.svg;
-        svg = svg.replace('$fillColor$', fillColor)
-          .replace('$strokeColor$', strokeColor)
-          .replace('$height$', 15 + size)
-          .replace('$width$', 15 + size);
-
-        // Create style with an SVG icon
-        style = new Style({
-          image: new Icon({
-            src: `data:image/svg+xml;utf8,${svg}`,
-            scale: 1,
-            rotation: (rotation / 360) * Math.PI,
-            anchor: [0.5, 0.85],
-            color: fill.getColor()
-          })
-        });
+        let src = foundMarker.src;
+        switch (foundMarker.type) {
+          case 'svg':
+            src = src.replace('$fillColor$', fillColor)
+              .replace('$strokeColor$', strokeColor)
+              .replace('$height$', 15 + size)
+              .replace('$width$', 15 + size);
+            // Create style with an svg icon
+            style = new Style({
+              image: new Icon({
+                src,
+                scale: 1,
+                rotation: (rotation / 360) * Math.PI,
+                anchor: [0.5, 0.85],
+                color: fill.getColor()
+              })
+            });
+            break;
+          case 'image':
+            // Create style with an png icon
+            style = new Style({
+              image: new Icon({
+                src,
+                scale: foundMarker.scale ? foundMarker.scale : 1,
+                rotation: (rotation / 360) * Math.PI,
+                anchor: [0.5, 0.85]
+              })
+            });
+            break;
+          default:
+            break;
+        }
       } else {
         // Fallback to default CircleStyle
         style = new Style({

--- a/src/style/styletemplate.js
+++ b/src/style/styletemplate.js
@@ -1,4 +1,4 @@
-export default function styleTemplate({ palette, swStyle, localization, svgMarkers }) {
+export default function styleTemplate({ palette, swStyle, localization, extraMarkers }) {
   function localize(key) {
     return localization.getStringByKeys({ targetParentKey: 'styleTemplate', targetKey: key });
   }
@@ -109,9 +109,9 @@ export default function styleTemplate({ palette, swStyle, localization, svgMarke
     </select>
   </div></div>`;
 
-  const arrSvgMarkers = [];
-  svgMarkers.forEach(marker => {
-    arrSvgMarkers.push(`<option value="${marker.name}">${marker.title}</option>`);
+  const arrExtraMarkers = [];
+  extraMarkers.forEach(marker => {
+    arrExtraMarkers.push(`<option value="${marker.name}">${marker.title}</option>`);
   });
   const pointHtml = `<div id="o-draw-style-point" class="padding border-bottom"><div class="text-large text-align-center">${localize('point')}</div><div class="padding-smaller o-tooltip active">
     <input id="o-draw-style-pointSizeSlider" type="range" min="1" max="50" value="${swStyle.pointSize}" step="1">
@@ -130,7 +130,7 @@ export default function styleTemplate({ palette, swStyle, localization, svgMarke
       <option value="triangle"${swStyle.pointType === 'triangle' ? ' selected' : ''}>${localize('pointTypeTriangle')}</option>
       <option value="square"${swStyle.pointType === 'square' ? ' selected' : ''}>${localize('pointTypeSquare')}</option>
       <option value="marker"${swStyle.pointType === 'marker' ? ' selected' : ''}>${localize('pointTypeMarker')}</option>
-      ${arrSvgMarkers.join('')}
+      ${arrExtraMarkers.join('')}
     </select>
   </div></div>`;
 

--- a/src/style/stylewindow.js
+++ b/src/style/stylewindow.js
@@ -24,7 +24,7 @@ const Stylewindow = function Stylewindow(optOptions = {}) {
     viewer,
     closeIcon = '#ic_close_24px',
     palette = ['rgb(166,206,227)', 'rgb(31,120,180)', 'rgb(178,223,138)', 'rgb(51,160,44)', 'rgb(251,154,153)', 'rgb(227,26,28)', 'rgb(253,191,111)'],
-    svgMarkers = []
+    extraMarkers = []
   } = optOptions;
 
   let annotationField;
@@ -499,7 +499,7 @@ const Stylewindow = function Stylewindow(optOptions = {}) {
         break;
       case 'Point':
       case 'MultiPoint':
-        style[0] = drawStyles.createRegularShape(newStyleObj.pointType, newStyleObj.pointSize, fill, stroke, newStyleObj.objRotation, svgMarkers);
+        style[0] = drawStyles.createRegularShape(newStyleObj.pointType, newStyleObj.pointSize, fill, stroke, newStyleObj.objRotation, extraMarkers);
         break;
       case 'TextPoint':
         style[0] = new Style({
@@ -725,7 +725,7 @@ const Stylewindow = function Stylewindow(optOptions = {}) {
 
       contentEl = Element({
         cls: 'o-draw-stylewindow-content overflow-auto',
-        innerHTML: `${styleTemplate({ palette, swStyle, localization, svgMarkers })}`
+        innerHTML: `${styleTemplate({ palette, swStyle, localization, extraMarkers })}`
       });
 
       this.addComponent(headerEl);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -57,8 +57,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
     tileGridOptions = {},
     loggerOptions = {},
     url,
-    palette,
-    svgMarkers
+    palette
   } = options;
 
   let {
@@ -571,7 +570,7 @@ const Viewer = function Viewer(targetOption, options = {}) {
       }));
 
       tileGrid = maputils.tileGrid(tileGridSettings);
-      stylewindow = Stylewindow({ palette, viewer: this, localization: controls.find((control) => control.name === 'localization'), svgMarkers });
+      stylewindow = Stylewindow({ palette, viewer: this, localization: controls.find((control) => control.name === 'localization'), extraMarkers: controls.find((control) => control.name === 'draw').options.extraMarkers });
 
       setMap(Map(Object.assign(options, { projection, center, zoom, target: this.getId() })));
 


### PR DESCRIPTION
Adds the possibility to define SVG markers for the draw tool.
Relates to #2201 

Config in the basic settings:
```
"svgMarkers": [
    {"name":"dricksvatten","title":"Dricksvatten","svg":"<svg xmlns='http://www.w3.org/2000/svg' height='$height$' width='$width$' viewBox='0 0 20.13 20.13'><path stroke='$strokeColor$' fill='$fillColor$' class='cls-2' d='M7.6,1.49H.85V4.34H6.68V6.05H9.94V3.83A2.34,2.34,0,0,0,7.6,1.49ZM5.17,8.13a.75.75,0,0,0-.12.41L6,17.83l0,.59h8.93l.05-.59.9-9.29a.69.69,0,0,0-.13-.41A.71.71,0,0,0,15.29,8H5.66A.76.76,0,0,0,5.17,8.13ZM15,11.84c-5,3.26-4-1.05-9,.28L5.66,8.54h9.63Z' id='path11' /></svg>"},
    {"name":"mat","title":"Mat","svg":"<svg xmlns='http://www.w3.org/2000/svg' height='$height$' width='$width$' viewBox='0 0 20.13 20.13'><path stroke='$strokeColor$' fill='$fillColor$' class='cls-2' d='M8.28,10.55,7.34,9.5a.23.23,0,0,0-.28-.05A3.54,3.54,0,0,1,3.14,8.38C1.67,6.91,1.32,4.76,2.46,3.6s3.3-.79,4.77.68A3.54,3.54,0,0,1,8.3,8.2a.25.25,0,0,0,.07.29l1.1,1ZM4.21,15l7.44-6.62a.18.18,0,0,0,0-.26,2.06,2.06,0,0,1,.63-2.83l3-2.47a.42.42,0,0,1,.57,0,.4.4,0,0,1,0,.57L13.39,5.88a.39.39,0,0,0,0,.59l0,0a.39.39,0,0,0,.59,0L16.48,4a.41.41,0,0,1,.58,0,.4.4,0,0,1,0,.57L14.57,7a.43.43,0,0,0,.61.6l2.48-2.46a.35.35,0,0,1,.55,0,.35.35,0,0,1,0,.55l-2.44,3a2.05,2.05,0,0,1-2.84.63.19.19,0,0,0-.27,0L6,16.84a1.13,1.13,0,0,1-1.82,0A1.14,1.14,0,0,1,4.21,15Zm6.17-2.09,1.3-1.47,4,3.56a1.13,1.13,0,0,1,0,1.83,1.13,1.13,0,0,1-1.82,0Z' /></svg>"}
  ]
```

![SVGMarker](https://github.com/user-attachments/assets/23a350d1-8fbb-473d-9dde-8a12e262ced6)
