### PR TITLE
feature: make logger toastr manually closable

### DIFF
--- a/src/components/logger.js
+++ b/src/components/logger.js
@@ -85,9 +85,14 @@ const createToast = function createToast(options = {}) {
   `;
   toast.innerHTML = content;
 
-  setTimeout(() => {
+  const timeout = setTimeout(() => {
     toast.parentNode.removeChild(toast);
   }, duration > 0 ? duration : 5000);
+
+  toast.addEventListener('click', () => {
+    clearTimeout(timeout);
+    toast.parentNode.removeChild(toast);
+  });
 };
 
 const Logger = function Logger(options = {}) {


### PR DESCRIPTION
Seeks to close #2249 
(should work with touch event too, at least in ff's simulated it does)