### PR TITLE
fix: check if layer is secure before making visible

### DIFF
--- a/src/controls/legend/group.js
+++ b/src/controls/legend/group.js
@@ -355,7 +355,9 @@ const Group = function Group(viewer, options = {}) {
           const overlays = groupList.getOverlays();
           overlays.forEach((overlay) => {
             const layer = overlay.getLayer();
-            layer.setVisible(true);
+            if (!layer.get('secure')) {
+              layer.setVisible(true);
+            }
           });
           const groups = groupList.getGroups();
           groups.forEach((group) => {


### PR DESCRIPTION
Closes #2231 