### PR TITLE
Add layer type COG

### DIFF
--- a/src/layer/cog.js
+++ b/src/layer/cog.js
@@ -1,0 +1,64 @@
+import GeoTIFFSource from 'ol/source/GeoTIFF';
+import WebGLTile from 'ol/layer/WebGLTile';
+
+function createSource(sourceInfo, sourceOptions, geoTIFFOptions = {}) {
+  return new GeoTIFFSource(Object.assign({}, geoTIFFOptions, {
+    sources: [sourceInfo],
+    sourceOptions
+  }));
+}
+
+const cog = function cog(layerOptions, viewer) {
+  const cogDefault = {
+    layerType: 'tile',
+    crossOrigin: 'anonymous'
+  };
+
+  const cogOptions = Object.assign({}, cogDefault, layerOptions);
+  const mapSource = viewer.getMapSource()[layerOptions.source] || {};
+  const sourceInfo = {};
+  const sourceOptions = {};
+
+  sourceOptions.headers = cogOptions.headers;
+
+  if (cogOptions.source && viewer.getMapSource()[cogOptions.source]) {
+    sourceInfo.url = viewer.getMapSource()[cogOptions.source].url;
+    if (viewer.getMapSource()[cogOptions.source].overviews) {
+      sourceInfo.overviews = viewer.getMapSource()[cogOptions.source].overviews;
+    }
+    cogOptions.sourceName = cogOptions.source;
+  } else if (cogOptions.source) {
+    sourceInfo.url = cogOptions.source;
+    cogOptions.sourceName = cogOptions.source;
+  } else if (cogOptions.url) {
+    sourceInfo.url = cogOptions.url;
+  }
+
+  if (cogOptions.overviews) {
+    sourceInfo.overviews = cogOptions.overviews;
+  }
+
+  if (mapSource.url && !sourceInfo.url) {
+    sourceInfo.url = mapSource.url;
+  }
+  if (mapSource.overviews && !sourceInfo.overviews) {
+    sourceInfo.overviews = mapSource.overviews;
+  }
+
+  const geoTIFFOptions = {};
+  if (cogOptions.projection) {
+    geoTIFFOptions.projection = cogOptions.projection;
+  }
+  if (cogOptions.convertToRGB !== undefined) {
+    geoTIFFOptions.convertToRGB = cogOptions.convertToRGB;
+  }
+  if (cogOptions.normalize !== undefined) {
+    geoTIFFOptions.normalize = cogOptions.normalize;
+  }
+
+  const cogSource = createSource(sourceInfo, sourceOptions, geoTIFFOptions);
+  const options = Object.assign({}, cogOptions, { source: cogSource });
+  return new WebGLTile(options);
+};
+
+export default cog;

--- a/src/layer/cog.js
+++ b/src/layer/cog.js
@@ -11,7 +11,10 @@ function createSource(sourceInfo, sourceOptions, geoTIFFOptions = {}) {
 const cog = function cog(layerOptions, viewer) {
   const cogDefault = {
     layerType: 'tile',
-    crossOrigin: 'anonymous'
+    crossOrigin: 'anonymous',
+    interpolate: true,
+    normalize: true,
+    wrapX: false
   };
 
   const cogOptions = Object.assign({}, cogDefault, layerOptions);
@@ -19,12 +22,34 @@ const cog = function cog(layerOptions, viewer) {
   const sourceInfo = {};
   const sourceOptions = {};
 
-  sourceOptions.headers = cogOptions.headers;
+  if (cogOptions.sourceOptions && typeof cogOptions.sourceOptions === 'object') {
+    Object.assign(sourceOptions, cogOptions.sourceOptions);
+  }
+
+  if (cogOptions.crossOrigin) {
+    sourceOptions.crossOrigin = cogOptions.crossOrigin;
+  }
+
+  if (cogOptions.headers) {
+    sourceOptions.headers = cogOptions.headers;
+  }
 
   if (cogOptions.source && viewer.getMapSource()[cogOptions.source]) {
     sourceInfo.url = viewer.getMapSource()[cogOptions.source].url;
     if (viewer.getMapSource()[cogOptions.source].overviews) {
       sourceInfo.overviews = viewer.getMapSource()[cogOptions.source].overviews;
+    }
+    if (viewer.getMapSource()[cogOptions.source].min !== undefined) {
+      sourceInfo.min = viewer.getMapSource()[cogOptions.source].min;
+    }
+    if (viewer.getMapSource()[cogOptions.source].max !== undefined) {
+      sourceInfo.max = viewer.getMapSource()[cogOptions.source].max;
+    }
+    if (viewer.getMapSource()[cogOptions.source].nodata !== undefined) {
+      sourceInfo.nodata = viewer.getMapSource()[cogOptions.source].nodata;
+    }
+    if (viewer.getMapSource()[cogOptions.source].bands !== undefined) {
+      sourceInfo.bands = viewer.getMapSource()[cogOptions.source].bands;
     }
     cogOptions.sourceName = cogOptions.source;
   } else if (cogOptions.source) {
@@ -37,6 +62,18 @@ const cog = function cog(layerOptions, viewer) {
   if (cogOptions.overviews) {
     sourceInfo.overviews = cogOptions.overviews;
   }
+  if (cogOptions.min !== undefined) {
+    sourceInfo.min = cogOptions.min;
+  }
+  if (cogOptions.max !== undefined) {
+    sourceInfo.max = cogOptions.max;
+  }
+  if (cogOptions.nodata !== undefined) {
+    sourceInfo.nodata = cogOptions.nodata;
+  }
+  if (cogOptions.bands !== undefined) {
+    sourceInfo.bands = cogOptions.bands;
+  }
 
   if (mapSource.url && !sourceInfo.url) {
     sourceInfo.url = mapSource.url;
@@ -46,15 +83,12 @@ const cog = function cog(layerOptions, viewer) {
   }
 
   const geoTIFFOptions = {};
-  if (cogOptions.projection) {
-    geoTIFFOptions.projection = cogOptions.projection;
-  }
-  if (cogOptions.convertToRGB !== undefined) {
-    geoTIFFOptions.convertToRGB = cogOptions.convertToRGB;
-  }
-  if (cogOptions.normalize !== undefined) {
-    geoTIFFOptions.normalize = cogOptions.normalize;
-  }
+
+  ['projection', 'convertToRGB', 'normalize', 'wrapX', 'interpolate', 'transition', 'cacheSize', 'minZoom', 'maxZoom', 'tileSize', 'gutter', 'reprojectionErrorThreshold', 'key'].forEach((option) => {
+    if (cogOptions[option] !== undefined) {
+      geoTIFFOptions[option] = cogOptions[option];
+    }
+  });
 
   const cogSource = createSource(sourceInfo, sourceOptions, geoTIFFOptions);
   const options = Object.assign({}, cogOptions, { source: cogSource });

--- a/src/layer/cog.js
+++ b/src/layer/cog.js
@@ -1,5 +1,5 @@
 import GeoTIFFSource from 'ol/source/GeoTIFF';
-import WebGLTile from 'ol/layer/WebGLTile';
+import webgltile from './webgltile.js';
 
 function createSource(sourceInfo, sourceOptions, geoTIFFOptions = {}) {
   return new GeoTIFFSource(Object.assign({}, geoTIFFOptions, {
@@ -91,8 +91,7 @@ const cog = function cog(layerOptions, viewer) {
   });
 
   const cogSource = createSource(sourceInfo, sourceOptions, geoTIFFOptions);
-  const options = Object.assign({}, cogOptions, { source: cogSource });
-  return new WebGLTile(options);
+  return webgltile(cogOptions, cogSource);
 };
 
 export default cog;

--- a/src/layer/cog.js
+++ b/src/layer/cog.js
@@ -1,5 +1,5 @@
 import GeoTIFFSource from 'ol/source/GeoTIFF';
-import webgltile from './webgltile.js';
+import webgltile from './webgltile';
 
 function createSource(sourceInfo, sourceOptions, geoTIFFOptions = {}) {
   return new GeoTIFFSource(Object.assign({}, geoTIFFOptions, {

--- a/src/layer/layertype.js
+++ b/src/layer/layertype.js
@@ -11,6 +11,7 @@ import agsTile from './agstile';
 import xyz from './xyz';
 import osm from './osm';
 import vectortile from './vectortile';
+import cog from './cog';
 import feature from './featurelayer';
 
 const layerType = {};
@@ -28,6 +29,7 @@ layerType.AGS_TILE = agsTile;
 layerType.XYZ = xyz;
 layerType.OSM = osm;
 layerType.VECTORTILE = vectortile;
+layerType.COG = cog;
 layerType.FEATURE = feature;
 
 export default layerType;

--- a/src/layer/webgltile.js
+++ b/src/layer/webgltile.js
@@ -1,0 +1,5 @@
+import WebGLTile from 'ol/layer/WebGLTile';
+
+export default function webgltile(options, source) {
+  return new WebGLTile(Object.assign({}, options, { source }));
+}


### PR DESCRIPTION
Fixes #2305 

This adds the layertype COG. This is written in part with the help of Claude AI. Please look at how the layer options is set up and if it's integrated correctly with the other layer type.

This requires WebGL to function since it renders arrays of pixels from bytebuffers. WebGL is supported by all major browsers. Also on mobile.

Openlayers does not support COG rendering of skewed and/or rotated images (affine transformed). So any imagery has to unrotated and unskewed to render correctly.