### PR TITLE
fix: show nodes only when modify geometry is allowed

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -858,7 +858,9 @@ function setInteractions(drawType) {
   select = new Select({
     layers: [editLayer],
     multi: !!floatingPanelCmp,
-    style: defaultSelectionStyle
+    // For now just short circuit the style function and use OL default. If the style should be customizable the check
+    // should be performed in the style function
+    style: allowEditGeometry ? defaultSelectionStyle : undefined
   });
   // Dispatch Component event when selection changes. 'change' is never emitted from Collection, so it's both 'add' and 'remove'.
   // select interaction's 'select' event is not fired when the feature collection is manipulated manually, so we take events from


### PR DESCRIPTION
Fixes #2313 by using default symbol if modify geometry is not allowed.

Note that until #2282 is merged testing this PR may look strange as it is possible to highlight features from other layers than the active editor layer, but the symbol should be correct.