### PR TITLE
Editor defaultvalue from json property in session or local storage

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -150,6 +150,17 @@ function getDefaultValueForAttribute(attribConf) {
       return sessionStorage.getItem(defaultsConfig.key);
     } else if (defaultsConfig.type === 'localStorage') {
       return localStorage.getItem(defaultsConfig.key);
+    } else if (defaultsConfig.type === 'sessionStorageJSON' || defaultsConfig.type === 'localStorageJSON') {
+      let keys = defaultsConfig.key.split('.');
+      let result = JSON.parse(
+        defaultsConfig.type === 'sessionStorageJSON' ? sessionStorage.getItem(keys.shift()) : localStorage.getItem(keys.shift())
+      );
+      while (result && keys.length) {
+        if (result[keys[0]]) {
+          result = result[keys.shift()];
+        } 
+      }
+      return result;
     } else if (defaultsConfig.type === 'timestamp') {
       // If an exact timestamp is needed, use a database default or trigger, this is taken when editor opens
       const today = new Date();

--- a/src/utils/searchjson.js
+++ b/src/utils/searchjson.js
@@ -1,0 +1,16 @@
+/**
+ * Finds and returns a value from a JSON string using simple dot-notation.
+ *
+ * @param {string} jsonstring A string containing JSON
+ * @param {string} key A key to the target value using simple dot-notation, e g "myobject.firstchild[1].targetvalue"
+ * @returns {string} The value found
+ */
+export default function searchjson(jsonstring, key) {
+  const keys = key.split(/[.[\]]/).filter((k) => k !== '');
+  let result = JSON.parse(jsonstring) || jsonstring;
+
+  while (keys.length && result != null) {
+    result = result[keys.shift()];
+  }
+  return result;
+}


### PR DESCRIPTION
Fixes #2218.

Adds the possibility to extract a subvalue from a returned JSON object when getting editor default values from sessionStorage or localStorage.

Now, by specifying the parameter `"keyType": "json_path"` and using simple dot-notation in the `key` parameter, values can be extracted from anywhere within the response, provided it can be parsed as JSON. It also works with array indices (e g `sessionStorageVariable[2].object.array[0].value`).

Config example:
```
"attributes": [
  {
    "name": "skapad_av",
    "title": "Skapad av: ",
    "type": "hidden",
    "defaultValue": {
      "type": "sessionStorage",
      "keyType": "json_path",
      "key": "oidc_user.displayname",
      "updateOnEdit": false
    }
  }
]
```