### PR TITLE
feature: localize scalepicker (round two)

### DIFF
--- a/src/controls/scalepicker.js
+++ b/src/controls/scalepicker.js
@@ -18,18 +18,23 @@ const Scalepicker = function Scalepicker(options = {}) {
   }
 
   function getScales() {
-    return resolutions.map(resolution => `${listItemPrefix}${mapUtils.resolutionToFormattedScale(resolution, projection)}`);
+    const theScales = resolutions.map(resolution => {
+      const scale = mapUtils.resolutionToScale(resolution, projection);
+      return {
+        label: `${listItemPrefix}${mapUtils.resolutionToFormattedScale(resolution, projection, localization)}`,
+        value: scale
+      };
+    });
+    return theScales;
   }
 
   function setMapScale(scale) {
-    const scaleDenominator = parseInt(scale.replace(/\s+/g, '').split(':').pop(), 10);
-    const resolution = mapUtils.scaleToResolution(scaleDenominator, projection);
-
+    const resolution = mapUtils.scaleToResolution(scale, projection);
     map.getView().animate({ resolution });
   }
 
   function onZoomChange() {
-    dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection)}`);
+    dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection, localization)}`);
   }
 
   return Component({
@@ -44,7 +49,7 @@ const Scalepicker = function Scalepicker(options = {}) {
       this.addComponent(dropdown);
       this.render();
 
-      dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection)}`);
+      dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection, localization)}`);
       dropdown.setItems(getScales());
 
       map.getView().on('change:resolution', onZoomChange);
@@ -71,7 +76,7 @@ const Scalepicker = function Scalepicker(options = {}) {
       this.dispatch('render');
 
       document.getElementById(dropdown.getId()).addEventListener('dropdown:select', (evt) => {
-        setMapScale(evt.target.textContent);
+        setMapScale(evt.detail.value);
       });
     }
   });

--- a/src/controls/scalepicker.js
+++ b/src/controls/scalepicker.js
@@ -3,8 +3,7 @@ import mapUtils from '../maputils';
 
 const Scalepicker = function Scalepicker(options = {}) {
   const {
-    buttonPrefix = '',
-    listItemPrefix = '',
+
     localization
   } = options;
   let map;
@@ -21,7 +20,7 @@ const Scalepicker = function Scalepicker(options = {}) {
     const theScales = resolutions.map(resolution => {
       const scale = mapUtils.resolutionToScale(resolution, projection);
       return {
-        label: `${listItemPrefix}${mapUtils.resolutionToFormattedScale(resolution, projection, localization)}`,
+        label: `${localize('scaleListItemPrefix')}${mapUtils.resolutionToFormattedScale(resolution, projection, localization)}`,
         value: scale
       };
     });
@@ -34,7 +33,7 @@ const Scalepicker = function Scalepicker(options = {}) {
   }
 
   function onZoomChange() {
-    dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection, localization)}`);
+    dropdown.setButtonText(`${localize('buttonPrefix')}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection, localization)}`);
   }
 
   return Component({
@@ -49,7 +48,7 @@ const Scalepicker = function Scalepicker(options = {}) {
       this.addComponent(dropdown);
       this.render();
 
-      dropdown.setButtonText(`${buttonPrefix}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection, localization)}`);
+      dropdown.setButtonText(`${localize('buttonPrefix')}${mapUtils.resolutionToFormattedScale(map.getView().getResolution(), projection, localization)}`);
       dropdown.setItems(getScales());
 
       map.getView().on('change:resolution', onZoomChange);

--- a/src/loc/en_US.json
+++ b/src/loc/en_US.json
@@ -174,7 +174,9 @@
             "scaleText": "Scale 1:"
         },
         "scalepicker": {
-            "selectScaleAriaLabel": "Pick scale"
+            "selectScaleAriaLabel": "Pick scale",
+            "buttonPrefix": "",
+            "scaleListItemPrefix": ""
         },
         "position": {
             "characterError": "Invalid character for coordinate, please try again.",

--- a/src/loc/sv_SE.json
+++ b/src/loc/sv_SE.json
@@ -174,7 +174,9 @@
             "scaleText": "Skala 1:"
         },
         "scalepicker": {
-            "selectScaleAriaLabel": "Välj skala"
+            "selectScaleAriaLabel": "Välj skala",
+            "buttonPrefix": "",
+            "scaleListItemPrefix": ""
         },
         "position": {
             "characterError": "Ogiltigt tecken för koordinat, vänligen försök igen.",


### PR DESCRIPTION
Aims to fix #2219 .

I have moved the two configurable strings into localization, else if configured they will remain static as the language is changed. It is a kind of breaking change but they are optional and I think it's better this way.