### PR TITLE
fix: ensure that interactions are disabled if the editor control is set not to be active at start

### DIFF
--- a/src/controls/editor/edithandler.js
+++ b/src/controls/editor/edithandler.js
@@ -1002,7 +1002,7 @@ function setEditLayer(layerName) {
 function setGeometryProps(layer) {
   const layerName = layer.get('name');
   editLayers[layerName].set('geometryType', layer.getSource().getFeatures()[0].getGeometry().getType());
-  if (layerName === currentLayer) {
+  if (layerName === currentLayer && isActive()) {
     setEditLayer(layerName);
   }
 }


### PR DESCRIPTION
When the editor-control starts it activates the modify interaction even if the option isActive is set to false. The interaction should only be set active when the control itself is active.