### PR TITLE
Text wrap, divider lines and flexible width in dropdown

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -1,8 +1,14 @@
 @mixin default {
     .o-dropdown li {
-        height: 1.5rem;
         line-height: 1.5rem;
         padding: .25rem .75rem;
+    }
+
+    .o-dropdown hr {
+        border: 0;
+        border-bottom: 1px dotted #00000033;
+        margin-left: 10px;
+        margin-right: 10px;
     }
 
     .o-dropdown li:hover {

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -13,14 +13,16 @@
         border-radius: 6px;
         bottom: 100%;
         box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-        box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
         box-sizing: border-box;
         display: none;
         left: 50%;
-        margin: 0 0 10px -125px;
+        transform: translate(-50%, 0);
+        margin: 0 0 10px 0;
         padding: .5rem 0;
         position: absolute;
-        width: 250px;
+        width: max-content;
+        min-width: min(100vw - 20px, 140px);
+        max-width: min(100vw - 20px, 320px);
     }
 
     .o-popover::before,

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -29,7 +29,7 @@ export default function dropDown(target, items, options) {
       }
       li[index] = utils.createElement('li', item.name + active, obj);
     });
-    ul = utils.createElement('ul', li.join(''), {
+    ul = utils.createElement('ul', li.join('<hr/>'), {
       cls: 'o-dropdown'
     });
 


### PR DESCRIPTION
Fixes #2246.

Adjusts the dropdown used for tool selection in the draw and editor controls, and the layer selector in the editor.

Allows the width to fit its content between 140 px and 320 px and allows ling layer titles to wrap to multiple lines. In order to still be able to visually distinguish layers, a faint divider line was added between items.