### PR TITLE
feature: localize the print scale selector

### DIFF
--- a/src/controls/print/index.js
+++ b/src/controls/print/index.js
@@ -133,8 +133,7 @@ const Print = function Print(options = {}) {
         mapInteractionsActive,
         supressResolutionsRecalculation,
         suppressNewDPIMethod,
-        localize,
-        localeId: localization.getCurrentLocaleId()
+        localization
       });
       if (placement.indexOf('screen') > -1) {
         mapTools = `${viewer.getMain().getMapTools().getId()}`;

--- a/src/controls/print/print-component.js
+++ b/src/controls/print/print-component.js
@@ -95,7 +95,7 @@ const PrintComponent = function PrintComponent(options = {}) {
 
   if (!Array.isArray(scales) || scales.length === 0) {
     scales = originalResolutions.map(currRes => {
-      const unlocalizedScaleLabel = maputils.resolutionToFormattedScale(currRes, viewer.getProjection()); // it's a pretty thankless job to interpret a localized scale string and it shouldn't need to be done
+      const unlocalizedScaleLabel = maputils.resolutionToFormattedScale(currRes, viewer.getProjection());
       const value = maputils.formattedScaleToScaleDenominator(unlocalizedScaleLabel);
       const label = maputils.resolutionToFormattedScale(currRes, viewer.getProjection(), localization);
       return { label, value };
@@ -238,7 +238,7 @@ const PrintComponent = function PrintComponent(options = {}) {
   };
 
   const created = function created() {
-    return showCreated ? `${createdPrefix}${today.toLocaleDateString(localeId)} ${today.toLocaleTimeString(localeId)}` : '';
+    return showCreated ? `${createdPrefix}${today.toLocaleDateString(localization.getCurrentLocaleId())} ${today.toLocaleTimeString(localization.getCurrentLocaleId())}` : '';
   };
 
   const titleComponent = Component({

--- a/src/controls/print/print-interaction-toggle.js
+++ b/src/controls/print/print-interaction-toggle.js
@@ -10,8 +10,12 @@ export default function PrintInteractionToggle(options = {}) {
     toggleIcon = '#ic_map_24px',
     mapInteractionsActive,
     pageSettings,
-    localize
+    localization
   } = options;
+
+  function localize(key) {
+    return localization.getStringByKeys({ targetParentKey: 'print', targetKey: key });
+  }
 
   const interactions = mapInteractions({ target, mapInteractions: pageSettings && pageSettings.mapInteractions ? pageSettings.mapInteractions : {} });
   let mapInteractionToggleButton;

--- a/src/controls/print/print-settings.js
+++ b/src/controls/print/print-settings.js
@@ -52,7 +52,7 @@ const PrintSettings = function PrintSettings(options = {}) {
     showPrintLegend,
     rotation,
     rotationStep,
-    localize
+    localization
   } = options;
 
   let headerComponent;
@@ -65,6 +65,10 @@ const PrintSettings = function PrintSettings(options = {}) {
   let printLegendControl;
   let rotationControl;
   let setScaleControl;
+
+  const localize = function localize(key) {
+    return localization.getStringByKeys({ targetParentKey: 'print', targetKey: key });
+  };
 
   // Set tabindex for all settings buttons to include or exclude in taborder depending on if expanded or not
   const setTabIndex = function setTabIndex() {
@@ -188,7 +192,7 @@ const PrintSettings = function PrintSettings(options = {}) {
       setScaleControl = SetScaleControl(map, {
         scales,
         initialScale: scaleInitial,
-        localize
+        localization
       });
 
       contentComponent = Component({

--- a/src/controls/print/print-toolbar.js
+++ b/src/controls/print/print-toolbar.js
@@ -1,6 +1,10 @@
 import { Button, Component } from '../../ui';
 
-const PrintToolbar = function PrintToolbar({ localize }) {
+const PrintToolbar = function PrintToolbar({ localization }) {
+  const localize = function localize(key) {
+    return localization.getStringByKeys({ targetParentKey: 'print', targetKey: key });
+  };
+
   const pngButton = Button({
     cls: 'light text-smaller padding-left-large',
     text: localize('pngButtonTitle')

--- a/src/controls/print/set-scale-control.js
+++ b/src/controls/print/set-scale-control.js
@@ -27,7 +27,7 @@ export default function SetScaleControl(map, options = {}) {
       this.addComponents([selectScale]);
     },
     onChangeScale(evt) {
-      this.dispatch('change:scale', { scale: evt.value / 1000 }); // 10000 blir till scale: 10 ..och nånting här sätter buttonText för selectScale
+      this.dispatch('change:scale', { scale: evt.value / 1000 });
     },
     onRender() {
       this.dispatch('render');

--- a/src/controls/print/set-scale-control.js
+++ b/src/controls/print/set-scale-control.js
@@ -5,18 +5,14 @@ export default function SetScaleControl(map, options = {}) {
   const {
     scales = [],
     initialScale,
-    localize
+    localization
   } = options;
 
   let selectScale;
 
-  /**
-   * Parses a formatted scale string and returns the denominator as a number
-   * @param {any} scale
-   */
-  function parseScale(scale) {
-    return parseInt(scale.replace(/\s+/g, '').split(':').pop(), 10);
-  }
+  const localize = function localize(key) {
+    return localization.getStringByKeys({ targetParentKey: 'print', targetKey: key });
+  };
 
   return Component({
     onInit() {
@@ -31,24 +27,29 @@ export default function SetScaleControl(map, options = {}) {
       this.addComponents([selectScale]);
     },
     onChangeScale(evt) {
-      const scaleDenominator = parseScale(evt);
-      this.dispatch('change:scale', { scale: scaleDenominator / 1000 });
-      selectScale.setButtonText(evt);
+      this.dispatch('change:scale', { scale: evt.value / 1000 }); // 10000 blir till scale: 10 ..och nånting här sätter buttonText för selectScale
     },
     onRender() {
       this.dispatch('render');
       selectScale.setItems(scales);
       document.getElementById(selectScale.getId()).addEventListener('dropdown:select', (evt) => {
-        this.onChangeScale(evt.target.textContent);
+        this.onChangeScale(evt.detail);
       });
       if (initialScale) {
-        this.onChangeScale(initialScale);
+        const scaleDenominator = mapUtils.formattedScaleToScaleDenominator(initialScale);
+        this.onChangeScale({
+          label: mapUtils.formatScale(scaleDenominator, localization),
+          value: scaleDenominator
+        });
       } else {
         const viewResolution = map.getView().getResolution();
         const projection = map.getView().getProjection();
         const mapScale = mapUtils.resolutionToScale(viewResolution, projection);
-        const closest = scales.reduce((prev, curr) => (Math.abs(parseScale(curr) - mapScale) < Math.abs(parseScale(prev) - mapScale) ? curr : prev));
-        this.onChangeScale(closest);
+        const closest = scales.reduce((prev, curr) => ((Math.abs(curr.value - mapScale)) < (Math.abs(prev.value - mapScale)) ? curr : prev));
+        this.onChangeScale({
+          label: mapUtils.formatScale(closest.value, localization),
+          value: closest.value
+        });
       }
     },
     render() {

--- a/src/maputils.js
+++ b/src/maputils.js
@@ -140,9 +140,9 @@ const maputils = {
     const resolution = scale / (mpu * 39.37 * dpi);
     return resolution;
   },
-  formatScale: function formatScale(scale) {
+  formatScale: function formatScale(scale, localization) {
     const roundedScale = Math.round(scale / 10) * 10;
-    return `1:${numberFormatter(roundedScale)}`;
+    return `1:${numberFormatter(roundedScale, localization)}`;
   },
   roundScale: function roundScale(scale) {
     let scaleValue = scale;
@@ -151,6 +151,15 @@ const maputils = {
       scaleValue += (10 - differens);
     }
     return scaleValue;
+  },
+
+  /**
+   * Returns the denominator of a scale string, e.g. 1:10000 => 10000
+   * @param {string} scaleString The scale string to parse. Must be of print conf form (not localized).
+   * @returns {number} The denominator of the scale string
+   */
+  formattedScaleToScaleDenominator: function formattedScaleToScaleDenominator(scaleString) {
+    return parseInt(scaleString.replace(/\s+/g, '').split(':').pop(), 10);
   },
   createMarker: function createMarker(coordinates, title, content, viewer, layerProps = {}, showPopup = true) {
     const {


### PR DESCRIPTION
This is proposed to fix #2220 

There is a minor annoyance that has been mentioned before which is the `olScaleLine` (the scale bar in the print preview). Currently it is being added with a `true` `text` prop and the localization of this scale string follows the browser.  I could try to subclass `ol/control/ScaleLine` but that comes with its own set of responsibilities. To the user however it would provide a more consistent experience.