### PR TITLE
fix: remove redundant style rule for inputs, selects and textareas

### DIFF
--- a/scss/ui/_input.scss
+++ b/scss/ui/_input.scss
@@ -20,7 +20,6 @@ input {
   line-height: variables.$line-height-base;
   margin-bottom: .375rem;
   padding: $button-padding-medium;
-  resize: vertical;
 
   &.grey {
     background-color: variables.$grey-lightest;


### PR DESCRIPTION
Aims to fix #2330 
(Indeed, the resize prop is included for textarea elements)