### PR TITLE
fix: add branches filter to demo map workflow

### DIFF
--- a/.github/workflows/demo_map_workflow.yml
+++ b/.github/workflows/demo_map_workflow.yml
@@ -2,7 +2,7 @@ name: Sync default member layer files to demo map
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - 'data/origo-cities-3857.geojson'
       - 'data/origo-mask-3857.geojson'

--- a/.github/workflows/demo_map_workflow.yml
+++ b/.github/workflows/demo_map_workflow.yml
@@ -1,6 +1,8 @@
 name: Sync default member layer files to demo map
 on:
   push:
+    branches:
+      - main
     paths:
       - 'data/origo-cities-3857.geojson'
       - 'data/origo-mask-3857.geojson'


### PR DESCRIPTION
Seeks to fix #2301 . 

This seems to be what the docs say 
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore

(on.push.paths and on.push.branches)