### PR TITLE
feat: add support for base64-formatted images in the default info window

### DIFF
--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -127,9 +127,15 @@ const getContent = {
     } else {
       const featGet = attribute.img ? feature.get(attribute.img) : feature.get(attribute.name);
       if (featGet) {
-        const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.img), attributes, null, map));
-        const attribution = attribute.attribution ? `<div class="o-image-attribution">${attribute.attribution}</div>` : '';
-        val = `<div class="o-image-container"><img src="${url}">${attribution}</div>`;
+        let attribution = attribute.attribution ? `<div class="o-image-attribution">${attribute.attribution}</div>` : '';
+        if (/^data/.test(featGet)) {
+          val = `<b>${attribute.title}</b><div class="o-image-container"><img src="${featGet}">${attribution}</div>`;
+        } else {
+          let url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.img), attributes, null, map));
+          if (url) {
+            val = `<div class="o-image-container"><img src="${url}">${attribution}</div>`;
+          }
+        }
       }
     }
     const newElement = document.createElement('li');

--- a/src/getattributes.js
+++ b/src/getattributes.js
@@ -127,11 +127,11 @@ const getContent = {
     } else {
       const featGet = attribute.img ? feature.get(attribute.img) : feature.get(attribute.name);
       if (featGet) {
-        let attribution = attribute.attribution ? `<div class="o-image-attribution">${attribute.attribution}</div>` : '';
+        const attribution = attribute.attribution ? `<div class="o-image-attribution">${attribute.attribution}</div>` : '';
         if (/^data/.test(featGet)) {
           val = `<b>${attribute.title}</b><div class="o-image-container"><img src="${featGet}">${attribution}</div>`;
         } else {
-          let url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.img), attributes, null, map));
+          const url = createUrl(attribute.urlPrefix, attribute.urlSuffix, replacer.replace(feature.get(attribute.img), attributes, null, map));
           if (url) {
             val = `<div class="o-image-container"><img src="${url}">${attribution}</div>`;
           }


### PR DESCRIPTION
Adds support for base64-formatted images in the default attribute based popup-window.

If the attribute value is of type "image or img" and the value looks like a base64-formatted string strarting with the word "data", it will be considered to honor that value as the image src-value, discarding the use of the createUrl-function.