### PR TITLE
fix: remove symbology from legend for secure layers

### DIFF
--- a/src/controls/legend/overlay.js
+++ b/src/controls/legend/overlay.js
@@ -2,6 +2,12 @@ import { Component, Button, dom, Collapse } from '../../ui';
 import { HeaderIcon, Legend } from '../../utils/legendmaker';
 import createMoreInfoButton from './moreinfobutton';
 
+/**
+ * Creates a Component that represents one row in the Legend. Includes symbology
+ * and visiblily toggle buttons and context menu etc.
+ * @param {object} options The options to use
+ * @returns {*} A Component
+ */
 const OverlayLayer = function OverlayLayer(options) {
   const {
     headerIconCls = '',
@@ -21,15 +27,17 @@ const OverlayLayer = function OverlayLayer(options) {
 
   const buttons = [];
   let headerIconClass = headerIconCls;
-
-  const hasStylePicker = viewer.getLayerStylePicker(layer).length > 0;
+  // Secure layers don't have StylePickers
+  const secure = layer.get('secure');
+  const hasStylePicker = viewer.getLayerStylePicker(layer).length > 0 && !secure;
   const layerIconCls = `round compact icon-small relative no-shrink light ${hasStylePicker ? 'style-picker' : ''}`;
   const cls = `${clsSettings} flex row align-center padding-left padding-right-smaller item wrap`.trim();
   const title = layer.get('title') || localize('layerTitleMissing');
   const name = layer.get('name');
-  const secure = layer.get('secure');
   let hasExtendedLegend = false;
   let thisComponent;
+  /** Style to use for Legend. Don't mess with incoming style or layer if you want to change in the Legend */
+  let legendStyle = style;
 
   const checkIcon = '#ic_check_circle_24px';
   let uncheckIcon = '#ic_radio_button_unchecked_24px';
@@ -39,11 +47,13 @@ const OverlayLayer = function OverlayLayer(options) {
     // If layer is secure, set it to not visible and not queryable to avoid unnecessary network traffic
     layer.setVisible(false);
     layer.set('queryable', false);
+    // Don't display legend for secure layers as it may involve a query that can be forbidden
+    legendStyle = undefined;
   }
 
   const opacity = layer.getOpacity();
 
-  let headerIcon = HeaderIcon(style, opacity);
+  let headerIcon = HeaderIcon(legendStyle, opacity);
   if (!headerIcon) {
     headerIcon = icon;
     headerIconClass = iconCls;
@@ -76,7 +86,7 @@ const OverlayLayer = function OverlayLayer(options) {
   // Always do this even if there is no extended legend, as user may change symbol later and then its nice to have a placeholder.
   const extendedLegendContent = Component({
     render() {
-      const legendContent = Legend({ styleRules: style, layer, viewer });
+      const legendContent = Legend({ styleRules: legendStyle, layer, viewer });
       if (typeof (legendContent) === 'string') {
         return `<div id="${this.getId()}" class="padding-left">${hasExtendedLegend ? legendContent : ''}</div>`;
       }

--- a/src/controls/legend/overlayproperties.js
+++ b/src/controls/legend/overlayproperties.js
@@ -2,6 +2,11 @@ import { Component, InputRange, Dropdown } from '../../ui';
 import { Legend } from '../../utils/legendmaker';
 import Style from '../../style';
 
+/**
+ * Creates a Component containing the layer properties displayed at the bottom om Legend when Layerinfo is selected
+ * @param {*} options The options to use
+ * @returns {*} A Component
+ */
 const OverlayProperties = function OverlayProperties(options = {}) {
   const {
     cls: clsOptions = '',
@@ -19,6 +24,7 @@ const OverlayProperties = function OverlayProperties(options = {}) {
   let style;
   let legendComponent;
   let stylePicker = [];
+  let secure = false;
   if (layer) {
     cls = `${clsOptions} item`.trim();
     title = layer.get('title') || '';
@@ -26,7 +32,9 @@ const OverlayProperties = function OverlayProperties(options = {}) {
     description = layer.get('description') || '';
     opacity = layer.getOpacity();
     opacityControl = layer.get('opacityControl') !== false;
-    style = viewer.getStyle(layer.get('styleName'));
+    // Use no style at all for secure layers as it may involve a request that will be forbidden
+    secure = !!layer.get('secure');
+    style = secure ? undefined : viewer.getStyle(layer.get('styleName'));
     legendComponent = Legend({ styleRules: style, opacity, layer, viewer, clickable: false });
     stylePicker = viewer.getLayerStylePicker(layer);
   } else if (group) {
@@ -58,7 +66,8 @@ const OverlayProperties = function OverlayProperties(options = {}) {
   }
 
   function hasStylePicker() {
-    return stylePicker.length > 0;
+    // Secure layers should not have StylePicker as it won't work anyway
+    return stylePicker.length > 0 && !secure;
   }
 
   function extendedLegendZoom(e) {


### PR DESCRIPTION
Fixes #2290 

No new configuration.

Symbology in the legend for secure layers is replaced with empty symbol (No legend available) to avoid potential calls to the server which may deny the request. The symbology setting of the layer itself is not affected in order to not mess too much up if someone implements a way to "unsecure" a layer without reloading the map.

A more fine grained approach could have been implemented that only avoid symbols using calls to _getLegendGraphics_, which is the most common problem with secure layers, but since the layer is not visible anyway there is no reason to display symbology even if client side symbology would be possible to display. This allows for a cleaner less layer dependent implementation.

If a secure layer has StylePicker, the StylePicker is not displayed for same reason as above.

PrintLegend is not affected as it only creates legend for visible layers and secure layers are not visible.